### PR TITLE
add more checks for the pre-commit config

### DIFF
--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -1,4 +1,26 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: debug-statements
+      - id: double-quote-string-fixer
+      - id: requirements-txt-fixer
+
+  - repo: https://github.com/hhatto/autopep8
+    rev: v2.1.0
+    hooks:
+      - id: autopep8
+
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v2.5.0
+    hooks:
+      - id: setup-cfg-fmt
+        always_run: true
+        pass_filenames: false
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.3
     hooks:


### PR DESCRIPTION
Ruff, a Python code linting tool, primarily focuses on code quality and best practices.
It may support certain types of linting checks but doesn't cover all tasks related to code formatting and dependency management.
Hooks like trailing-whitespace, end-of-file-fixer, check-yaml, debug-statements, double-quote-string-fixer, requirements-txt-fixer, and autopep8 handle tasks such as formatting, syntax checking, and dependency management.
These tasks may not be directly supported by Ruff.
Depending on the project's needs, we may need to use additional tools or hooks alongside Ruff to address these concerns effectively.