### PR TITLE
doc: README displays incorrect env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ You'll see OpenDevin running at localhost:3001
 We use LiteLLM, so you can run OpenDevin with any foundation model, including OpenAI, Claude, and Gemini.
 LiteLLM has a [full list of providers](https://docs.litellm.ai/docs/providers).
 
-To change the model, set the `LLM_MODEL` and `LLM_API_KEY` environment variables.
+To change the model, set the `MODEL_NAME` and `LLM_API_KEY` environment variables.
 
 For example, to run Claude:
 ```bash
 export LLM_API_KEY="your-api-key"
-export LLM_MODEL="claude-3-opus-20240229"
+export MODEL_NAME="claude-3-opus-20240229"
 ```
 
 ## 🤔 What is [Devin](https://www.cognition-labs.com/introducing-devin)?


### PR DESCRIPTION
The main README instructions say to use Claude or other models should set
`export LLM_MODEL='...'`
but this fails.  The `LLM_MODEL` env var seems to be the variable for a cmd line parser that is separate from the server for the web app.  Not sure as I just started reading the code but maybe going forward you'd like to add a stand alone cmd line program? 

In any event if users follow the current README it will fail.  Just adding this PR to fix quickly so users don't annoyed, but maybe the `MODEL_NAME` and `LLM_MODEL` vars should be changed to the one or the other to avoid confusion?