### PR TITLE
fix(evaluation): solve graceful shutdown of docker containers

### DIFF
--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -138,7 +138,7 @@ class DockerInteractive:
     # clean up the container, cannot do it in __del__ because the python interpreter is already shutting down
     def cleanup(self):
         self.container.remove(force=True)
-        print("Finish Cleaning up Docker container")
+        print("Finish cleaning up Docker container")
 
 if __name__ == "__main__":
     import argparse

--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -10,6 +10,7 @@ import docker
 import time
 from typing import List, Tuple
 from collections import namedtuple
+import atexit
 
 InputType = namedtuple("InputDtype", ["content"])
 OutputType = namedtuple("OutputDtype", ["content"])
@@ -53,6 +54,8 @@ class DockerInteractive:
         self.restart_docker_container()
         uid = os.getuid()
         self.execute('useradd --shell /bin/bash -u {uid} -o -c \"\" -m devin && su devin')
+        # regester container cleanup function
+        atexit.register(self.cleanup)
 
     def read_logs(self) -> str:
         if not hasattr(self, "log_generator"):
@@ -132,11 +135,11 @@ class DockerInteractive:
         if self.container.status != "running":
             raise Exception("Failed to start container")
 
-
-    def __del__(self):
-        # FIXME: this fails because python is already shutting down. How can we clean up?
-        # self.container.remove(force=True)
-        pass
+    # clean up the container, cannot do it in __del__ because the python interpreter is already shutting down
+    def cleanup(self):
+        print("Cleaning up Docker container")
+        self.container.remove(force=True)
+        print("Finish Cleaning up Docker container")
 
 if __name__ == "__main__":
     import argparse

--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -137,7 +137,6 @@ class DockerInteractive:
 
     # clean up the container, cannot do it in __del__ because the python interpreter is already shutting down
     def cleanup(self):
-        print("Cleaning up Docker container")
         self.container.remove(force=True)
         print("Finish Cleaning up Docker container")
 


### PR DESCRIPTION
In #95 @rbren meantion that we cannot cleanup the docker containers in `__del__` because the python interpreter is already shutting down.

In this PR, I use the [atexit](https://docs.python.org/3/library/atexit.html) package to solve this problem. We can register cleanup functions. Functions thus registered are automatically executed upon normal interpreter termination.

Step:
1. `PYTHONPATH=pwd python ./opendevin/main.py -d ./workspace -t "write a bash script that prints hello world"
 ` 
2. CMD will output: `Finish cleaning up Docker container`
3. Use `docker ps`, no `sandbox` container.