### PR TITLE
Fix Cors issue with files endpoints

### DIFF
--- a/frontend/src/services/fileService.ts
+++ b/frontend/src/services/fileService.ts
@@ -5,10 +5,12 @@ export type WorkspaceFile = {
 
 export async function selectFile(file: string): Promise<string> {
   const res = await fetch(`/api/select-file?file=${file}`);
-  return (await JSON.parse(await res.json()).code) as string;
+  const data = await res.json();
+  return data.code as string;
 }
 
 export async function getWorkspace(): Promise<WorkspaceFile> {
   const res = await fetch("/api/refresh-files");
-  return (await JSON.parse(await res.json())) as WorkspaceFile;
+  const data = await res.json();
+  return data as WorkspaceFile;
 }

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -1,4 +1,3 @@
-import json
 import uuid
 from pathlib import Path
 
@@ -120,11 +119,11 @@ def read_default_model():
 def refresh_files():
     structure = files.get_folder_structure(
         Path(str(config.get('WORKSPACE_DIR'))))
-    return json.dumps(structure.to_dict())
+    return structure.to_dict()
 
 
 @app.get('/select-file')
 def select_file(file: str):
     with open(Path(Path(str(config.get('WORKSPACE_DIR'))), file), 'r') as selected_file:
         content = selected_file.read()
-    return json.dumps({'code': content})
+    return {'code': content}


### PR DESCRIPTION
Issue:

The following endpoint used `json.dumps` as a return for the endpoints

/refresh-files
/select-file

This conflicts with FastAPI's ability to assign the proper response headers causing CORS issues.

Also, the client side handler code was adjusted to work with the FastAPI rendered JSON response.