### PR TITLE
Remove md around json

### DIFF
--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -18,9 +18,9 @@ You're a thoughtful robot. Your main task is this:
 Don't expand the scope of your task--just complete it as written.
 
 This is your internal monologue, in JSON format:
-```json
+
 %(monologue)s
-```
+
 
 Your most recent thought is at the bottom of that monologue. Continue your train of thought.
 What is your next thought or action? Your response must be in JSON format.
@@ -71,9 +71,9 @@ Please return a new, smaller JSON array, which summarizes the
 internal monologue. You can summarize individual thoughts, and
 you can condense related thoughts together with a description
 of their content.
-```json
+
 %(monologue)s
-```
+
 Make the summaries as pithy and informative as possible.
 Be specific about what happened and what was learned. The summary
 will be used as keywords for searching for the original memory.

--- a/agenthub/planner_agent/prompt.py
+++ b/agenthub/planner_agent/prompt.py
@@ -53,9 +53,9 @@ You've been given the following task:
 ## Plan
 As you complete this task, you're building a plan and keeping
 track of your progress. Here's a JSON representation of your plan:
-```json
+
 %(plan)s
-```
+
 
 %(plan_status)s
 
@@ -84,9 +84,9 @@ you MUST respond with the `finish` action.
 Here is a recent history of actions you've taken in service of this plan,
 as well as observations you've made. This only includes the MOST RECENT
 ten actions--more happened before that.
-```json
+
 %(history)s
-```
+
 
 Your most recent action is at the bottom of that history.
 
@@ -118,7 +118,7 @@ It must be an object, and it must contain two fields:
 * `modify_task` - close a task. Arguments:
   * `id` - the ID of the task to close
   * `state` - set to 'in_progress' to start the task, 'completed' to finish it, 'verified' to assert that it was successful, 'abandoned' to give up on it permanently, or `open` to stop working on it for now.
-* `finish` - if ALL of your tasks and subtasks have been verified or abanded, and you're absolutely certain that you've completed your task and have tested your work, use the finish action to stop working.
+* `finish` - if ALL of your tasks and subtasks have been verified or abandoned, and you're absolutely certain that you've completed your task and have tested your work, use the finish action to stop working.
 
 You MUST take time to think in between read, write, run, browse, and recall actions.
 You should never act twice in a row without thinking. But if your last several


### PR DESCRIPTION
We had multiple reports of broken JSON from the LLM. I think the presence of markdown in prompts must be what is "breaking" responses in this particular way: the LLM sends back markdown around JSON. We're telling it this is JSON format, and it sure looks like millions of lines associated with JSON it has been trained on. 😆 Just a guess, it just makes some sense to me.

Testing with GPT-3.5, I see over 40% backticks in responses with the current code, and with this, zero. Testing was spot-checking, not exhaustive, but the difference is remarkable.

I'm not sure if GPT-4 has completely solved this, I didn't yet test this one with it.