### PR TITLE
make BackgroundCommand.kill actually kill the process

### DIFF
--- a/opendevin/controller/command_manager.py
+++ b/opendevin/controller/command_manager.py
@@ -26,29 +26,29 @@ class CommandManager:
     def _run_background(self, command: str) -> CmdOutputObservation:
         bg_cmd = self.shell.execute_in_background(command)
         return CmdOutputObservation(
-            content=f"Background command started. To stop it, send a `kill` action with id {bg_cmd.id}",
-            command_id=bg_cmd.id,
+            content=f"Background command started. To stop it, send a `kill` action with id {bg_cmd.pid}",
+            command_id=bg_cmd.pid,
             command=command,
             exit_code=0
         )
 
-    def kill_command(self, id: int) -> CmdOutputObservation:
-        cmd = self.shell.kill_background(id)
+    def kill_command(self, pid: int) -> CmdOutputObservation:
+        cmd = self.shell.kill_background(pid)
         return CmdOutputObservation(
-            content=f"Background command with id {id} has been killed.",
-            command_id=id,
+            content=f"Background command with pid {pid} has been killed.",
+            command_id=pid,
             command=cmd.command,
             exit_code=0
         )
 
     def get_background_obs(self) -> List[CmdOutputObservation]:
         obs = []
-        for _id, cmd in self.shell.background_commands.items():
+        for _pid, cmd in self.shell.background_commands.items():
             output = cmd.read_logs()
             if output is not None and output != "":
                 obs.append(
                     CmdOutputObservation(
-                        content=output, command_id=_id, command=cmd.command
+                        content=output, command_id=_pid, command=cmd.command
                     )
                 )
         return obs


### PR DESCRIPTION
fixes #179 
here's my attempt :D

![image](https://github.com/OpenDevin/OpenDevin/assets/135171913/9c6ce51a-1863-4075-bb68-c3754bd7c8e0)


I did this by IDing our `BackgroundCommand` using it's PID.
This way we can send signals to it (sigterm or sigkill or otherwise)

not too sure the id before is used in other places. :s    