### PR TITLE
Fix Docker container creation and error handling

### DIFF
--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -180,9 +180,12 @@ class DockerInteractive:
 
     def stop_docker_container(self):
 
+        # Initialize docker client. Throws an exception if Docker is not reachable.
         try:
             docker_client = docker.from_env()
         except docker.errors.DockerException as e:
+            print('Please check Docker is running using `docker ps`.')
+            print(f"Error! {e}", flush=True)
             raise e
 
         try:
@@ -206,8 +209,11 @@ class DockerInteractive:
             print(f"Failed to stop container: {e}")
             raise e 
 
-        docker_client = docker.from_env()
         try:
+            # Initialize docker client. Throws an exception if Docker is not reachable.
+            docker_client = docker.from_env()
+
+            # start the container
             self.container = docker_client.containers.run(
                 self.container_image,
                 command="tail -f /dev/null",

--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -1,12 +1,13 @@
-import os
-import sys
-import uuid
-import time
-import select
-import docker
-from typing import Tuple, Dict, List
-from collections import namedtuple
 import atexit
+import os
+import select
+import sys
+import time
+import uuid
+from collections import namedtuple
+from typing import Dict, List, Tuple
+
+import docker
 
 InputType = namedtuple("InputType", ["content"])
 OutputType = namedtuple("OutputType", ["content"])
@@ -178,7 +179,12 @@ class DockerInteractive:
         self.closed = True
 
     def stop_docker_container(self):
-        docker_client = docker.from_env()
+
+        try:
+            docker_client = docker.from_env()
+        except docker.errors.DockerException as e:
+            raise e
+
         try:
             container = docker_client.containers.get(self.container_name)
             container.stop()
@@ -194,7 +200,12 @@ class DockerInteractive:
             pass
 
     def restart_docker_container(self):
-        self.stop_docker_container()
+        try:
+            self.stop_docker_container()
+        except docker.errors.DockerException as e:
+            print(f"Failed to stop container: {e}")
+            raise e 
+
         docker_client = docker.from_env()
         try:
             self.container = docker_client.containers.run(
@@ -246,9 +257,14 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    docker_interactive = DockerInteractive(
-        workspace_dir=args.directory,
-    )
+    try:
+        docker_interactive = DockerInteractive(
+            workspace_dir=args.directory,
+        )
+    except Exception as e:
+        print(f"Failed to start Docker container: {e}")
+        sys.exit(1)
+
     print("Interactive Docker container started. Type 'exit' or use Ctrl+C to exit.")
 
     bg_cmd = docker_interactive.execute_in_background(

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -131,7 +131,7 @@ class Session:
             self.controller = AgentController(self.agent, workdir=directory, callbacks=[self.on_agent_event])
         except Exception:
             print("Error creating controller.")
-            await self.send_error("Error creating controller. ")
+            await self.send_error("Error creating controller. Please check Docker is running using `docker ps`.")
             return
         await self.send({"action": "initialize", "message": "Control loop started."})
 

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -129,9 +129,8 @@ class Session:
         self.agent = AgentCls(llm)
         try:
             self.controller = AgentController(self.agent, workdir=directory, callbacks=[self.on_agent_event])
-        except Exception as e:
-            print("Error creating controller. Please check Docker is running using `docker ps`.")
-            print(f"Error! {e}", flush=True)
+        except Exception:
+            print("Error creating controller.")
             await self.send_error("Error creating controller. ")
             return
         await self.send({"action": "initialize", "message": "Control loop started."})

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -1,28 +1,25 @@
-import os
 import asyncio
-from typing import Optional, Dict, Type
+import os
+from typing import Dict, Optional, Type
 
 from fastapi import WebSocketDisconnect
 
 from opendevin.action import (
     Action,
-    NullAction,
-    CmdRunAction,
-    CmdKillAction,
-    BrowseURLAction,
-    FileReadAction,
-    FileWriteAction,
+    AgentFinishAction,
     AgentRecallAction,
     AgentThinkAction,
-    AgentFinishAction,
+    BrowseURLAction,
+    CmdKillAction,
+    CmdRunAction,
+    FileReadAction,
+    FileWriteAction,
+    NullAction,
 )
 from opendevin.agent import Agent
 from opendevin.controller import AgentController
 from opendevin.llm.llm import LLM
-from opendevin.observation import (
-    Observation,
-    UserMessageObservation
-)
+from opendevin.observation import Observation, UserMessageObservation
 
 # NOTE: this is a temporary solution - but hopefully we can use Action/Observation throughout the codebase
 ACTION_TYPE_TO_CLASS: Dict[str, Type[Action]] = {
@@ -130,7 +127,13 @@ class Session:
         llm = LLM(model)
         AgentCls = Agent.get_cls(agent_cls)
         self.agent = AgentCls(llm)
-        self.controller = AgentController(self.agent, workdir=directory, callbacks=[self.on_agent_event])
+        try:
+            self.controller = AgentController(self.agent, workdir=directory, callbacks=[self.on_agent_event])
+        except Exception as e:
+            print("Error creating controller. Please check Docker is running using `docker ps`.")
+            print(f"Error! {e}", flush=True)
+            await self.send_error("Error creating controller. ")
+            return
         await self.send({"action": "initialize", "message": "Control loop started."})
 
     async def start_task(self, start_event):


### PR DESCRIPTION
1. Fixes #102. Print an error if Docker is not reachable. As docker restart tried in every session, server will automatically recover even if docker bounces.
2. Fixed some python module import order in `session.py` and `sandbox.py`

## Tests
When docker is not running:
```
INFO:     Started server process [58282]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     ('127.0.0.1', 59155) - "WebSocket /ws" [accepted]
INFO:     connection open
INFO:     Started server process [63469]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     ('127.0.0.1', 60186) - "WebSocket /ws" [accepted]
INFO:     connection open
Failed to stop container: Error while fetching server API version: ('Connection aborted.', PermissionError(13, 'Permission denied'))
Error creating controller. Please check Docker is running using `docker ps`.
Error! Error while fetching server API version: ('Connection aborted.', PermissionError(13, 'Permission denied'))```
```

When docker is running:
```
INFO:     ('127.0.0.1', 60325) - "WebSocket /ws" [accepted]
INFO:     connection open
INFO:     connection closed

==============
STEP 0
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
```