### PR TITLE
Enhancement: Add default model option to setup-config in Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DOCKER_IMAGE = ghcr.io/opendevin/sandbox
 BACKEND_PORT = 3000
 FRONTEND_PORT = 3001
 DEFAULT_WORKSPACE_DIR = "./workspace"
+DEFAULT_MODEL = "gpt-4-0125-preview"
 CONFIG_FILE = config.toml
 
 # Build
@@ -41,7 +42,8 @@ setup-config:
 	@echo "Setting up config.toml..."
 	@read -p "Enter your LLM API key: " llm_api_key; \
 	 echo "LLM_API_KEY=\"$$llm_api_key\"" >> $(CONFIG_FILE).tmp
-	@read -p "Enter your LLM Model name [default: gpt-4-0125-preview]: " llm_model; \
+	@read -p "Enter your LLM Model name [default: $(DEFAULT_MODEL)]: " llm_model; \
+	 llm_model=$${llm_model:-$(DEFAULT_MODEL)}; \
 	 echo "LLM_MODEL=\"$$llm_model\"" >> $(CONFIG_FILE).tmp
 	@read -p "Enter your workspace directory [default: $(DEFAULT_WORKSPACE_DIR)]: " workspace_dir; \
 	 workspace_dir=$${workspace_dir:-$(DEFAULT_WORKSPACE_DIR)}; \


### PR DESCRIPTION
**What problem or use case are you trying to solve?**

- Allows for more convenient update of default LLM model in Makefile.  
- Ensures non null config when user does not provide default model.  
- Reduces typing when default model intended by user

- Follows the same pattern as Workspace