### PR TITLE
feat(sandbox): Support running sudo in a passwordless manner

### DIFF
--- a/opendevin/sandbox/sandbox.py
+++ b/opendevin/sandbox/sandbox.py
@@ -140,6 +140,18 @@ class DockerInteractive(CommandExecutor):
         atexit.register(self.cleanup)
 
     def setup_user(self):
+
+        # Make users sudoers passwordless
+        # TODO(sandbox): add this line in the Dockerfile for next minor version of docker image
+        exit_code, logs = self.container.exec_run(
+            ['/bin/bash', '-c',
+                r"echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"],
+            workdir='/workspace',
+        )
+        if exit_code != 0:
+            raise Exception(
+                f'Failed to make all users passwordless sudoers in sandbox: {logs}')
+
         # Check if the opendevin user exists
         exit_code, logs = self.container.exec_run(
             ['/bin/bash', '-c', 'id -u opendevin'],


### PR DESCRIPTION
Now `opendevin` user can run the command with `sudo` in the sandbox. This will largely get rid of the need for OpenDevin to run as root (modified in #895).

<img width="2219" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/38853559/511afc4e-f7a0-483c-85c0-7850dbdd3a3a">
