### PR TITLE
Make poetry install manual and provide user with install instructions

### DIFF
--- a/.github/workflows/build_run-tests.yml
+++ b/.github/workflows/build_run-tests.yml
@@ -13,5 +13,6 @@ jobs:
           python-version: '3.11'
       - name: Run tests
         run: |
+          curl -sSL https://install.python-poetry.org | python3 -
           make build
           poetry run pytest ./tests

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,6 @@ build:
 		echo "$(RED)Docker is not installed. Please install Docker to continue.$(RESET)"; \
 		exit 1; \
 	fi
-	@echo "$(GREEN)Pulling Docker image...$(RESET)"
-	@docker pull $(DOCKER_IMAGE)
 	@echo "$(GREEN)Installing Python dependencies...$(RESET)"
 	@if command -v poetry > /dev/null; then \
 		echo "$(BLUE)Poetry is already installed.$(RESET)"; \
@@ -64,6 +62,8 @@ build:
 		echo "$(YELLOW)curl -sSL https://install.python-poetry.org | python3 -$(RESET)"; \
 		exit 1; \
 	fi
+	@echo "$(GREEN)Pulling Docker image...$(RESET)"
+	@docker pull $(DOCKER_IMAGE)
 	@poetry install --without evaluation
 	@echo "$(GREEN)Activating Poetry shell...$(RESET)"
 	@echo "$(GREEN)Setting up frontend environment...$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ build:
 		echo "$(BLUE)Poetry is already installed.$(RESET)"; \
 	else \
 		echo "$(YELLOW)Poetry is not installed. You can install poetry by running the following command, then adding Poetry to your PATH:"; \
-		echo "$(YELLOW)curl -sSL https://install.python-poetry.org | python3 -$(RESET)"; \
+		echo "$(YELLOW) curl -sSL https://install.python-poetry.org | python3 -$(RESET)"; \
+		echo "$(YELLOW)More detail here: https://python-poetry.org/docs/#installing-with-the-official-installer$(RESET)"; \
 		exit 1; \
 	fi
 	@echo "$(GREEN)Pulling Docker image...$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,13 @@ build:
 	@echo "$(GREEN)Pulling Docker image...$(RESET)"
 	@docker pull $(DOCKER_IMAGE)
 	@echo "$(GREEN)Installing Python dependencies...$(RESET)"
-	@curl -sSL https://install.python-poetry.org | python3 -
+	@if command -v poetry > /dev/null; then \
+		echo "$(BLUE)Poetry is already installed.$(RESET)"; \
+	else \
+		echo "$(YELLOW)Poetry is not installed. You can install poetry by running the following command, then adding Poetry to your PATH:"; \
+		echo "$(YELLOW)curl -sSL https://install.python-poetry.org | python3 -$(RESET)"; \
+		exit 1; \
+	fi
 	@poetry install --without evaluation
 	@echo "$(GREEN)Activating Poetry shell...$(RESET)"
 	@echo "$(GREEN)Setting up frontend environment...$(RESET)"


### PR DESCRIPTION
On mac, Poetry previously auto-installed when it was missing, but didn't install completely due to the path not being set, leaving the user with a confusing "poetry not found" error.

This PR:
1. Makes it so the user has to install poetry manually (because it's probably better for the make file to not make global changes to their system without the user knowing).
2. Provides some instruction on how they can do so.

Fixes https://github.com/OpenDevin/OpenDevin/issues/777
Fixes https://github.com/OpenDevin/OpenDevin/issues/785