### PR TITLE
fix to pass api key to openai embedding

### DIFF
--- a/agenthub/monologue_agent/utils/memory.py
+++ b/agenthub/monologue_agent/utils/memory.py
@@ -21,7 +21,8 @@ if embedding_strategy == "llama2":
 elif embedding_strategy == "openai":
     from llama_index.embeddings.openai import OpenAIEmbedding
     embed_model = OpenAIEmbedding(
-        model="text-embedding-ada-002"
+        model="text-embedding-ada-002",
+        api_key=config.get_or_error("LLM_API_KEY")
     )
 elif embedding_strategy == "azureopenai":
     from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding  # Need to instruct to set these env variables in documentation


### PR DESCRIPTION
API key parameter missing in call to llama_index.embeddings.openai.OpenAIEmbedding in OpenDevin/agenthub/monologue_agent/utils/memory.py causing a connection error