### PR TITLE
fix(agenthub): Handle common case where summary is JSON-wrapped-in-MD-fences.

### DIFF
--- a/agenthub/langchains_agent/utils/prompts.py
+++ b/agenthub/langchains_agent/utils/prompts.py
@@ -140,5 +140,11 @@ def parse_action_response(response: str) -> Action:
     return action_from_dict(action_dict)
 
 def parse_summary_response(response: str) -> List[dict]:
+    response = response.strip()
+    if response.startswith('```') and response.endswith('```'):
+        if response.startswith('```json'):
+            response = response[7:-3]
+        else:
+            response = response[3:-3]
     parsed = json.loads(response)
     return parsed['new_monologue']


### PR DESCRIPTION
It might be better to handle this more broadly, but this is the place where it comes up for me.

The LLM appears to return
~~~markdown
```json
{
  'new_monologue': 'No, Mr. Bond, ...',
  'et': 'cetera'
}
```
~~~

instead of just

```json
{
  'new_monologue': 'No, Mr. Bond, ...',
  'et': 'cetera'
}
```

So I strip off the outer fences.