### PR TITLE
build: add files created for other dev envs to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+requirements.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -85,7 +86,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
@@ -168,6 +169,8 @@ evaluation/SWE-bench/data
 # dependencies
 frontend/node_modules
 frontend/.pnp
+frontend/bun.lockb
+frontend/yarn.lock
 .pnp.js
 
 # testing


### PR DESCRIPTION
Add files such as requirements.txt, .python-version, bun.lockb, and yarn.lock so that if anybody uses these systems, they don't accidentally push the files