### PR TITLE
fix #375: update python version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,4 +29,4 @@ toml = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.10"
+python_version = "3.11"


### PR DESCRIPTION
python 3.10 may cause sqlite3 version error.