### PR TITLE
optimize(sandbox): cleanup docker when disconnect to speed up restart speed

### DIFF
--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -176,4 +176,5 @@ class Session:
         self.websocket = None
         if self.agent_task:
             self.agent_task.cancel()
-        self.controller.command_manager.shell.close()
+        if self.controller is not None:
+            self.controller.command_manager.shell.close()

--- a/opendevin/server/session.py
+++ b/opendevin/server/session.py
@@ -98,10 +98,8 @@ class Session:
                         await self.send_error("I didn't recognize this action:" + action)
 
         except WebSocketDisconnect as e:
-            self.websocket = None
-            if self.agent_task:
-                self.agent_task.cancel()
             print("Client websocket disconnected", e)
+            self.disconnect()
 
     async def create_controller(self, start_event=None):
         """Creates an AgentController instance.
@@ -173,3 +171,9 @@ class Session:
             return
         event_dict = event.to_dict()
         asyncio.create_task(self.send(event_dict), name="send event in callback")
+    
+    def disconnect(self):
+        self.websocket = None
+        if self.agent_task:
+            self.agent_task.cancel()
+        self.controller.command_manager.shell.close()


### PR DESCRIPTION
Solve #418. Optimize the initialization spped. Also necessary to collect resource in time.
1. This PR will try to close the docker container when website disconnected.
2. In previous logic, the sandbox will not stop when websocket disconnected. It will try to stop and restart it when a new connection comming, which stop process will largely slow down the initialization.
3. If user just refresh the frontend, which means close the websocket and start a new one immediately. it still need 10+s to initialization. We do need 10s to stop and restart te container.