### PR TITLE
fix(frontend): Remove extra vertical spacing from layout

### DIFF
--- a/frontend/src/components/Browser.css
+++ b/frontend/src/components/Browser.css
@@ -1,11 +1,13 @@
 .url {
-    margin: 0.5rem;
-    padding: 0.5rem 1rem;
-    background-color: white;
-    border-radius: 2rem;
-    color: #252526;
+  margin: 0.5rem;
+  padding: 0.5rem 1rem;
+  background-color: white;
+  border-radius: 2rem;
+  color: #252526;
 }
 
 .screenshot {
-    width: 100%;
+  width: 100%;
+  max-height: calc(100vh - 100px); /* 100px is the height of the header */
+  object-fit: cover;
 }


### PR DESCRIPTION
This PR removes extra vertical space from the layout and scales browser screenshot according to window size.

Aims to fix the issue below: 
- https://github.com/OpenDevin/OpenDevin/issues/131 