### PR TITLE
feat(backend): add mock backend server for frontend

### DIFF
--- a/opendevin/mock/README.md
+++ b/opendevin/mock/README.md
@@ -1,0 +1,10 @@
+# OpenDevin mock server
+This is a simple mock server to facilitate development in the frontend.
+
+## Start the Server
+```
+python -m pip install -r requirements.txt
+python listen.py
+```
+
+Then open the frontend to connect to the mock server. It will simply reply to every received message.

--- a/opendevin/mock/listen.py
+++ b/opendevin/mock/listen.py
@@ -1,0 +1,29 @@
+import uvicorn
+from fastapi import FastAPI, WebSocket
+
+app = FastAPI()
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    # send message to mock connection
+    await websocket.send_json({"action": "initialize", "message": "Control loop started."})
+    
+    try:
+        while True:
+            # receive message
+            data = await websocket.receive_json()
+            print(f"Received message: {data}")
+
+            # send mock response to client
+            response = {"message": f"receive {data}"}
+            await websocket.send_json(response)
+            print(f"Sent message: {response}")
+    except Exception as e:
+        print(f"WebSocket Error: {e}")
+
+@app.get("/")
+def read_root():
+    return {"message": "This is a mock server"}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=3000)


### PR DESCRIPTION
As title. Problem proposed in #133. Add a mock server. Will simply forward every message it got to frontend. Not sure whether this is what team want.

![image](https://github.com/OpenDevin/OpenDevin/assets/33971064/e16cfb5f-9aa7-46dd-b05a-eb507e6d3883)
