### PR TITLE
fix(sandbox): add get pid code and kill the process

### DIFF
--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -181,10 +181,9 @@ class DockerInteractive:
         bg_cmd = self.background_commands[id]
         pid = self.get_pid(bg_cmd)
         if pid is not None:
-            exec_result = self.container.exec_run(
+            self.container.exec_run(
                 f"kill -9 {pid}", workdir="/workspace"
             )
-            print(exec_result.output.decode('utf-8'))
         bg_cmd.kill()
         self.background_commands.pop(id)
         return bg_cmd


### PR DESCRIPTION
Proposed in #179.  
Method: Match the cmd. 
1. Everytime want to kill the cmd, run `ps aux` to get the all thread. 
2. We will save the `cmd` in `BackgroundCommand`, then get the `pid` by comparing the `cmd` prameters. 
3. Then kill it by using `kill -9 pid`. I tried to convert it into `su devin -c kill -9 19`, but will fail. So just will the simple one.

The `for loop` maybe have some performance problem if thread become more and more. But in our current size, i think it is fine.

Result show below:
![image](https://github.com/OpenDevin/OpenDevin/assets/33971064/c04d6106-78d4-43fb-a38d-73db290955a3)
