### PR TITLE
fix: let make run output both backend and frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+logs
+
 # agent
 .envrc
 /workspace

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ start-frontend:
 # Run the app
 run:
 	@echo "Running the app..."
-	@mkdir -p logs
-	@pipenv run nohup uvicorn opendevin.server.listen:app --port $(BACKEND_PORT) --host "::" > logs/backend_$(shell date +'%Y%m%d_%H%M%S').log 2>&1 &
-	@cd frontend && npm run start -- --port $(FRONTEND_PORT)
+	@mkfifo logs/pipe
+	@cat logs/pipe | (make start-backend) &
+	@echo 'test' | tee logs/pipe | (make start-frontend)
 
 # Setup config.toml
 setup-config:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ start-frontend:
 # Run the app
 run:
 	@echo "Running the app..."
+	@rm logs/pipe
 	@mkfifo logs/pipe
 	@cat logs/pipe | (make start-backend) &
 	@echo 'test' | tee logs/pipe | (make start-frontend)


### PR DESCRIPTION
`make run` does not output any backend logs, leading many people to be unaware that the backend did not start successfully or encountered errors. Now it will output both frontend and backend logs simultaneously.

<img width="662" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/5436704/242db242-6256-47ce-9125-bc6f674600b9">
