### PR TITLE
fix #1028, /select-file api call on deleted file in Code Editor caused Error

### DIFF
--- a/frontend/src/services/fileService.ts
+++ b/frontend/src/services/fileService.ts
@@ -6,6 +6,9 @@ export type WorkspaceFile = {
 export async function selectFile(file: string): Promise<string> {
   const res = await fetch(`/api/select-file?file=${file}`);
   const data = await res.json();
+  if (res.status !== 200) {
+    throw new Error(data.error);
+  }
   return data.code as string;
 }
 

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -133,8 +133,8 @@ def select_file(file: str):
         with open(file_path, 'r') as selected_file:
             content = selected_file.read()
     except Exception as e:
-        logger.error(f"Error opening file {file}: {e}", exc_info=False)
-        error_msg = f"Error opening file: {e}"
+        logger.error(f'Error opening file {file}: {e}', exc_info=False)
+        error_msg = f'Error opening file: {e}'
         return Response(f'{{"error": "{error_msg}"}}', status_code=500)
     return {'code': content}
 

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -2,7 +2,7 @@ import uuid
 from pathlib import Path
 
 import litellm
-from fastapi import Depends, FastAPI, WebSocket
+from fastapi import Depends, FastAPI, WebSocket, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
@@ -13,6 +13,7 @@ from starlette.responses import JSONResponse
 import agenthub  # noqa F401 (we import this to get the agents registered)
 from opendevin import config, files
 from opendevin.agent import Agent
+from opendevin.logger import opendevin_logger as logger
 from opendevin.server.agent import agent_manager
 from opendevin.server.auth import get_sid_from_token, sign_token
 from opendevin.server.session import message_stack, session_manager
@@ -126,10 +127,16 @@ def refresh_files():
 
 @app.get('/api/select-file')
 def select_file(file: str):
-    with open(Path(Path(str(config.get('WORKSPACE_BASE'))), file), 'r') as selected_file:
-        content = selected_file.read()
+    try:
+        workspace_base = config.get('WORKSPACE_BASE')
+        file_path = Path(workspace_base, file)
+        with open(file_path, 'r') as selected_file:
+            content = selected_file.read()
+    except Exception as e:
+        logger.error(f"Error opening file {file}: {e}", exc_info=False)
+        error_msg = f"Error opening file: {e}"
+        return Response(f'{{"error": "{error_msg}"}}', status_code=500)
     return {'code': content}
-
 
 @app.get('/')
 async def docs_redirect():

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -138,6 +138,7 @@ def select_file(file: str):
         return Response(f'{{"error": "{error_msg}"}}', status_code=500)
     return {'code': content}
 
+
 @app.get('/')
 async def docs_redirect():
     response = RedirectResponse(url='/index.html')


### PR DESCRIPTION
In Code Editor, When select a file and then call /select-file, if selected file is deleted, or the file can't be opened with exceptions like encoding problems, current error handling of server side and frontend side are not good, and the failure reason is not clear in frontend.

this pr will fix: https://github.com/OpenDevin/OpenDevin/issues/1028 

## before: 
server:
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/0bc12aff-5256-4157-82e5-60705b6b694d)


frontend:
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/6cb06b8c-8c1b-45b9-a86b-046f800c3a8a)


## after
server:
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/78ef8e73-8a02-4c52-bbad-754970fa6f7f)
frontend:
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/21c737f4-6b69-4f39-be73-ca2be6faed48)
