### PR TITLE
remove auto-open from vite

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,8 +7,6 @@ export default defineConfig({
   base: "",
   plugins: [react(), viteTsconfigPaths()],
   server: {
-    // this ensures that the browser opens upon server start
-    open: true,
     // this sets a default port to 3000
     port: 3000,
   },


### PR DESCRIPTION
Two users have reported issues with `open`:
* https://github.com/OpenDevin/OpenDevin/issues/241
* https://github.com/OpenDevin/OpenDevin/issues/253

Since it fails with a bad warning message on some envs, I think we should remove it. It's just a minor convenience when it works.