### PR TITLE
fix: make run on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ start-frontend:
 run:
 	@echo "Running the app..."
 	@if [ "$(OS)" == "Windows_NT" ]; then \
-		echo "Windows is not supported. Please run `make start-frontend` and `make start-backend` separately."; \
+		echo "`make run` is not supported on Windows. Please run `make start-frontend` and `make start-backend` separately."; \
 		exit 1; \
 	fi
 	@mkdir -p logs

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ start-frontend:
 # Run the app
 run:
 	@echo "Running the app..."
+	@if [ "$(OS)" == "Windows_NT" ]; then \
+		echo "Windows is not supported. Please run `make start-frontend` and `make start-backend` separately."; \
+		exit 1; \
+	fi
 	@mkdir -p logs
 	@rm -f logs/pipe
 	@mkfifo logs/pipe


### PR DESCRIPTION
A "fix" for https://github.com/OpenDevin/OpenDevin/issues/655

Using fifo is to allow make run to display the logs of backend and frontend at the same time. If Windows doesn't support it, there don't seem to be any good solutions to achieve a similar effect.

A simple solution is to let make run remind users to use make start-frontend and make start-backend to start separately in Windows.