### PR TITLE
feature: Add action 'files' to get files in workspace dir, print to console

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -8,6 +8,7 @@ import { useTypingEffect } from "../hooks/useTypingEffect";
 import { sendChatMessage } from "../services/chatService";
 import { Message } from "../state/chatSlice";
 import { RootState } from "../store";
+import { getFiles } from "../services/fileService";
 
 interface ITypingChatProps {
   msg: Message;
@@ -92,6 +93,12 @@ interface Props {
 function ChatInterface({ setSettingOpen }: Props): JSX.Element {
   const { initialized } = useSelector((state: RootState) => state.task);
   const [inputMessage, setInputMessage] = useState("");
+
+  useEffect(() => {
+    if (initialized) {
+      getFiles();
+    }
+  }, [initialized]);
 
   const handleSendMessage = () => {
     if (inputMessage.trim() !== "") {

--- a/frontend/src/services/fileService.ts
+++ b/frontend/src/services/fileService.ts
@@ -1,0 +1,7 @@
+import socket from "../socket/socket";
+
+export function getFiles() {
+  const event = { action: "files" };
+  const eventString = JSON.stringify(event);
+  socket.send(eventString);
+}

--- a/frontend/src/socket/socket.ts
+++ b/frontend/src/socket/socket.ts
@@ -14,6 +14,9 @@ socket.addEventListener("message", (event) => {
   const socketMessage = JSON.parse(event.data) as SocketMessage;
   if ("action" in socketMessage) {
     handleActionMessage(socketMessage);
+  } else if (socketMessage.observation === "files") {
+    // TODO handle the files observation
+    console.log(socketMessage.content);
   } else {
     handleObservationMessage(socketMessage);
   }

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -1,3 +1,4 @@
+import os
 from opendevin.server.session import Session
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
@@ -14,6 +15,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+from opendevin import config
+DEFAULT_WORKSPACE_DIR = config.get_or_default("WORKSPACE_DIR", os.path.join(os.getcwd(), "workspace"))
 
 # This endpoint receives events from the client (i.e. the browser)
 @app.websocket("/ws")

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -1,4 +1,3 @@
-import os
 from opendevin.server.session import Session
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -16,9 +16,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-from opendevin import config
-DEFAULT_WORKSPACE_DIR = config.get_or_default("WORKSPACE_DIR", os.path.join(os.getcwd(), "workspace"))
-
 # This endpoint receives events from the client (i.e. the browser)
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -91,10 +91,14 @@ class Session:
                     await self.start_task(data)
                 elif action == "files":
                     # TODO get files from using command manager
-                    observation = self.controller.command_manager.run_command("ls")
-                    observation_dict = observation.to_dict()
-                    observation_dict["observation"] = "files"
-                    await self.send(observation_dict)
+                    if self.controller:
+                        observation = self.controller.command_manager.run_command("ls")
+                        observation_dict = observation.to_dict()
+                        observation_dict["observation"] = "files"
+                        await self.send(observation_dict)
+                    else:
+                        # TODO Raise ControllerNotImplentedError
+                        pass
                 else:
                     if self.controller is None:
                         await self.send_error("No agent started. Please wait a second...")

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -89,13 +89,19 @@ class Session:
                     await self.create_controller(data)
                 elif action == "start":
                     await self.start_task(data)
+                elif action == "files":
+                    # TODO get files from using command manager
+                    observation = self.controller.command_manager.run_command("ls")
+                    observation_dict = observation.to_dict()
+                    observation_dict["observation"] = "files"
+                    await self.send(observation_dict)
                 else:
                     if self.controller is None:
                         await self.send_error("No agent started. Please wait a second...")
                     elif action == "chat":
                         self.controller.add_history(NullAction(), UserMessageObservation(data["message"]))
                     else:
-                        await self.send_error("I didn't recognize this action:" + action)
+                        await self.send_error("I didn't recognize this action: " + action)
 
         except WebSocketDisconnect as e:
             self.websocket = None


### PR DESCRIPTION
Working draft for #529 

Sends payload `{"action": "files"}` over socket to backend, which then returns `ls` output in workspace dir.  Currently just prints contents to web console.