### PR TITLE
Added Retry for LLM calls

### DIFF
--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -1,3 +1,5 @@
+import backoff
+import litellm
 
 from litellm import completion as litellm_completion
 from functools import partial
@@ -29,6 +31,8 @@ class LLM:
 
         completion_unwrapped = self._completion
 
+        @backoff.on_exception(backoff.expo,
+                              litellm.exceptions.APIConnectionError)
         def wrapper(*args, **kwargs):
             if 'messages' in kwargs:
                 messages = kwargs['messages']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/OpenDevin/OpenDevin"
 
 [tool.poetry.dependencies]
 python = "^3.11"
+backoff = "*"
 datasets = "*"
 pandas = "*"
 litellm = "*"


### PR DESCRIPTION
Solves APIConnectionErrors

Before
```
Traceback (most recent call last):
  File "/mnt/c/Users/91638/Documents/GitHub/OpenDevin/opendevin/controller/agent_controller.py", line 150, in step
    action = self.agent.step(self.state)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/91638/Documents/GitHub/OpenDevin/agenthub/monologue_agent/agent.py", line 217, in step
    resp = self.llm.completion(messages=messages)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/91638/Documents/GitHub/OpenDevin/opendevin/llm/llm.py", line 38, in wrapper
    resp = completion_unwrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/g/.cache/pypoetry/virtualenvs/opendevin-kRdIAkXu-py3.11/lib/python3.11/site-packages/litellm/utils.py", line 2944, in wrapper
    raise e
  File "/home/g/.cache/pypoetry/virtualenvs/opendevin-kRdIAkXu-py3.11/lib/python3.11/site-packages/litellm/utils.py", line 2842, in wrapper
    result = original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/g/.cache/pypoetry/virtualenvs/opendevin-kRdIAkXu-py3.11/lib/python3.11/site-packages/litellm/main.py", line 2127, in completion
    raise exception_type(
          ^^^^^^^^^^^^^^^
  File "/home/g/.cache/pypoetry/virtualenvs/opendevin-kRdIAkXu-py3.11/lib/python3.11/site-packages/litellm/utils.py", line 8539, in exception_type
    raise e
  File "/home/g/.cache/pypoetry/virtualenvs/opendevin-kRdIAkXu-py3.11/lib/python3.11/site-packages/litellm/utils.py", line 8507, in exception_type
    raise APIConnectionError(
litellm.exceptions.APIConnectionError: 429 Resource has been exhausted (e.g. check quota).
```

After 
```

STEP 5

PLAN:
run sudo whoami

Give Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new
LiteLLM.Info: If you need to debug this error, use `litellm.set_verbose=True'.

INFO:backoff:Backing off wrapper(...) for 0.5s (litellm.exceptions.APIConnectionError: 429 Resource has been exhausted (e.g. check quota).)

Give Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new
LiteLLM.Info: If you need to debug this error, use `litellm.set_verbose=True'.

INFO:backoff:Backing off wrapper(...) for 1.3s (litellm.exceptions.APIConnectionError: 429 Resource has been exhausted (e.g. check quota).)

Give Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new
LiteLLM.Info: If you need to debug this error, use `litellm.set_verbose=True'.

INFO:backoff:Backing off wrapper(...) for 2.1s (litellm.exceptions.APIConnectionError: 429 Resource has been exhausted (e.g. check quota).)
```