### PR TITLE
add: .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.ipynb linguist-language=python
+*.ipynb linguist-vendored


### PR DESCRIPTION
Currently the entire repository is recognized as jupyter notebook due to `*ipynb`, add `.gitattributes` and modify it to ensure consistency.