### PR TITLE
Add an Pipfile example for AMD GPU or CPU only users

### DIFF
--- a/Pipfile.torchidx
+++ b/Pipfile.torchidx
@@ -1,0 +1,36 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[[source]]
+url = "https://download.pytorch.org/whl/cpu"
+verify_ssl = true
+name = "pytorch"
+
+[packages]
+torch = {version = "*", index = "pytorch"}
+datasets = "*"
+pandas = "*"
+litellm = "*"
+termcolor = "*"
+seaborn = "*"
+docker = "*"
+fastapi = "*"
+uvicorn = {extras = ["standard"], version = "*"}
+ruff = "*"
+mypy = "*"
+llama-index = "*"
+llama-index-vector-stores-chroma = "*"
+chromadb = "*"
+llama-index-embeddings-huggingface = "*"
+llama-index-embeddings-azure-openai = "*"
+llama-index-embeddings-ollama = "*"
+google-generativeai = "*"
+toml = "*"
+json_repair = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.11"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ If `pipenv` doesn't work for you, you can also run:
 python -m pipenv requirements > requirements.txt && python -m pip install -r requirements.txt
 ```
 
+If you don't have CUDA 12 compatible graphic card, you may change `Pipfile` like `PipFile.torchidx` to select appropriate PyTorch package.
+Please consult the value of `--index-url` in [PyTorch install command browser](https://pytorch.org/get-started/locally/#start-locally) to find appropriate package index URL for you.
+
 Then, in a second terminal, start the frontend:
 ```bash
 cd frontend

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If `pipenv` doesn't work for you, you can also run:
 python -m pipenv requirements > requirements.txt && python -m pip install -r requirements.txt
 ```
 
-If you don't have CUDA 12 compatible graphic card, you may change `Pipfile` like `PipFile.torchidx` to select appropriate PyTorch package.
+If you're seeing installation errors due to `torch`, try using `Pipfile.torchidx` instead of `Pipfile`.
 Please consult the value of `--index-url` in [PyTorch install command browser](https://pytorch.org/get-started/locally/#start-locally) to find appropriate package index URL for you.
 
 Then, in a second terminal, start the frontend:


### PR DESCRIPTION
PyTorch packages in PyPI repository requires CUDA 12 interface.
This makes AMD owners and CPU only owners cannot run OpenDevin.

However, you can select appropriate PyTorch packages according to the GPU you have by changing the index URL of pip repository.
(See: https://pytorch.org/get-started/locally/#start-locally )

This PR added an example of Pipfile that installs torch package which runs on CPU only environment and added a comment on README.md

This PR was tested on Ubuntu 22.04 LTS amd64.

This PR may resolve #437 