### PR TITLE
Added Discord Logo with Link to GitHub README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
   <a href="https://github.com/OpenDevin/OpenDevin/stargazers"><img src="https://img.shields.io/github/stars/opendevin/opendevin?style=for-the-badge" alt="Stargazers"></a>
   <a href="https://github.com/OpenDevin/OpenDevin/issues"><img src="https://img.shields.io/github/issues/opendevin/opendevin?style=for-the-badge" alt="Issues"></a>
   <a href="https://github.com/OpenDevin/OpenDevin/blob/main/LICENSE"><img src="https://img.shields.io/github/license/opendevin/opendevin?style=for-the-badge" alt="MIT License"></a>
+  <a href="https://discord.gg/mBuDGRzzES"><img src="https://discord.com/assets/07dca80a102d4149e9736d4b162cff6f.ico" alt="Discord" height="30" width="30"></a>
+
 </div>
 
 <!-- PROJECT LOGO -->


### PR DESCRIPTION
Added a Discord logo with a hyperlink to the Discord server invite in the README.md file of the OpenDevin GitHub repository. This enhancement provides users with easy access to join the Discord community directly from the project's README. The Discord logo is linked to the Discord server invite, ensuring seamless navigation for users interested in engaging with the project's community. This update aims to improve user experience and promote community engagement within the OpenDevin project.