### PR TITLE
fix(ghcr image): Bump minor version to fix docker build

### DIFF
--- a/opendevin/sandbox/Makefile
+++ b/opendevin/sandbox/Makefile
@@ -1,7 +1,7 @@
 DOCKER_BUILD_REGISTRY=ghcr.io
 DOCKER_BUILD_ORG=opendevin
 DOCKER_BUILD_REPO=sandbox
-DOCKER_BUILD_TAG=v0.1.1
+DOCKER_BUILD_TAG=v0.2
 FULL_IMAGE=$(DOCKER_BUILD_REGISTRY)/$(DOCKER_BUILD_ORG)/$(DOCKER_BUILD_REPO):$(DOCKER_BUILD_TAG)
 
 LATEST_FULL_IMAGE=$(DOCKER_BUILD_REGISTRY)/$(DOCKER_BUILD_ORG)/$(DOCKER_BUILD_REPO):latest
@@ -25,7 +25,7 @@ test:
 # cross platform build, you may need to manually stop the buildx(buildkit) container
 all:
 	docker buildx build --platform linux/amd64,linux/arm64 \
-	-t ${FULL_IMAGE} -t ${LATEST_FULL_IMAGE}  -t ${MINOR_FULL_IMAGE}--push -f Dockerfile .
+	-t ${FULL_IMAGE} -t ${LATEST_FULL_IMAGE}  -t ${MINOR_FULL_IMAGE} --push -f Dockerfile .
 
 get-full-image:
 	@echo ${FULL_IMAGE}


### PR DESCRIPTION
Version `v0.1.1` will be recognized as `v0.1` minor version in [the Makefile implementation](https://github.com/OpenDevin/OpenDevin/blob/55760ec4ddc669daf4a0b8b36028d2e73c9ab17a/opendevin/sandbox/Makefile#L9-L12), potentially causing the new docker image to fail to build and push to ghcr.

This PR bumps up `v0.1.1` into `v0.2` to fix this issue.

<img width="1104" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/38853559/1d403bd2-855e-4d40-b11e-1fba46a02059">
