### PR TITLE
Frontend: Implement browser tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,24 +5,10 @@ import ChatInterface from "./components/ChatInterface";
 import Terminal from "./components/Terminal";
 import Planner from "./components/Planner";
 import CodeEditor from "./components/CodeEditor";
+import Browser from "./components/Browser";
 
-const TAB_OPTIONS = ["terminal", "planner", "code"] as const;
+const TAB_OPTIONS = ["terminal", "planner", "code", "browser"] as const;
 type TabOption = (typeof TAB_OPTIONS)[number];
-
-const tabData = {
-  terminal: {
-    name: "Terminal",
-    component: <Terminal />,
-  },
-  planner: {
-    name: "Planner",
-    component: <Planner />,
-  },
-  code: {
-    name: "Code Editor",
-    component: <CodeEditor />,
-  },
-};
 
 type TabProps = {
   name: string;
@@ -39,6 +25,29 @@ function Tab({ name, active, onClick }: TabProps): JSX.Element {
 
 function App(): JSX.Element {
   const [activeTab, setActiveTab] = useState<TabOption>("terminal");
+  const [url] = useState("https://github.com/OpenDevin/OpenDevin");
+  const [screenshotSrc] = useState(
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN0uGvyHwAFCAJS091fQwAAAABJRU5ErkJggg==",
+  );
+
+  const tabData = {
+    terminal: {
+      name: "Terminal",
+      component: <Terminal />,
+    },
+    planner: {
+      name: "Planner",
+      component: <Planner />,
+    },
+    code: {
+      name: "Code Editor",
+      component: <CodeEditor />,
+    },
+    browser: {
+      name: "Browser",
+      component: <Browser url={url} screenshotSrc={screenshotSrc} />,
+    },
+  };
 
   return (
     <div className="app">

--- a/frontend/src/components/Browser.css
+++ b/frontend/src/components/Browser.css
@@ -1,0 +1,11 @@
+.url {
+    margin: 0.5rem;
+    padding: 0.5rem 1rem;
+    background-color: white;
+    border-radius: 2rem;
+    color: #252526;
+}
+
+.screenshot {
+    width: 100%;
+}

--- a/frontend/src/components/Browser.tsx
+++ b/frontend/src/components/Browser.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import "./Browser.css";
+
+type UrlBarProps = {
+  url: string;
+};
+
+function UrlBar({ url }: UrlBarProps): JSX.Element {
+  return <div className="url">{url}</div>;
+}
+
+type ScreenshotProps = {
+  src: string;
+};
+
+function Screenshot({ src }: ScreenshotProps): JSX.Element {
+  return <img className="screenshot" src={src} alt="screenshot" />;
+}
+
+type BrowserProps = {
+  url: string;
+  screenshotSrc: string;
+};
+
+function Browser({ url, screenshotSrc }: BrowserProps): JSX.Element {
+  return (
+    <div className="browser">
+      <UrlBar url={url} />
+      <Screenshot src={screenshotSrc} />
+    </div>
+  );
+}
+
+export default Browser;


### PR DESCRIPTION
This PR adds the browser tab for the frontend only. It displays the URL and accompanying screenshot (currently a base64-encoded green image as a placeholder).

As our state management becomes more complex, we'll want to consider adding a library like Redux. Each module could have its own store, which a WebSocket updates each time Devin makes a change.

I was considering adding Selenium on the backend and WebSocket integration to make this PR end-to-end. However, I now think WebSocket integration deserves its own PR since
1. It will be used to render all modules of Devin (i.e., planner, code editor, terminal, not just the browser)
2. We need to decide on a WebSocket API schema, which deserves its own discussion
3. There's technical nuances (e.g., `AttachAddon` of `Xterm.js` forwards all WebSocket messages to the terminal, so we need to intercept messages before passing them to `AttachAddon`).

Resolves https://github.com/OpenDevin/OpenDevin/issues/37