### PR TITLE
Fix: Default Value Saving in Setup Config (#596)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ setup-config:
 	@read -p "Enter your LLM API key: " llm_api_key; \
 	 echo "LLM_API_KEY=\"$$llm_api_key\"" >> $(CONFIG_FILE).tmp
 	@read -p "Enter your LLM Model name [default: gpt-4-0125-preview]: " llm_model; \
+	 llm_model=$${llm_model:-gpt-4-0125-preview}; \
 	 echo "LLM_MODEL=\"$$llm_model\"" >> $(CONFIG_FILE).tmp
 	@read -p "Enter your workspace directory [default: $(DEFAULT_WORKSPACE_DIR)]: " workspace_dir; \
 	 workspace_dir=$${workspace_dir:-$(DEFAULT_WORKSPACE_DIR)}; \


### PR DESCRIPTION
### Issue
Closes #596

The current setup-config script fails to save default values in the config.toml file when users hit enter without providing input. This leads to errors when starting a project due to missing model information.

### Changes Made
Modified the setup-config script to properly handle default values when users don't provide input. Now, default values for LLM model and workspace directory are saved in the config.toml file even if users hit enter without providing input. This ensures smooth project initialization without requiring users to manually enter default values.

This fix resolves the issue of missing default values and improves the usability of the setup-config script.