### PR TITLE
Updating MakeFile and fixing monologue memory parameter issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,18 +51,18 @@ setup-config:
 
 	@echo "Enter your LLM Embedding Model\nChoices are openai, azureopenai, llama2 or leave blank to default to 'BAAI/bge-small-en-v1.5' via huggingface"; \
 	 read -p "> " llm_embedding_model; \
-	 echo "LLM_EMBEDDING_MODEL=\"$$llm_embedding_model\"" >> $(CONFIG_FILE).tmp; \
-	 if [ "$$llm_embedding_model" = "llama2" ]; then \
-	 read -p "Enter the local model URL: " llm_base_url; \
-	 echo "LLM_BASE_URL=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
-	 elif [ "$$llm_embedding_model" = "azureopenai" ]; then \
-	 read -p "Enter the Azure endpoint URL: " llm_base_url; \
-	 echo "LLM_BASE_URL=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
-	 read -p "Enter the Azure LLM Deployment Name: " llm_deployment_name; \
-	 echo "LLM_DEPLOYMENT_NAME=\"$$llm_deployment_name\"" >> $(CONFIG_FILE).tmp; \
-	 read -p "Enter the Azure API Version: " llm_api_version; \
-	 echo "LLM_API_VERSION=\"$$llm_api_version\"" >> $(CONFIG_FILE).tmp; \
-	 fi
+	 	echo "LLM_EMBEDDING_MODEL=\"$$llm_embedding_model\"" >> $(CONFIG_FILE).tmp; \
+		if [ "$$llm_embedding_model" = "llama2" ]; then \
+			read -p "Enter the local model URL: " llm_base_url; \
+				echo "LLM_BASE_URL=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
+		elif [ "$$llm_embedding_model" = "azureopenai" ]; then \
+			read -p "Enter the Azure endpoint URL: " llm_base_url; \
+				echo "LLM_BASE_URL=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
+			read -p "Enter the Azure LLM Deployment Name: " llm_deployment_name; \
+				echo "LLM_DEPLOYMENT_NAME=\"$$llm_deployment_name\"" >> $(CONFIG_FILE).tmp; \
+			read -p "Enter the Azure API Version: " llm_api_version; \
+				echo "LLM_API_VERSION=\"$$llm_api_version\"" >> $(CONFIG_FILE).tmp; \
+		fi
 
 	@read -p "Enter your workspace directory [default: $(DEFAULT_WORKSPACE_DIR)]: " workspace_dir; \
 	 workspace_dir=$${workspace_dir:-$(DEFAULT_WORKSPACE_DIR)}; \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,21 @@ setup-config:
 	@read -p "Enter your LLM API key: " llm_api_key; \
 	 echo "LLM_API_KEY=\"$$llm_api_key\"" >> $(CONFIG_FILE).tmp
 
+	@echo "Enter your LLM Embedding Model\nChoices are openai, azureopenai, llama2 or leave blank to default to 'BAAI/bge-small-en-v1.5' via huggingface"; \
+	 read -p "> " llm_embedding_model; \
+	 echo "LLM_EMBEDDING_MODEL=\"$$llm_embedding_model\"" >> $(CONFIG_FILE).tmp; \
+	 if [ "$$llm_embedding_model" = "llama2" ]; then \
+	 read -p "Enter the local model URL: " llm_base_url; \
+	 echo "LLM_BASE_URL=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
+	 elif [ "$$llm_embedding_model" = "azureopenai" ]; then \
+	 read -p "Enter the Azure endpoint URL: " llm_base_url; \
+	 echo "LLM_BASE_URL=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
+	 read -p "Enter the Azure LLM Deployment Name: " llm_deployment_name; \
+	 echo "LLM_DEPLOYMENT_NAME=\"$$llm_deployment_name\"" >> $(CONFIG_FILE).tmp; \
+	 read -p "Enter the Azure API Version: " llm_api_version; \
+	 echo "LLM_API_VERSION=\"$$llm_api_version\"" >> $(CONFIG_FILE).tmp; \
+	 fi
+
 	@read -p "Enter your workspace directory [default: $(DEFAULT_WORKSPACE_DIR)]: " workspace_dir; \
 	 workspace_dir=$${workspace_dir:-$(DEFAULT_WORKSPACE_DIR)}; \
 	 echo "WORKSPACE_DIR=\"$$workspace_dir\"" >> $(CONFIG_FILE).tmp

--- a/agenthub/monologue_agent/utils/memory.py
+++ b/agenthub/monologue_agent/utils/memory.py
@@ -21,7 +21,7 @@ if embedding_strategy == "llama2":
 elif embedding_strategy == "openai":
     from llama_index.embeddings.openai import OpenAIEmbedding
     embed_model = OpenAIEmbedding(
-        base_url=config.get_or_error("LLM_BASE_URL"),
+        model="text-embedding-ada-002"
     )
 elif embedding_strategy == "azureopenai":
     from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding  # Need to instruct to set these env variables in documentation


### PR DESCRIPTION
Updates to makefile and monologue agent memory

- agenthub/monologue_agent/utils/memory.py was using base_url as parameter in call to llama_index.embeddings.openai.OpenAIEmbedding. This was causing an issue when setting the LLM embedding option to OpenAI but not the LLM base url. Also from LlamaIndex docs, that parameter is not needed. I have removed that and place a default model parameter of text-embedding-ada-002

- I have added more embedding model configuration settings in make file for setup-config. This now sets the azure or llama2 needed options if one of those embedding models are selected