### PR TITLE
Add rewrite logic to help with docker-in-docker scenarios

### DIFF
--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -95,10 +95,9 @@ class DockerInteractive:
         atexit.register(self.cleanup)
 
     def setup_devin_user(self):
-        uid = os.getuid()
         exit_code, logs = self.container.exec_run([
             '/bin/bash', '-c',
-            f'useradd --shell /bin/bash -u {uid} -o -c \"\" -m devin'
+            f'useradd --shell /bin/bash -u {USER_ID} -o -c \"\" -m devin'
             ],
             workdir="/workspace"
         )

--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -11,6 +11,7 @@ import atexit
 InputType = namedtuple("InputType", ["content"])
 OutputType = namedtuple("OutputType", ["content"])
 
+DIRECTORY_REWRITE = os.getenv("DIRECTORY_REWRITE", "") # helpful for docker-in-docker scenarios
 CONTAINER_IMAGE = os.getenv("SANDBOX_CONTAINER_IMAGE", "opendevin/sandbox:latest")
 
 class DockerInteractive:
@@ -33,6 +34,10 @@ class DockerInteractive:
         else:
             self.workspace_dir = os.getcwd()
             print(f"workspace unspecified, using current directory: {workspace_dir}")
+        if DIRECTORY_REWRITE != "" and DIRECTORY_REWRITE is not None:
+            parts = DIRECTORY_REWRITE.split(":")
+            self.workspace_dir = self.workspace_dir.replace(parts[0], parts[1])
+            print("Rewriting workspace directory to:", self.workspace_dir)
 
         # TODO: this timeout is actually essential - need a better way to set it
         # if it is too short, the container may still waiting for previous

--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -34,7 +34,7 @@ class DockerInteractive:
         else:
             self.workspace_dir = os.getcwd()
             print(f"workspace unspecified, using current directory: {workspace_dir}")
-        if DIRECTORY_REWRITE != "" and DIRECTORY_REWRITE is not None:
+        if DIRECTORY_REWRITE != "":
             parts = DIRECTORY_REWRITE.split(":")
             self.workspace_dir = self.workspace_dir.replace(parts[0], parts[1])
             print("Rewriting workspace directory to:", self.workspace_dir)


### PR DESCRIPTION
My dev environment is inside an ubuntu container running on my macbook. I mount `/Users/rbren` on my macbook to `/home/rbren` in ubuntu. This causes issues with directory mounting.

This change allows me to specify `DIRECTORY_REWRITE="/home/rbren:/Users/rbren"` to make the volume mounting work properly.