### PR TITLE
Frontend: implement code editor tab

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "opendevin-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.6.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3239,6 +3240,30 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -16900,6 +16925,11 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/static-eval": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@monaco-editor/react": "^4.6.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,11 +4,41 @@ import "./App.css";
 import ChatInterface from "./components/ChatInterface";
 import Terminal from "./components/Terminal";
 import Planner from "./components/Planner";
+import CodeEditor from "./components/CodeEditor";
+
+const TAB_OPTIONS = ["terminal", "planner", "code"] as const;
+type TabOption = (typeof TAB_OPTIONS)[number];
+
+const tabData = {
+  terminal: {
+    name: "Terminal",
+    component: <Terminal />,
+  },
+  planner: {
+    name: "Planner",
+    component: <Planner />,
+  },
+  code: {
+    name: "Code Editor",
+    component: <CodeEditor />,
+  },
+};
+
+type TabProps = {
+  name: string;
+  active: boolean;
+  onClick: () => void;
+};
+function Tab({ name, active, onClick }: TabProps): JSX.Element {
+  return (
+    <div className={`tab ${active ? "active" : ""}`} onClick={() => onClick()}>
+      {name}
+    </div>
+  );
+}
 
 function App(): JSX.Element {
-  const [activeTab, setActiveTab] = useState<"terminal" | "planner">(
-    "terminal",
-  );
+  const [activeTab, setActiveTab] = useState<TabOption>("terminal");
 
   return (
     <div className="app">
@@ -17,22 +47,16 @@ function App(): JSX.Element {
       </div>
       <div className="right-pane">
         <div className="tab-container">
-          <div
-            className={`tab ${activeTab === "terminal" ? "active" : ""}`}
-            onClick={() => setActiveTab("terminal")}
-          >
-            Shell
-          </div>
-          <div
-            className={`tab ${activeTab === "planner" ? "active" : ""}`}
-            onClick={() => setActiveTab("planner")}
-          >
-            Planner
-          </div>
+          {TAB_OPTIONS.map((tab) => (
+            <Tab
+              key={tab}
+              name={tabData[tab].name}
+              active={activeTab === tab}
+              onClick={() => setActiveTab(tab)}
+            />
+          ))}
         </div>
-        <div className="tab-content">
-          {activeTab === "terminal" ? <Terminal /> : <Planner />}
-        </div>
+        <div className="tab-content">{tabData[activeTab].component}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import Editor from "@monaco-editor/react";
+
+function CodeEditor(): JSX.Element {
+  const handleEditorChange = (value: string | undefined) => {
+    console.log("Content changed:", value);
+  };
+
+  return (
+    <Editor
+      height="100%"
+      defaultLanguage="javascript"
+      defaultValue="// Welcome to OpenDevin!"
+      onChange={handleEditorChange}
+    />
+  );
+}
+
+export default CodeEditor;


### PR DESCRIPTION
This PR adds a `@monaco-editor/react` code panel. If OpenDevin writes code on the backend, this will serve as as a display only. We might want a WebSocket interface for the OpenDevin backend to stream code updates to this editor.

This PR also refactors how tabs are represented in `App.tsx`, reducing code duplication.

Resolves https://github.com/OpenDevin/OpenDevin/issues/38