### PR TITLE
fix: change default RUN_AS_DEVIN to true and change some network setting

### DIFF
--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -14,7 +14,7 @@ DEFAULT_CONFIG: dict = {
     ConfigType.WORKSPACE_DIR: os.path.join(os.getcwd(), 'workspace'),
     ConfigType.LLM_MODEL: 'gpt-3.5-turbo-1106',
     ConfigType.SANDBOX_CONTAINER_IMAGE: 'ghcr.io/opendevin/sandbox',
-    ConfigType.RUN_AS_DEVIN: 'false',
+    ConfigType.RUN_AS_DEVIN: 'true',
     ConfigType.LLM_EMBEDDING_MODEL: 'local',
     ConfigType.LLM_NUM_RETRIES: 6,
     ConfigType.LLM_COOLDOWN_TIME: 1,

--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -296,8 +296,8 @@ class DockerInteractive(CommandExecutor):
             self.container = docker_client.containers.run(
                 self.container_image,
                 # only allow connections from localhost
-                command="/usr/sbin/sshd -D -p 2222 -o 'ListenAddress=127.0.0.1'",
-                network_mode='host',
+                command="/usr/sbin/sshd -D -p 2222 -o 'ListenAddress=0.0.0.0'",
+                ports={'2222/tcp': 2222},
                 working_dir='/workspace',
                 name=self.container_name,
                 hostname='opendevin_sandbox',


### PR DESCRIPTION
Quick fix the problem #887 introduced in #847. Firstly change the `RUN_AS_DEVIN: 'true'`.
After changing also meet problem like 
```
pexpect.pxssh.ExceptionPxssh: Could not establish connection to host
```
After trying locally with `ssh -p 2222 opendevin@localhost` still will meet. 
So do little change to the docker network setting. (not sure this change from my local env setting, or a wrong docker network configruation)