### PR TITLE
Support --task-file argument for main.py

### DIFF
--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -1,49 +1,53 @@
-
 import asyncio
 import argparse
 import sys
 from typing import Type
 
-import agenthub  # noqa F401 (we import this to get the agents registered)
-from opendevin import config  
+import agenthub  # noqa: F401
 from opendevin.agent import Agent
 from opendevin.controller import AgentController
 from opendevin.llm.llm import LLM
 
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments for running an agent with various task inputs."""
+    parser = argparse.ArgumentParser(description="Run an agent with a specific task or a task read from a file/stdin.")
+    parser.add_argument("-d", "--directory", required=True, help="The working directory for the agent.")
+    parser.add_argument("-t", "--task", help="The task for the agent to perform. This is overridden if --file is provided.")
+    parser.add_argument("-f", "--task-file", help="Path to a file containing the task. Overrides --task if provided.")
+    parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", help="The agent class to use.")
+    parser.add_argument("-m", "--model-name", default="gpt-4-0125-preview", help="The (litellm) model name to use, defaults to env LLM_MODEL or gpt-4-0125-preview.")
+    parser.add_argument("-i", "--max-iterations", type=int, default=100, help="The maximum number of iterations to run the agent.")
+    return parser.parse_args()
+
 def read_task_from_file(file_path: str) -> str:
     """Read task from the specified file."""
     with open(file_path, 'r', encoding='utf-8') as file:
-        return file.read()
+        return file.read().strip()
 
 def read_task_from_stdin() -> str:
     """Read task from stdin."""
-    return sys.stdin.read()
+    return sys.stdin.read().strip()
 
 async def main():
-    """Main coroutine to run the agent controller with task input flexibility."""
-    parser = argparse.ArgumentParser(description="Run an agent with a specific task")
-    parser.add_argument("-d", "--directory", required=True, type=str, help="The working directory for the agent")
-    parser.add_argument("-t", "--task", type=str, default="", help="The task for the agent to perform")
-    parser.add_argument("-f", "--task-file", type=str, help="Path to a file containing the task. Overrides -t if both are provided.")
-    parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", type=str, help="The agent class to use")
-    parser.add_argument("-m", "--model-name", default=config.get_or_default("LLM_MODEL", "gpt-4-0125-preview"), type=str, help="The (litellm) model name to use")
-    parser.add_argument("-i", "--max-iterations", default=100, type=int, help="The maximum number of iterations to run the agent")
-    args = parser.parse_args()
+    """Main coroutine to run the agent controller with flexible task input."""
+    args = parse_arguments()
 
-    # Determine the task source
+    task = args.task
     if args.file:
         task = read_task_from_file(args.file)
     elif not sys.stdin.isatty():
         task = read_task_from_stdin()
-    else:
-        task = args.task
 
     if not task:
-        raise ValueError("No task provided. Please specify a task through -t, -f")
+        raise ValueError("No task provided. Please specify a task through -t, -f.")
 
-    print(f"Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task: \"{task}\"")
-    llm = LLM(args.model_name)
-    AgentCls: Type[Agent] = Agent.get_cls(args.agent_cls)
+    print(f"Running agent {args.agent_cls} with model: {args.model_name}, directory: {args.directory}, task: \"{task}\"")
+
+    llm = LLM(model_name=args.model_name)
+    AgentCls: Type[Agent] = getattr(Agent, f"get_{args.agent_cls}_cls", None)
+    if not AgentCls:
+        raise ValueError(f"Agent class '{args.agent_cls}' not found.")
+    
     agent = AgentCls(llm=llm)
     controller = AgentController(agent, workdir=args.directory, max_iterations=args.max_iterations)
 

--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -2,23 +2,13 @@ import os
 import asyncio
 import argparse
 import sys
-from typing import Type, Optional
+from typing import Type
 
-import agenthub
+import agenthub  # noqa F401 (we import this to get the agents registered)
+from opendevin import config  
 from opendevin.agent import Agent
 from opendevin.controller import AgentController
 from opendevin.llm.llm import LLM
-
-def parse_arguments():
-    """Parse command line arguments including an option to read from a file."""
-    parser = argparse.ArgumentParser(description="Run an agent with a specific task or a task read from a file/stdin.")
-    parser.add_argument("-d", "--directory", required=True, type=str, help="The working directory for the agent")
-    parser.add_argument("-t", "--task", type=str, default="", help="The task for the agent to perform")
-    parser.add_argument("-f", "--file", type=str, help="Path to a file containing the task. This option overrides -t if both are provided.")
-    parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", type=str, help="The agent class to use")
-    parser.add_argument("-m", "--model-name", default=os.environ.get("LLM_MODEL", "gpt-4-0125-preview"), type=str, help="The (litellm) model name to use")
-    parser.add_argument("-i", "--max-iterations", default=100, type=int, help="The maximum number of iterations to run the agent")
-    return parser.parse_args()
 
 def read_task_from_file(file_path: str) -> str:
     """Read task from the specified file."""
@@ -31,7 +21,14 @@ def read_task_from_stdin() -> str:
 
 async def main():
     """Main coroutine to run the agent controller with task input flexibility."""
-    args = parse_arguments()
+    parser = argparse.ArgumentParser(description="Run an agent with a specific task")
+    parser.add_argument("-d", "--directory", required=True, type=str, help="The working directory for the agent")
+    parser.add_argument("-t", "--task", type=str, default="", help="The task for the agent to perform")
+    parser.add_argument("-f", "--file", type=str, help="Path to a file containing the task. Overrides -t if both are provided.")
+    parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", type=str, help="The agent class to use")
+    parser.add_argument("-m", "--model-name", default=config.get_or_default("LLM_MODEL", "gpt-4-0125-preview"), type=str, help="The (litellm) model name to use")
+    parser.add_argument("-i", "--max-iterations", default=100, type=int, help="The maximum number of iterations to run the agent")
+    args = parser.parse_args()
 
     # Determine the task source
     if args.file:

--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -24,7 +24,7 @@ async def main():
     parser = argparse.ArgumentParser(description="Run an agent with a specific task")
     parser.add_argument("-d", "--directory", required=True, type=str, help="The working directory for the agent")
     parser.add_argument("-t", "--task", type=str, default="", help="The task for the agent to perform")
-    parser.add_argument("-f", "--file", type=str, help="Path to a file containing the task. Overrides -t if both are provided.")
+    parser.add_argument("-f", "--task-file", type=str, help="Path to a file containing the task. Overrides -t if both are provided.")
     parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", type=str, help="The agent class to use")
     parser.add_argument("-m", "--model-name", default=config.get_or_default("LLM_MODEL", "gpt-4-0125-preview"), type=str, help="The (litellm) model name to use")
     parser.add_argument("-i", "--max-iterations", default=100, type=int, help="The maximum number of iterations to run the agent")
@@ -39,7 +39,7 @@ async def main():
         task = args.task
 
     if not task:
-        raise ValueError("No task provided. Please specify a task through -t, -f, or pipe it into stdin.")
+        raise ValueError("No task provided. Please specify a task through -t, -f")
 
     print(f"Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task: \"{task}\"")
     llm = LLM(args.model_name)

--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -1,56 +1,56 @@
 import os
 import asyncio
 import argparse
+import sys
+from typing import Type, Optional
 
-from typing import Type
-
-import agenthub # noqa F401 (we import this to get the agents registered)
+import agenthub
 from opendevin.agent import Agent
 from opendevin.controller import AgentController
 from opendevin.llm.llm import LLM
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Run an agent with a specific task")
-    parser.add_argument(
-        "-d",
-        "--directory",
-        required=True,
-        type=str,
-        help="The working directory for the agent",
-    )
-    parser.add_argument(
-        "-t",
-        "--task",
-        required=True,
-        type=str,
-        help="The task for the agent to perform",
-    )
-    parser.add_argument(
-        "-c",
-        "--agent-cls",
-        default="LangchainsAgent",
-        type=str,
-        help="The agent class to use",
-    )
-    parser.add_argument(
-        "-m",
-        "--model-name",
-        default=os.getenv("LLM_MODEL") or "gpt-4-0125-preview",
-        type=str,
-        help="The (litellm) model name to use",
-    )
-    parser.add_argument(
-        "-i",
-        "--max-iterations",
-        default=100,
-        type=int,
-        help="The maximum number of iterations to run the agent",
-    )
-    args = parser.parse_args()
+def parse_arguments():
+    """Parse command line arguments including an option to read from a file."""
+    parser = argparse.ArgumentParser(description="Run an agent with a specific task or a task read from a file/stdin.")
+    parser.add_argument("-d", "--directory", required=True, type=str, help="The working directory for the agent")
+    parser.add_argument("-t", "--task", type=str, default="", help="The task for the agent to perform")
+    parser.add_argument("-f", "--file", type=str, help="Path to a file containing the task. This option overrides -t if both are provided.")
+    parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", type=str, help="The agent class to use")
+    parser.add_argument("-m", "--model-name", default=os.environ.get("LLM_MODEL", "gpt-4-0125-preview"), type=str, help="The (litellm) model name to use")
+    parser.add_argument("-i", "--max-iterations", default=100, type=int, help="The maximum number of iterations to run the agent")
+    return parser.parse_args()
 
-    print(f"Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task: \"{args.task}\"")
+def read_task_from_file(file_path: str) -> str:
+    """Read task from the specified file."""
+    with open(file_path, 'r', encoding='utf-8') as file:
+        return file.read()
+
+def read_task_from_stdin() -> str:
+    """Read task from stdin."""
+    return sys.stdin.read()
+
+async def main():
+    """Main coroutine to run the agent controller with task input flexibility."""
+    args = parse_arguments()
+
+    # Determine the task source
+    if args.file:
+        task = read_task_from_file(args.file)
+    elif not sys.stdin.isatty():
+        task = read_task_from_stdin()
+    else:
+        task = args.task
+
+    if not task:
+        raise ValueError("No task provided. Please specify a task through -t, -f, or pipe it into stdin.")
+
+    print(f"Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task: \"{task}\"")
     llm = LLM(args.model_name)
     AgentCls: Type[Agent] = Agent.get_cls(args.agent_cls)
     agent = AgentCls(llm=llm)
     controller = AgentController(agent, workdir=args.directory, max_iterations=args.max_iterations)
-    asyncio.run(controller.start_loop(args.task))
+
+    await controller.start_loop(task)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -41,7 +41,7 @@ async def main():
     if not task:
         raise ValueError("No task provided. Please specify a task through -t, -f, or pipe it into stdin.")
 
-    print(f"Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task: \"{task}\"")
+    print(f"Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task:\n{task}")
     llm = LLM(args.model_name)
     AgentCls: Type[Agent] = Agent.get_cls(args.agent_cls)
     agent = AgentCls(llm=llm)

--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -3,51 +3,46 @@ import argparse
 import sys
 from typing import Type
 
-import agenthub  # noqa: F401
+import agenthub  # noqa F401 (we import this to get the agents registered)
+from opendevin import config  
 from opendevin.agent import Agent
 from opendevin.controller import AgentController
 from opendevin.llm.llm import LLM
 
-def parse_arguments() -> argparse.Namespace:
-    """Parse command line arguments for running an agent with various task inputs."""
-    parser = argparse.ArgumentParser(description="Run an agent with a specific task or a task read from a file/stdin.")
-    parser.add_argument("-d", "--directory", required=True, help="The working directory for the agent.")
-    parser.add_argument("-t", "--task", help="The task for the agent to perform. This is overridden if --file is provided.")
-    parser.add_argument("-f", "--task-file", help="Path to a file containing the task. Overrides --task if provided.")
-    parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", help="The agent class to use.")
-    parser.add_argument("-m", "--model-name", default="gpt-4-0125-preview", help="The (litellm) model name to use, defaults to env LLM_MODEL or gpt-4-0125-preview.")
-    parser.add_argument("-i", "--max-iterations", type=int, default=100, help="The maximum number of iterations to run the agent.")
-    return parser.parse_args()
-
 def read_task_from_file(file_path: str) -> str:
     """Read task from the specified file."""
     with open(file_path, 'r', encoding='utf-8') as file:
-        return file.read().strip()
+        return file.read()
 
 def read_task_from_stdin() -> str:
     """Read task from stdin."""
-    return sys.stdin.read().strip()
+    return sys.stdin.read()
 
 async def main():
-    """Main coroutine to run the agent controller with flexible task input."""
-    args = parse_arguments()
+    """Main coroutine to run the agent controller with task input flexibility."""
+    parser = argparse.ArgumentParser(description="Run an agent with a specific task")
+    parser.add_argument("-d", "--directory", required=True, type=str, help="The working directory for the agent")
+    parser.add_argument("-t", "--task", type=str, default="", help="The task for the agent to perform")
+    parser.add_argument("-f", "--file", type=str, help="Path to a file containing the task. Overrides -t if both are provided.")
+    parser.add_argument("-c", "--agent-cls", default="LangchainsAgent", type=str, help="The agent class to use")
+    parser.add_argument("-m", "--model-name", default=config.get_or_default("LLM_MODEL", "gpt-4-0125-preview"), type=str, help="The (litellm) model name to use")
+    parser.add_argument("-i", "--max-iterations", default=100, type=int, help="The maximum number of iterations to run the agent")
+    args = parser.parse_args()
 
-    task = args.task
+    # Determine the task source
     if args.file:
         task = read_task_from_file(args.file)
     elif not sys.stdin.isatty():
         task = read_task_from_stdin()
+    else:
+        task = args.task
 
     if not task:
         raise ValueError("No task provided. Please specify a task through -t, -f.")
 
-    print(f"Running agent {args.agent_cls} with model: {args.model_name}, directory: {args.directory}, task: \"{task}\"")
-
-    llm = LLM(model_name=args.model_name)
-    AgentCls: Type[Agent] = getattr(Agent, f"get_{args.agent_cls}_cls", None)
-    if not AgentCls:
-        raise ValueError(f"Agent class '{args.agent_cls}' not found.")
-    
+    print(f"Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task: \"{task}\"")
+    llm = LLM(args.model_name)
+    AgentCls: Type[Agent] = Agent.get_cls(args.agent_cls)
     agent = AgentCls(llm=llm)
     controller = AgentController(agent, workdir=args.directory, max_iterations=args.max_iterations)
 

--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -1,4 +1,4 @@
-import os
+
 import asyncio
 import argparse
 import sys


### PR DESCRIPTION
File Input Support: First up, we've introduced the ability to specify a task through a file. This is super handy when dealing with longer tasks or when you want to keep a record of the tasks being processed. Just use the -f or --file flag followed by the path to your task file, and you're good to go.
Stdin Piping: For those who love their pipes and filters in Unix-like systems, this one's for you. You can now pipe tasks directly into the script from another command. This makes it incredibly flexible when integrating with other tools or scripts. No more temporary files or awkward string manipulations!
Clear Priorities: I've set up a clear priority system for where the script looks for its task input. Command-line arguments come first, then file input, and finally, stdin. This order ensures that the script remains backward compatible while opening up new possibilities for automation and integration.
