### PR TITLE
Set default user namespace for docker

### DIFF
--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -247,6 +247,7 @@ class DockerInteractive:
                 self.container_image,
                 command="tail -f /dev/null",
                 network_mode="host",
+                userns_mode="host",
                 working_dir="/workspace",
                 name=self.container_name,
                 detach=True,


### PR DESCRIPTION
the current code raises the following error
```
  File "/root/.local/share/virtualenvs/OpenDevin-73tHkqWu/lib/python3.11/site-packages/docker/models/containers.py", line 873, in run
    container = self.create(image=image, command=command,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/OpenDevin-73tHkqWu/lib/python3.11/site-packages/docker/models/containers.py", line 932, in create
    resp = self.client.api.create_container(**create_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/OpenDevin-73tHkqWu/lib/python3.11/site-packages/docker/api/container.py", line 439, in create_container
    return self.create_container_from_config(config, name, platform)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/OpenDevin-73tHkqWu/lib/python3.11/site-packages/docker/api/container.py", line 456, in create_container_from_config
    return self._result(res, True)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/OpenDevin-73tHkqWu/lib/python3.11/site-packages/docker/api/client.py", line 271, in _result
    self._raise_for_status(response)
  File "/root/.local/share/virtualenvs/OpenDevin-73tHkqWu/lib/python3.11/site-packages/docker/api/client.py", line 267, in _raise_for_status
    raise create_api_error_from_http_exception(e) from e
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/virtualenvs/OpenDevin-73tHkqWu/lib/python3.11/site-packages/docker/errors.py", line 39, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation) from e
docker.errors.APIError: 400 Client Error for http+docker://localhost/v1.43/containers/create?name=sandbox-default: Bad Request ("cannot share the host's network namespace when user namespaces are enabled")
```