### PR TITLE
fix: Handle api key error

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -64,7 +64,7 @@ class AgentController:
             except Exception as e:
                 print("Error in loop", e, flush=True)
                 traceback.print_exc()
-                break
+                raise e
             if finished:
                 break
         if not finished:
@@ -94,6 +94,7 @@ class AgentController:
             observation = AgentErrorObservation(str(e))
             print_with_indent("\nAGENT ERROR:\n%s" % observation)
             traceback.print_exc()
+            raise 
         self.update_state_after_step()
 
         await self._run_callbacks(action)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -63,7 +63,6 @@ class AgentController:
                 finished = await self.step(i)
             except Exception as e:
                 print("Error in loop", e, flush=True)
-                traceback.print_exc()
                 raise e
             if finished:
                 break

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -93,7 +93,8 @@ class AgentController:
             observation = AgentErrorObservation(str(e))
             print_with_indent("\nAGENT ERROR:\n%s" % observation)
             traceback.print_exc()
-            raise 
+            if "The api_key client option must be set" in observation.content:
+                raise 
         self.update_state_after_step()
 
         await self._run_callbacks(action)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -93,6 +93,7 @@ class AgentController:
             observation = AgentErrorObservation(str(e))
             print_with_indent("\nAGENT ERROR:\n%s" % observation)
             traceback.print_exc()
+            # TODO Change to more robust error handling
             if "The api_key client option must be set" in observation.content:
                 raise 
         self.update_state_after_step()

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -120,7 +120,7 @@ class Session:
         try:
             self.agent_task = await asyncio.create_task(self.controller.start_loop(task), name="agent loop")
         except Exception as e:
-            await self.send_error(f"Could not start task.")
+            await self.send_error(f"Error during task loop.")
 
     def on_agent_event(self, event: Observation | Action):
         if isinstance(event, NullAction):

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -117,7 +117,10 @@ class Session:
         if self.controller is None:
             await self.send_error("No agent started. Please wait a second...")
             return
-        self.agent_task = asyncio.create_task(self.controller.start_loop(task), name="agent loop")
+        try:
+            self.agent_task = await asyncio.create_task(self.controller.start_loop(task), name="agent loop")
+        except Exception as e:
+            await self.send_error(f"Could not start task.")
 
     def on_agent_event(self, event: Observation | Action):
         if isinstance(event, NullAction):

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -119,8 +119,8 @@ class Session:
             return
         try:
             self.agent_task = await asyncio.create_task(self.controller.start_loop(task), name="agent loop")
-        except Exception as e:
-            await self.send_error(f"Error during task loop.")
+        except Exception:
+            await self.send_error("Error during task loop.")
 
     def on_agent_event(self, event: Observation | Action):
         if isinstance(event, NullAction):


### PR DESCRIPTION
Breaks the task loop on ANY error by propagating error up the stack and returning to caller from coroutine.  The generic message "Error during task loop" is printed to chat.   

Resolves #483 