### PR TITLE
Don't save backend file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ run:
 	fi
 	@mkdir -p logs
 	@echo "$(YELLOW)Starting backend server...$(RESET)"
-	@poetry run uvicorn opendevin.server.listen:app --port $(BACKEND_PORT)
+	@poetry run uvicorn opendevin.server.listen:app --port $(BACKEND_PORT) &
 	@echo "$(YELLOW)Waiting for the backend to start...$(RESET)"
 	@until nc -z localhost $(BACKEND_PORT); do sleep 0.1; done
 	@echo "$(GREEN)Backend started successfully.$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ run:
 	fi
 	@mkdir -p logs
 	@echo "$(YELLOW)Starting backend server...$(RESET)"
-	@poetry run nohup uvicorn opendevin.server.listen:app --port $(BACKEND_PORT) > logs/backend_$(shell date +'%Y%m%d_%H%M%S').log 2>&1 &
+	@poetry run uvicorn opendevin.server.listen:app --port $(BACKEND_PORT)
 	@echo "$(YELLOW)Waiting for the backend to start...$(RESET)"
 	@until nc -z localhost $(BACKEND_PORT); do sleep 0.1; done
 	@echo "$(GREEN)Backend started successfully.$(RESET)"


### PR DESCRIPTION
Don't save backend file anymore, for two reasons:
- redundant, since we have now an opendevin.log for the app
- in particular cases liteLLM can still leak sensitive data. That is being fixed [here](https://github.com/OpenDevin/OpenDevin/compare/main...enyst:OpenDevin:log) 
 @dorbanianas @rbren 