### PR TITLE
Fix(sandbox): add byte order

### DIFF
--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -35,6 +35,7 @@ class BackgroundCommand:
         res = b""
         tail = b""
         i = 0
+        byte_order = sys.byteorder
         while i < len(logs):
             prefix = logs[i : i + 8]
             if len(prefix) < 8:
@@ -49,7 +50,7 @@ class BackgroundCommand:
                 msg_type in [b"\x00", b"\x01", b"\x02", b"\x03"]
                 and padding == b"\x00\x00\x00"
             ):
-                msg_length = int.from_bytes(prefix[4:8])  # , byteorder='big'
+                msg_length = int.from_bytes(prefix[4:8], byteorder=byte_order)
                 res += logs[i + 8 : i + 8 + msg_length]
                 i += 8 + msg_length
             else:


### PR DESCRIPTION
When I develop the sandbox `python3 opendevin/sandbox/sandbox.py`, will always meet problem:
```
Traceback (most recent call last):
  File "/Users/yufansong/code/OpenDevin/opendevin/sandbox/sandbox.py", line 277, in <module>
    logs = docker_interactive.read_logs(bg_cmd.id)
  File "/Users/yufansong/code/OpenDevin/opendevin/sandbox/sandbox.py", line 149, in read_logs
    return bg_cmd.read_logs()
  File "/Users/yufansong/code/OpenDevin/opendevin/sandbox/sandbox.py", line 70, in read_logs
    chunk, last_remains = self.parse_docker_exec_output(last_remains + data)
  File "/Users/yufansong/code/OpenDevin/opendevin/sandbox/sandbox.py", line 52, in parse_docker_exec_output
    msg_length = int.from_bytes(prefix[4:8])  # , byteorder='big'
TypeError: from_bytes() missing required argument 'byteorder' (pos 2)
```
It seems somebody intent not to specify this prameter. Do not know why. Fix it here.