### PR TITLE
fix(frontend): #182

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import "./ChatInterface.css";
 import userAvatar from "../assets/user-avatar.png";
@@ -41,6 +41,13 @@ function InitializingStatus(): JSX.Element {
 function ChatInterface(): JSX.Element {
   const { initialized } = useSelector((state: RootState) => state.task);
   const [inputMessage, setInputMessage] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(()=>{
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [])
 
   const handleSendMessage = () => {
     if (inputMessage.trim() !== "") {
@@ -59,13 +66,13 @@ function ChatInterface(): JSX.Element {
           onChange={(e) => setInputMessage(e.target.value)}
           placeholder="Send a message (won't interrupt the Assistant)"
           onKeyDown={(e) => {
-            if (e.key === "Enter") {
+            if (e.key === "Enter" && initialized) {
               handleSendMessage();
             }
           }}
-          disabled={!initialized}
+          ref={inputRef}
         />
-        <button type="button" onClick={handleSendMessage}>
+        <button type="button" onClick={handleSendMessage} disabled={!initialized}>
           <span className="button-text">Send</span>
         </button>
       </div>


### PR DESCRIPTION
The issue: #182 
During startup, enable text field, but disable submit
The current behavior of the application prevents users from typing their prompts while waiting for the initialization process to complete. This hampers the ideal user experience, especially in cases where the initialization phase takes some time.

So the fix ensures that users can type their prompts while the application is initializing, allowing them to be ready to submit their input once the initialization process is complete.