### PR TITLE
Revamp Exception handling

### DIFF
--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -3,6 +3,7 @@ from opendevin.agent import Agent
 from opendevin.state import State
 from opendevin.llm.llm import LLM
 from opendevin.schema import ActionType, ObservationType
+from opendevin.exceptions import AgentNoInstructionError
 
 from opendevin.action import (
     Action,
@@ -131,14 +132,14 @@ class MonologueAgent(Agent):
         - task (str): The initial goal statement provided by the user
 
         Raises:
-        - ValueError: If task is not provided
+        - AgentNoInstructionError: If task is not provided
         """
 
         if self._initialized:
             return
 
         if task is None or task == '':
-            raise ValueError('Instruction must be provided')
+            raise AgentNoInstructionError()
         self.monologue = Monologue()
         self.memory = LongTermMemory()
 

--- a/agenthub/monologue_agent/utils/monologue.py
+++ b/agenthub/monologue_agent/utils/monologue.py
@@ -1,5 +1,7 @@
 import traceback
+
 from opendevin.llm.llm import LLM
+from opendevin.exceptions import AgentEventTypeError
 import agenthub.monologue_agent.utils.json as json
 import agenthub.monologue_agent.utils.prompts as prompts
 
@@ -24,10 +26,10 @@ class Monologue:
         - t (dict): The thought that we want to add to memory
 
         Raises:
-        - ValueError: If t is not a dict
+        - AgentEventTypeError: If t is not a dict
         """
         if not isinstance(t, dict):
-            raise ValueError('Event must be a dictionary')
+            raise AgentEventTypeError()
         self.thoughts.append(t)
 
     def get_thoughts(self):
@@ -51,7 +53,7 @@ class Monologue:
             try:
                 total_length += len(json.dumps(t))
             except TypeError as e:
-                print(f"Error serializing thought: {e}")
+                print(f'Error serializing thought: {e}')
         return total_length
 
     def condense(self, llm: LLM):
@@ -73,4 +75,4 @@ class Monologue:
             self.thoughts = prompts.parse_summary_response(summary_resp)
         except Exception as e:
             traceback.print_exc()
-            raise RuntimeError(f"Error condensing thoughts: {e}")
+            raise RuntimeError(f'Error condensing thoughts: {e}')

--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -12,6 +12,7 @@ from opendevin.action import (
 from opendevin.observation import (
     CmdOutputObservation,
 )
+from opendevin.exceptions import LLMOutputError
 
 ACTION_PROMPT = """
 You're a thoughtful robot. Your main task is this:
@@ -93,12 +94,13 @@ def get_summarize_monologue_prompt(thoughts: List[dict]):
     """
     Gets the prompt for summarizing the monologue
 
-    Returns: 
+    Returns:
     - str: A formatted string with the current monologue within the prompt
     """
     return MONOLOGUE_SUMMARY_PROMPT % {
         'monologue': json.dumps({'old_monologue': thoughts}, indent=2),
     }
+
 
 def get_request_action_prompt(
     task: str,
@@ -120,23 +122,23 @@ def get_request_action_prompt(
     hint = ''
     if len(thoughts) > 0:
         latest_thought = thoughts[-1]
-        if "action" in latest_thought:
-            if latest_thought["action"] == "think":
-                if latest_thought["args"]["thought"].startswith("OK so my task is"):
+        if 'action' in latest_thought:
+            if latest_thought['action'] == 'think':
+                if latest_thought['args']['thought'].startswith('OK so my task is'):
                     hint = "You're just getting started! What should you do first?"
                 else:
                     hint = "You've been thinking a lot lately. Maybe it's time to take action?"
-            elif latest_thought["action"] == "error":
-                hint = "Looks like that last command failed. Maybe you need to fix it, or try something else."
+            elif latest_thought['action'] == 'error':
+                hint = 'Looks like that last command failed. Maybe you need to fix it, or try something else.'
 
-    bg_commands_message = ""
+    bg_commands_message = ''
     if len(background_commands_obs) > 0:
-        bg_commands_message = "The following commands are running in the background:"
+        bg_commands_message = 'The following commands are running in the background:'
         for command_obs in background_commands_obs:
             bg_commands_message += (
-                f"\n`{command_obs.command_id}`: {command_obs.command}"
+                f'\n`{command_obs.command_id}`: {command_obs.command}'
             )
-        bg_commands_message += "\nYou can end any process by sending a `kill` action with the numerical `id` above."
+        bg_commands_message += '\nYou can end any process by sending a `kill` action with the numerical `id` above.'
 
     return ACTION_PROMPT % {
         'task': task,
@@ -144,6 +146,7 @@ def get_request_action_prompt(
         'background_commands': bg_commands_message,
         'hint': hint,
     }
+
 
 def parse_action_response(response: str) -> Action:
     """
@@ -162,17 +165,20 @@ def parse_action_response(response: str) -> Action:
         response_json_matches = re.finditer(
             r"""{\s*\"action\":\s?\"(\w+)\"(?:,?|,\s*\"args\":\s?{((?:.|\s)*?)})\s*}""",
             response)  # Find all response-looking strings
+
         def rank(match):
-            return len(match[2]) if match[1] == "think" else 130  # Crudely rank multiple responses by length
+            # Crudely rank multiple responses by length
+            return len(match[2]) if match[1] == 'think' else 130
         try:
-            action_dict = json.loads(max(response_json_matches, key=rank)[0])  # Use the highest ranked response
+            action_dict = json.loads(max(response_json_matches, key=rank)[
+                                     0])  # Use the highest ranked response
         except ValueError as e:
-            raise ValueError(
+            raise LLMOutputError(
                 "Output from the LLM isn't properly formatted. The model may be misconfigured."
             ) from e
-    if "content" in action_dict:
+    if 'content' in action_dict:
         # The LLM gets confused here. Might as well be robust
-        action_dict["contents"] = action_dict.pop("content")
+        action_dict['contents'] = action_dict.pop('content')
     return action_from_dict(action_dict)
 
 
@@ -187,4 +193,4 @@ def parse_summary_response(response: str) -> List[dict]:
     - List[dict]: The list of summaries output by the model
     """
     parsed = json.loads(response)
-    return parsed["new_monologue"]
+    return parsed['new_monologue']

--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -169,8 +169,7 @@ def parse_action_response(response: str) -> Action:
         def rank(match):
             return len(match[2]) if match[1] == 'think' else 130  # Crudely rank multiple responses by length
         try:
-            action_dict = json.loads(max(response_json_matches, key=rank)[
-                                     0])  # Use the highest ranked response
+            action_dict = json.loads(max(response_json_matches, key=rank)[0])  # Use the highest ranked response
         except ValueError as e:
             raise LLMOutputError(
                 "Output from the LLM isn't properly formatted. The model may be misconfigured."

--- a/opendevin/action/__init__.py
+++ b/opendevin/action/__init__.py
@@ -28,6 +28,8 @@ ACTION_TYPE_TO_CLASS = {action_class.action: action_class for action_class in ac
 
 
 def action_from_dict(action: dict) -> Action:
+    if not isinstance(action, dict):
+        raise TypeError('action must be a dictionary')
     action = action.copy()
     if 'action' not in action:
         raise KeyError(f"'action' key is not found in {action=}")

--- a/opendevin/agent.py
+++ b/opendevin/agent.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
     from opendevin.action import Action
     from opendevin.state import State
 from opendevin.llm.llm import LLM
+from opendevin.exceptions import AgentAlreadyRegisteredError, AgentNotRegisteredError
 
 
 class Agent(ABC):
@@ -71,9 +72,12 @@ class Agent(ABC):
         Parameters:
         - name (str): The name to register the class under.
         - agent_cls (Type['Agent']): The class to register.
+
+        Raises:
+        - AgentAlreadyRegisteredError: If name already registered
         """
         if name in cls._registry:
-            raise ValueError(f"Agent class already registered under '{name}'.")
+            raise AgentAlreadyRegisteredError(name)
         cls._registry[name] = agent_cls
 
     @classmethod
@@ -86,16 +90,22 @@ class Agent(ABC):
 
         Returns:
         - agent_cls (Type['Agent']): The class registered under the specified name.
+
+        Raises:
+        - AgentNotRegisteredError: If name not registered
         """
         if name not in cls._registry:
-            raise ValueError(f"No agent class registered under '{name}'.")
+            raise AgentNotRegisteredError(name)
         return cls._registry[name]
 
     @classmethod
     def list_agents(cls) -> list[str]:
         """
         Retrieves the list of all agent names from the registry.
+
+        Raises:
+        - AgentNotRegisteredError: If no agent is registered
         """
         if not bool(cls._registry):
-            raise ValueError('No agent class registered.')
+            raise AgentNotRegisteredError()
         return list(cls._registry.keys())

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -5,7 +5,8 @@ import time
 from typing import List, Callable, Literal, Mapping, Awaitable, Any, cast
 
 from termcolor import colored
-from litellm.exceptions import AuthenticationError, APIConnectionError
+from litellm.exceptions import APIConnectionError
+from openai import AuthenticationError
 
 from opendevin import config
 from opendevin.action import (
@@ -158,6 +159,12 @@ class AgentController:
                 time.sleep(3)
 
             # raise specific exceptions that need to be handled outside
+            # note: we are using AuthenticationError class from openai rather than
+            # litellm because:
+            # 1) litellm.exceptions.AuthenticationError is a subclass of openai.AuthenticationError
+            # 2) embeddings call, initiated by llama-index, has no wrapper for authentication
+            #    errors. This means we have to catch individual authentication errors
+            #    from different providers, and OpenAI is one of these.
             if isinstance(e, (AuthenticationError, AgentNoActionError)):
                 raise
         self.update_state_after_step()

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -1,10 +1,11 @@
 import asyncio
 import inspect
 import traceback
+import time
 from typing import List, Callable, Literal, Mapping, Awaitable, Any, cast
 
 from termcolor import colored
-from litellm.exceptions import AuthenticationError
+from litellm.exceptions import AuthenticationError, APIConnectionError
 
 from opendevin import config
 from opendevin.action import (
@@ -153,6 +154,8 @@ class AgentController:
             observation = AgentErrorObservation(str(e))
             print_with_color(observation, 'ERROR')
             traceback.print_exc()
+            if isinstance(e, APIConnectionError):
+                time.sleep(3)
 
             # raise specific exceptions that need to be handled outside
             if isinstance(e, (AuthenticationError, AgentNoActionError)):

--- a/opendevin/exceptions.py
+++ b/opendevin/exceptions.py
@@ -3,7 +3,63 @@ class MaxCharsExceedError(Exception):
         if num_of_chars is not None and max_chars_limit is not None:
             # FIXME: autopep8 and mypy are fighting each other on this line
             # autopep8: off
-            message = f"Number of characters {num_of_chars} exceeds MAX_CHARS limit: {max_chars_limit}"
+            message = f'Number of characters {num_of_chars} exceeds MAX_CHARS limit: {max_chars_limit}'
         else:
             message = 'Number of characters exceeds MAX_CHARS limit'
+        super().__init__(message)
+
+
+class AgentNoActionError(Exception):
+    def __init__(self, message='Agent must return an action'):
+        super().__init__(message)
+
+
+class AgentNoInstructionError(Exception):
+    def __init__(self, message='Instruction must be provided'):
+        super().__init__(message)
+
+
+class AgentEventTypeError(Exception):
+    def __init__(self, message='Event must be a dictionary'):
+        super().__init__(message)
+
+
+class AgentAlreadyRegisteredError(Exception):
+    def __init__(self, name=None):
+        if name is not None:
+            message = f"Agent class already registered under '{name}'"
+        else:
+            message = 'Agent class already registered'
+        super().__init__(message)
+
+
+class AgentNotRegisteredError(Exception):
+    def __init__(self, name=None):
+        if name is not None:
+            message = f"No agent class registered under '{name}'"
+        else:
+            message = 'No agent class registered'
+        super().__init__(message)
+
+
+class LLMOutputError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class SandboxInvalidBackgroundCommandError(Exception):
+    def __init__(self, id=None):
+        if id is not None:
+            message = f'Invalid background command id {id}'
+        else:
+            message = 'Invalid background command id'
+        super().__init__(message)
+
+
+class PlanInvalidStateError(Exception):
+    def __init__(self, state=None):
+        if state is not None:
+            message = f'Invalid state {state}'
+        else:
+            message = 'Invalid state'
         super().__init__(message)

--- a/opendevin/plan.py
+++ b/opendevin/plan.py
@@ -1,5 +1,7 @@
 from typing import List
+
 from opendevin.logger import opendevin_logger as logger
+from opendevin.exceptions import PlanInvalidStateError
 
 OPEN_STATE = 'open'
 COMPLETED_STATE = 'completed'
@@ -87,11 +89,11 @@ class Task:
         Args:            state: The new state of the task.
 
         Raises:
-            ValueError: If the provided state is invalid.
+            PlanInvalidStateError: If the provided state is invalid.
         """
         if state not in STATES:
             logger.error('Invalid state: %s', state)
-            raise ValueError('Invalid state:' + state)
+            raise PlanInvalidStateError(state)
         self.state = state
         if state == COMPLETED_STATE or state == ABANDONED_STATE or state == VERIFIED_STATE:
             for subtask in self.subtasks:

--- a/opendevin/sandbox/exec_box.py
+++ b/opendevin/sandbox/exec_box.py
@@ -228,8 +228,7 @@ class DockerExecBox(Sandbox):
                 break
             time.sleep(1)
             elapsed += 1
-            self.container = self.docker_client.containers.get(
-                self.container_name)
+            self.container = self.docker_client.containers.get(self.container_name)
             if elapsed > self.timeout:
                 break
         if self.container.status != 'running':

--- a/opendevin/sandbox/exec_box.py
+++ b/opendevin/sandbox/exec_box.py
@@ -13,6 +13,7 @@ from opendevin import config
 from opendevin.logger import opendevin_logger as logger
 from opendevin.sandbox.sandbox import Sandbox, BackgroundCommand
 from opendevin.schema import ConfigType
+from opendevin.exceptions import SandboxInvalidBackgroundCommandError
 
 InputType = namedtuple('InputType', ['content'])
 OutputType = namedtuple('OutputType', ['content'])
@@ -107,7 +108,7 @@ class DockerExecBox(Sandbox):
 
     def read_logs(self, id) -> str:
         if id not in self.background_commands:
-            raise ValueError('Invalid background command id')
+            raise SandboxInvalidBackgroundCommandError()
         bg_cmd = self.background_commands[id]
         return bg_cmd.read_logs()
 
@@ -157,7 +158,7 @@ class DockerExecBox(Sandbox):
 
     def kill_background(self, id: int) -> BackgroundCommand:
         if id not in self.background_commands:
-            raise ValueError('Invalid background command id')
+            raise SandboxInvalidBackgroundCommandError()
         bg_cmd = self.background_commands[id]
         if bg_cmd.pid is not None:
             self.container.exec_run(
@@ -227,7 +228,8 @@ class DockerExecBox(Sandbox):
                 break
             time.sleep(1)
             elapsed += 1
-            self.container = self.docker_client.containers.get(self.container_name)
+            self.container = self.docker_client.containers.get(
+                self.container_name)
             if elapsed > self.timeout:
                 break
         if self.container.status != 'running':

--- a/opendevin/sandbox/ssh_box.py
+++ b/opendevin/sandbox/ssh_box.py
@@ -15,6 +15,7 @@ from opendevin.logger import opendevin_logger as logger
 from opendevin.sandbox.sandbox import Sandbox, BackgroundCommand
 from opendevin.schema import ConfigType
 from opendevin.utils import find_available_tcp_port
+from opendevin.exceptions import SandboxInvalidBackgroundCommandError
 
 InputType = namedtuple('InputType', ['content'])
 OutputType = namedtuple('OutputType', ['content'])
@@ -188,7 +189,7 @@ class DockerSSHBox(Sandbox):
 
     def read_logs(self, id) -> str:
         if id not in self.background_commands:
-            raise ValueError('Invalid background command id')
+            raise SandboxInvalidBackgroundCommandError()
         bg_cmd = self.background_commands[id]
         return bg_cmd.read_logs()
 
@@ -239,7 +240,7 @@ class DockerSSHBox(Sandbox):
 
     def kill_background(self, id: int) -> BackgroundCommand:
         if id not in self.background_commands:
-            raise ValueError('Invalid background command id')
+            raise SandboxInvalidBackgroundCommandError()
         bg_cmd = self.background_commands[id]
         if bg_cmd.pid is not None:
             self.container.exec_run(


### PR DESCRIPTION
This PR aims to revamp exception handling, including:

1) Use custom exceptions if needed, especially when callers might need to catch the exception
2) Instance type check failure should throw "TypeError" rather than "ValueError"
3) In agent controller, sleep 3 seconds if APIConnectionError to avoid bursting the LLM backend
4) Avoid LLM-specific exception handling if there's a more generic substitute: E.g. use `litellm.exceptions.AuthenticationError` type check rather than OpenAI specific handling: 'The api_key client option must be set' string match.

Closes #1056
