### PR TITLE
playwright is causing devin to fail to start

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,7 +24,6 @@ google-generativeai = "*"
 toml = "*"
 json_repair = "*"
 numpy = "*"
-playwright = "*"
 
 [dev-packages]
 


### PR DESCRIPTION
Reverts 625 as it is causing devin to fail to start on aarch64 machines. 

Additional information: https://github.com/OpenDevin/OpenDevin/pull/625#issuecomment-2035194367

TLDR: palywright introduces a dependency that must be compiled on aarch machines. The compile takes 15+ minutes then always fails (even in a python:3.11-bookworm docker container)