### PR TITLE
Frontend: Implement real terminal with xterm.js

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+REACT_APP_TERMINAL_WS_URL="ws://localhost:8080/ws"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -49,23 +49,4 @@ The OpenDevin terminal is powered by [Xterm.js](https://github.com/xtermjs/xterm
 
 The terminal listens for events over a WebSocket connection. The WebSocket URL is specified by the environment variable `REACT_APP_TERMINAL_WS_URL` (prepending `REACT_APP_` to environment variable names is necessary to expose them).
 
-Since the backend WebSocket server is not yet implemented, an echo server is provided below for testing:
-
-```js
-const WebSocket = require("ws");
-
-const wss = new WebSocket.Server({ port: 8080 });
-
-wss.on("connection", (ws) => {
-  ws.on("message", (message) => {
-    ws.send(message);
-  });
-});
-```
-
-To reproduce,
-
-1. Save the above code snippet in the file `echo.js`
-2. Install `ws` (`npm install ws`)
-3. Run `node echo.js`
-4. Run the frontend and type characters. You should see them being echoed end-to-end.
+A simple websocket server can be found in the `/server` directory.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,3 +42,30 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Terminal
+
+The OpenDevin terminal is powered by [Xterm.js](https://github.com/xtermjs/xterm.js).
+
+The terminal listens for events over a WebSocket connection. The WebSocket URL is specified by the environment variable `REACT_APP_TERMINAL_WS_URL` (prepending `REACT_APP_` to environment variable names is necessary to expose them).
+
+Since the backend WebSocket server is not yet implemented, an echo server is provided below for testing:
+
+```js
+const WebSocket = require("ws");
+
+const wss = new WebSocket.Server({ port: 8080 });
+
+wss.on("connection", (ws) => {
+  ws.on("message", (message) => {
+    ws.send(message);
+  });
+});
+```
+
+To reproduce,
+
+1. Save the above code snippet in the file `echo.js`
+2. Install `ws` (`npm install ws`)
+3. Run `node echo.js`
+4. Run the frontend and type characters. You should see them being echoed end-to-end.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,13 +16,16 @@
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@types/react-syntax-highlighter": "^15.5.11",
+        "@xterm/xterm": "^5.4.0",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
         "react-syntax-highlighter": "^15.5.0",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "xterm-addon-attach": "^0.9.0",
+        "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
         "@typescript-eslint/parser": "^5.62.0",
@@ -4629,6 +4632,11 @@
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.4.0.tgz",
+      "integrity": "sha512-GlyzcZZ7LJjhFevthHtikhiDIl8lnTSgol6eTM4aoSNLcuXu3OEhnbqdCVIjtIil3jjabf3gDtb1S8FGahsuEw=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -19114,6 +19122,22 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/xterm-addon-attach": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-attach/-/xterm-addon-attach-0.9.0.tgz",
+      "integrity": "sha512-NykWWOsobVZPPK3P9eFkItrnBK9Lw0f94uey5zhqIVB1bhswdVBfl+uziEzSOhe2h0rT9wD0wOeAYsdSXeavPw==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
+      }
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
+      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/y18n": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,16 @@
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@types/react-syntax-highlighter": "^15.5.11",
+    "@xterm/xterm": "^5.4.0",
     "eslint-config-airbnb-typescript": "^18.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "xterm-addon-attach": "^0.9.0",
+    "xterm-addon-fit": "^0.8.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -3,25 +3,9 @@ import { Terminal as XtermTerminal } from "@xterm/xterm";
 import { AttachAddon } from "xterm-addon-attach";
 import { FitAddon } from "xterm-addon-fit";
 import "@xterm/xterm/css/xterm.css";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { atomDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 function Terminal(): JSX.Element {
   const terminalRef = useRef<HTMLDivElement>(null);
-  const terminalOutput = `> chatbot-ui@2.0.0 prepare
-> husky install
-
-husky - Git hooks installed
-
-added 1455 packages, and audited 1456 packages in 1m
-
-295 packages are looking for funding
-  run \`npm fund\` for details
-  
-found 0 vulnerabilities
-npm notice
-npm notice New minor version of npm available! 10.7.3 -> 10.9.0
-...`;
 
   useEffect(() => {
     const terminal = new XtermTerminal({
@@ -55,14 +39,7 @@ npm notice New minor version of npm available! 10.7.3 -> 10.9.0
     };
   }, []);
 
-  return (
-    // <div className="terminal">
-    //   <SyntaxHighlighter language="bash" style={atomDark}>
-    //     {terminalOutput}
-    //   </SyntaxHighlighter>
-    // </div>
-    <div ref={terminalRef} style={{ width: "100%", height: "100%" }} />
-  );
+  return <div ref={terminalRef} style={{ width: "100%", height: "100%" }} />;
 }
 
 export default Terminal;

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1,8 +1,13 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import { Terminal as XtermTerminal } from "@xterm/xterm";
+import { AttachAddon } from "xterm-addon-attach";
+import { FitAddon } from "xterm-addon-fit";
+import "@xterm/xterm/css/xterm.css";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { atomDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 function Terminal(): JSX.Element {
+  const terminalRef = useRef<HTMLDivElement>(null);
   const terminalOutput = `> chatbot-ui@2.0.0 prepare
 > husky install
 
@@ -18,12 +23,45 @@ npm notice
 npm notice New minor version of npm available! 10.7.3 -> 10.9.0
 ...`;
 
+  useEffect(() => {
+    const terminal = new XtermTerminal({
+      fontFamily: "Menlo, Monaco, 'Courier New', monospace",
+      fontSize: 14,
+    });
+
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+
+    terminal.open(terminalRef.current as HTMLDivElement);
+
+    // Without this timeout, `fitAddon.fit()` throws the error
+    // "this._renderer.value is undefined"
+    setTimeout(() => {
+      fitAddon.fit();
+    }, 1);
+
+    if (!process.env.REACT_APP_TERMINAL_WS_URL) {
+      throw new Error(
+        "The environment variable REACT_APP_TERMINAL_WS_URL is not set. Please set it to the WebSocket URL of the terminal server.",
+      );
+    }
+    const attachAddon = new AttachAddon(
+      new WebSocket(process.env.REACT_APP_TERMINAL_WS_URL as string),
+    );
+    terminal.loadAddon(attachAddon);
+
+    return () => {
+      terminal.dispose();
+    };
+  }, []);
+
   return (
-    <div className="terminal">
-      <SyntaxHighlighter language="bash" style={atomDark}>
-        {terminalOutput}
-      </SyntaxHighlighter>
-    </div>
+    // <div className="terminal">
+    //   <SyntaxHighlighter language="bash" style={atomDark}>
+    //     {terminalOutput}
+    //   </SyntaxHighlighter>
+    // </div>
+    <div ref={terminalRef} style={{ width: "100%", height: "100%" }} />
   );
 }
 


### PR DESCRIPTION
This pull request instantiates an Xterm terminal, replacing the mock terminal with one functional over WebSocket.

The terminal listens for events over a WebSocket connection. The WebSocket URL is specified by the environment variable `REACT_APP_TERMINAL_WS_URL` (prepending `REACT_APP_` to environment variable names is necessary to expose them).

You can test with a WebSocket server. Below is an echo server for example:
```js
const WebSocket = require('ws');

const wss = new WebSocket.Server({ port: 8080 });

wss.on('connection', (ws) => {
  ws.on('message', (message) => {
    ws.send(message);
  });
});
```

To reproduce,
1. Save the above code snippet in the file `echo.js`
2. Install `ws` (`npm install ws`)
3. Run `node echo.js`
4. Run the frontend and type characters. You should see them being echoed end-to-end.

Resolves https://github.com/OpenDevin/OpenDevin/issues/36