### PR TITLE
bug: Check for env var in parser argument default value

### DIFF
--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import argparse
 
@@ -34,7 +35,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m",
         "--model-name",
-        default="gpt-4-0125-preview",
+        default=os.getenv("LLM_MODEL") or "gpt-4-0125-preview",
         type=str,
         help="The (litellm) model name to use",
     )


### PR DESCRIPTION
Currently the command line program does not check for the `LLM_MODEL` env var because it uses the `--model-name` argument to initialize `LLM` object.  Since the argument defaults to gpt-4 if the argument is not specified it will always pass this to the `LLM` constructor and so it never finds the `DEFAULT_MODEL` const `llm.py`

This is just a quick workaround using `or` statement in parser default but probably should be some refactoring with regards to the classes being used by both command line and web app.  