### PR TITLE
Add iframe implementation to Browser component

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,12 +25,12 @@ function Tab({ name, active, onClick }: TabProps): JSX.Element {
 
 function App(): JSX.Element {
   const [activeTab, setActiveTab] = useState<TabOption>("terminal");
-  // URL of browser window (placeholder for now, will be replaced with the actual URL later)
-  const [url] = useState("https://github.com/OpenDevin/OpenDevin");
-  // Base64-encoded screenshot of browser window (placeholder for now, will be replaced with the actual screenshot later)
-  const [screenshotSrc] = useState(
-    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN0uGvyHwAFCAJS091fQwAAAABJRU5ErkJggg==",
-  );
+  // // URL of browser window (placeholder for now, will be replaced with the actual URL later)
+  // const [url] = useState("https://github.com/OpenDevin/OpenDevin");
+  // // Base64-encoded screenshot of browser window (placeholder for now, will be replaced with the actual screenshot later)
+  // const [screenshotSrc] = useState(
+  //   "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN0uGvyHwAFCAJS091fQwAAAABJRU5ErkJggg==",
+  // );
 
   const tabData = {
     terminal: {
@@ -47,7 +47,7 @@ function App(): JSX.Element {
     },
     browser: {
       name: "Browser",
-      component: <Browser url={url} screenshotSrc={screenshotSrc} />,
+      component: <Browser url="https://en.wikipedia.org/wiki/Main_Page" />,
     },
   };
 

--- a/frontend/src/components/Browser.css
+++ b/frontend/src/components/Browser.css
@@ -9,3 +9,8 @@
 .screenshot {
     width: 100%;
 }
+.browser-content{
+    width: 100% !important;
+    height: 88vh;
+    border: none;
+}

--- a/frontend/src/components/Browser.tsx
+++ b/frontend/src/components/Browser.tsx
@@ -9,24 +9,19 @@ function UrlBar({ url }: UrlBarProps): JSX.Element {
   return <div className="url">{url}</div>;
 }
 
-type ScreenshotProps = {
-  src: string;
-};
-
-function Screenshot({ src }: ScreenshotProps): JSX.Element {
-  return <img className="screenshot" src={src} alt="screenshot" />;
-}
-
 type BrowserProps = {
   url: string;
-  screenshotSrc: string;
 };
 
-function Browser({ url, screenshotSrc }: BrowserProps): JSX.Element {
+function Browser({ url }: BrowserProps): JSX.Element {
   return (
     <div className="browser">
       <UrlBar url={url} />
-      <Screenshot src={screenshotSrc} />
+      <iframe
+        className="browser-content"
+        src="https://en.wikipedia.org/wiki/Main_Page"
+        title="Browser"
+      />
     </div>
   );
 }


### PR DESCRIPTION
This commit adds the implementation for displaying web content within the Browser component using an iframe. It includes the necessary changes to Browser.tsx, App.tsx and Browser.css files. The iframe allows loading external websites such as Wikipedia for display within the application.
