### PR TITLE
fix(logger): use .getLogger to avoid same logging message to get printed twice

### DIFF
--- a/opendevin/logging.py
+++ b/opendevin/logging.py
@@ -63,15 +63,14 @@ def log_uncaught_exceptions(ex_cls, ex, tb):
 
 sys.excepthook = log_uncaught_exceptions
 
-opendevin_logger = logging.getLogger()
+opendevin_logger = logging.getLogger("opendevin")
 opendevin_logger.setLevel(logging.INFO)
-opendevin_logger.propagate = False
 opendevin_logger.addHandler(get_console_handler())
 opendevin_logger.addHandler(get_file_handler())
+opendevin_logger.propagate = False
 opendevin_logger.debug('Logging initialized')
 opendevin_logger.debug('Logging to %s', os.path.join(
     os.getcwd(), 'logs', 'opendevin.log'))
-opendevin_logger.name = 'opendevin'
 
 # Exclude "litellm" from logging output
 logging.getLogger('LiteLLM').disabled = True


### PR DESCRIPTION
Fix the duplicated log printing issue mentioned [here](https://github.com/OpenDevin/OpenDevin/pull/847#issue-2229598945).

<img width="1051" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/38853559/7cfed0b5-cc2f-4ac3-b283-6f2031fd8c12">

As seen above, each logger.info get printed twice, once to the `root` logger, once to the `opendevin` logger.

According to [GPT-4](https://chat.openai.com/share/7caf102c-9058-4e56-bf5d-c5542b63e96f):

> You initially get the root logger using logging.getLogger() with no arguments, and then change its name later. This could be misleading because changing the name of the root logger does not change its behavior or its instance; it just changes a property of the root logger. If other parts of your application or third-party libraries also configure the root logger, it could lead to unexpected results.

In this PR, we create a dedicated `opendevin` logger to resolve this issue.

After fixing:

<img width="1525" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/38853559/23d8f384-8b3b-4864-9bc3-c6e54930b095">
