### PR TITLE
fix(frontend): Pass BACKEND_PORT to frontend on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ start-backend:
 # Start frontend
 start-frontend:
 	@echo "Starting frontend..."
-	@cd frontend && npm run start -- --port $(FRONTEND_PORT)
+	@cd frontend && BACKEND_HOST="127.0.0.1:$(BACKEND_PORT)" npm run start -- --port $(FRONTEND_PORT)
 
 # Run the app
 run:


### PR DESCRIPTION
When changing `BACKEND_PORT` in the `Makefile`, `make start-frontend` (and `make run`) will not be aware of this change, still using the default 3000 port.

The fix is to just provide the `BACKEND_HOST` environment variable to the frontend startup command.