### PR TITLE
doc: add version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OpenDevin is still a work in progress. But you can run the current app to see th
 
 ### Requirements
 * [Docker](https://docs.docker.com/engine/install/)
-* [Python](https://www.python.org/downloads/)
+* [Python](https://www.python.org/downloads/) >= 3.10
 * [NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 
 ### Installation


### PR DESCRIPTION
Some syntax in our code require python >= 3.10
for example: 
```python
    def __init__(
        self,
        workspace_dir: str | None = None,
        container_image: str | None = None,
        timeout: int = 120,
        id: str | None = None
    ):
```
the python 3.9 cannot recognize `str | None = None`