### PR TITLE
Make user messages blue

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -27,7 +27,9 @@ function MessageList(): JSX.Element {
               alt={`${msg.sender} avatar`}
               className="w-[40px] h-[40px] mx-2.5"
             />
-            <Card className="w-4/5">
+            <Card
+              className={`w-4/5 ${msg.sender === "user" ? "bg-primary" : ""}`}
+            >
               <CardBody>{msg.content}</CardBody>
             </Card>
           </div>


### PR DESCRIPTION
The user messages were previously blue to differentiate them from the agent messages. This coloring was lost; it is reintroduced in this PR.

Before this PR
<img width="712" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/46636043/5db4e1c5-a701-47d7-b143-ed6f8cf22631">

After this PR
<img width="712" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/46636043/f460544d-c322-421c-a954-633809edc3a7">
