### PR TITLE
Re-add banner to App and add change message

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -58,6 +58,7 @@ function App(): JSX.Element {
       <div className="right-pane">
         <div className="workspace-heading">
           <p>OpenDevin Workspace</p>
+          <BannerSettings />
         </div>
         <div role="tablist" className="tabs tabs-bordered tabs-lg">
           {TAB_OPTIONS.map((tab) => (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,11 +56,15 @@ function App(): JSX.Element {
         <ChatInterface />
       </div>
       <div className="right-pane">
-        <div className="workspace-heading">
-          <p>OpenDevin Workspace</p>
-          <BannerSettings />
+        <div className="navbar bg-base-100">
+          <div className="flex-1">
+            <div className="btn btn-ghost text-xl">OpenDevin Workspace</div>
+          </div>
+          <div className="flex-none">
+            <BannerSettings />
+          </div>
         </div>
-        <div role="tablist" className="tabs tabs-bordered tabs-lg">
+        <div role="tablist" className="tabs tabs-bordered tabs-lg bg-base-100">
           {TAB_OPTIONS.map((tab) => (
             <Tab
               key={tab}

--- a/frontend/src/components/BannerSettings.css
+++ b/frontend/src/components/BannerSettings.css
@@ -9,4 +9,5 @@ select {
     padding: 0.5rem;
     border: 0;
     border-radius: 5px;
+    font-size: 1rem;
 }

--- a/frontend/src/components/BannerSettings.tsx
+++ b/frontend/src/components/BannerSettings.tsx
@@ -13,7 +13,7 @@ function ModelSelect(): JSX.Element {
       onChange={(e: ChangeEvent<HTMLSelectElement>) =>
         changeModel(e.target.value)
       }
-      className="model-select"
+      className="select w-full max-w-xs bg-base-300"
     >
       {MODELS.map((model) => (
         <option>{model}</option>
@@ -28,7 +28,7 @@ function AgentSelect(): JSX.Element {
       onChange={(e: ChangeEvent<HTMLSelectElement>) =>
         changeAgent(e.target.value)
       }
-      className="agent-select"
+      className="select w-full max-w-xs bg-base-300"
     >
       {AGENTS.map((agent) => (
         <option>{agent}</option>

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -1,4 +1,5 @@
 import socket from "../socket/socket";
+import { appendAssistantMessage } from "../state/chatSlice";
 import { setInitialized } from "../state/taskSlice";
 import store from "../store";
 
@@ -21,6 +22,7 @@ function changeSetting(setting: string, value: string): void {
   const eventString = JSON.stringify(event);
   socket.send(eventString);
   store.dispatch(setInitialized(false));
+  store.dispatch(appendAssistantMessage(`Changed ${setting} to "${value}"`));
 }
 
 export function changeModel(model: Model): void {
@@ -28,7 +30,7 @@ export function changeModel(model: Model): void {
 }
 
 export function changeAgent(agent: Agent): void {
-  changeSetting("agent", agent);
+  changeSetting("agent_cls", agent);
 }
 
 export function changeDirectory(directory: string): void {


### PR DESCRIPTION
The model and agent selection buttons were accidentally overwritten in https://github.com/OpenDevin/OpenDevin/pull/266. Also, the payload for changing the agent had key `agent`, but the correct key is `agent_cls`.

This PR
1. Adds them back
2. Changes the `agent` key to the correct `agent_cls`
3. Adds a message in chat when a setting is changed