### PR TITLE
frontend: add attachment button + editor theme update

### DIFF
--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -43,7 +43,7 @@
     padding: 10px;
     border: none;
     border-radius: 5px;
-    margin-right: 10px;
+    margin: 0 10px;
     background-color: #3c3c3c;
     color: #fff;
   }
@@ -59,4 +59,8 @@
   
   .button-text {
     font-size: 16px;
+  }
+
+  .input-container svg {
+    height: 16px;
   }

--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -56,6 +56,22 @@ function ChatInterface(): JSX.Element {
         ))}
       </div>
       <div className="input-container">
+        <button className="attach-button" type="button" aria-label="file">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M9 7C9 4.23858 11.2386 2 14 2C16.7614 2 19 4.23858 19 7V15C19 18.866 15.866 22 12 22C8.13401 22 5 18.866 5 15V9C5 8.44772 5.44772 8 6 8C6.55228 8 7 8.44772 7 9V15C7 17.7614 9.23858 20 12 20C14.7614 20 17 17.7614 17 15V7C17 5.34315 15.6569 4 14 4C12.3431 4 11 5.34315 11 7V15C11 15.5523 11.4477 16 12 16C12.5523 16 13 15.5523 13 15V9C13 8.44772 13.4477 8 14 8C14.5523 8 15 8.44772 15 9V15C15 16.6569 13.6569 18 12 18C10.3431 18 9 16.6569 9 15V7Z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
         <input
           type="text"
           value={inputMessage}

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -9,6 +9,7 @@ function CodeEditor(): JSX.Element {
   return (
     <Editor
       height="100%"
+      theme="vs-dark"
       defaultLanguage="javascript"
       defaultValue="// Welcome to OpenDevin!"
       onChange={handleEditorChange}


### PR DESCRIPTION
This PR implements the changes from an [earlier PR](https://github.com/OpenDevin/OpenDevin/pull/26#issue-2190145942) to add an attachment button to the frontend. It also updates the Monaco editor's theme to match the overall UI theme for a consistent look and feel.