### PR TITLE
remove base_path from file actions

### DIFF
--- a/opendevin/action/fileop.py
+++ b/opendevin/action/fileop.py
@@ -17,10 +17,9 @@ def resolve_path(base_path, file_path):
 @dataclass
 class FileReadAction(ExecutableAction):
     path: str
-    base_path: str = ""
 
-    def run(self, *args, **kwargs) -> FileReadObservation:
-        path = resolve_path(self.base_path, self.path)
+    def run(self, controller) -> FileReadObservation:
+        path = resolve_path(controller.workdir, self.path)
         with open(path, 'r', encoding='utf-8') as file:
             return FileReadObservation(
                 path=path,
@@ -35,10 +34,9 @@ class FileReadAction(ExecutableAction):
 class FileWriteAction(ExecutableAction):
     path: str
     contents: str
-    base_path: str = ""
 
-    def run(self, *args, **kwargs) -> FileWriteObservation:
-        path = resolve_path(self.base_path, self.path)
+    def run(self, controller) -> FileWriteObservation:
+        path = resolve_path(controller.workdir, self.path)
         with open(path, 'w', encoding='utf-8') as file:
             file.write(self.contents)
         return FileWriteObservation(content="", path=self.path)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -97,12 +97,7 @@ class AgentController:
         if isinstance(action, AgentFinishAction):
             print_with_indent("\nFINISHED")
             return True
-        if isinstance(action, (FileReadAction, FileWriteAction)):
-            action_cls = action.__class__
-            _kwargs = action.__dict__
-            _kwargs["base_path"] = self.workdir
-            action = action_cls(**_kwargs)
-            print(action, flush=True)
+
         if action.executable:
             try:
                 observation = action.run(self)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -7,8 +7,6 @@ from opendevin.agent import Agent
 from opendevin.action import (
     Action,
     NullAction,
-    FileReadAction,
-    FileWriteAction,
     AgentFinishAction,
 )
 from opendevin.observation import (


### PR DESCRIPTION
This was putting `base_path` into the message history, confusing the agent. It'd try and read/write/run things, explicitly specifying the `workspace` dir