### PR TITLE
Refactor actions a bit

### DIFF
--- a/opendevin/action/agent.py
+++ b/opendevin/action/agent.py
@@ -18,7 +18,7 @@ class AgentRecallAction(ExecutableAction):
     query: str
     action: str = ActionType.RECALL
 
-    def run(self, controller: 'AgentController') -> AgentRecallObservation:
+    async def run(self, controller: 'AgentController') -> AgentRecallObservation:
         return AgentRecallObservation(
             content='Recalling memories...',
             memories=controller.agent.search_memory(self.query),
@@ -34,7 +34,7 @@ class AgentThinkAction(NotExecutableAction):
     thought: str
     action: str = ActionType.THINK
 
-    def run(self, controller: 'AgentController') -> 'Observation':
+    async def run(self, controller: 'AgentController') -> 'Observation':
         raise NotImplementedError
 
     @property
@@ -47,7 +47,7 @@ class AgentEchoAction(ExecutableAction):
     content: str
     action: str = 'echo'
 
-    def run(self, controller: 'AgentController') -> 'Observation':
+    async def run(self, controller: 'AgentController') -> 'Observation':
         return AgentMessageObservation(self.content)
 
     @property
@@ -70,7 +70,7 @@ class AgentSummarizeAction(NotExecutableAction):
 class AgentFinishAction(NotExecutableAction):
     action: str = ActionType.FINISH
 
-    def run(self, controller: 'AgentController') -> 'Observation':
+    async def run(self, controller: 'AgentController') -> 'Observation':
         raise NotImplementedError
 
     @property

--- a/opendevin/action/base.py
+++ b/opendevin/action/base.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class Action:
-    def run(self, controller: 'AgentController') -> 'Observation':
+    async def run(self, controller: 'AgentController') -> 'Observation':
         raise NotImplementedError
 
     def to_dict(self):

--- a/opendevin/action/bash.py
+++ b/opendevin/action/bash.py
@@ -16,7 +16,7 @@ class CmdRunAction(ExecutableAction):
     action: str = ActionType.RUN
 
     def run(self, controller: 'AgentController') -> 'CmdOutputObservation':
-        return controller.command_manager.run_command(self.command, self.background)
+        return controller.action_manager.run_command(self.command, self.background)
 
     @property
     def message(self) -> str:
@@ -29,7 +29,7 @@ class CmdKillAction(ExecutableAction):
     action: str = ActionType.KILL
 
     def run(self, controller: 'AgentController') -> 'CmdOutputObservation':
-        return controller.command_manager.kill_command(self.id)
+        return controller.action_manager.kill_command(self.id)
 
     @property
     def message(self) -> str:

--- a/opendevin/action/bash.py
+++ b/opendevin/action/bash.py
@@ -15,7 +15,7 @@ class CmdRunAction(ExecutableAction):
     background: bool = False
     action: str = ActionType.RUN
 
-    def run(self, controller: 'AgentController') -> 'CmdOutputObservation':
+    async def run(self, controller: 'AgentController') -> 'CmdOutputObservation':
         return controller.action_manager.run_command(self.command, self.background)
 
     @property
@@ -28,7 +28,7 @@ class CmdKillAction(ExecutableAction):
     id: int
     action: str = ActionType.KILL
 
-    def run(self, controller: 'AgentController') -> 'CmdOutputObservation':
+    async def run(self, controller: 'AgentController') -> 'CmdOutputObservation':
         return controller.action_manager.kill_command(self.id)
 
     @property

--- a/opendevin/action/fileop.py
+++ b/opendevin/action/fileop.py
@@ -22,7 +22,7 @@ class FileReadAction(ExecutableAction):
     path: str
     action: str = ActionType.READ
 
-    def run(self, controller) -> FileReadObservation:
+    async def run(self, controller) -> FileReadObservation:
         path = resolve_path(self.path)
         with open(path, 'r', encoding='utf-8') as file:
             return FileReadObservation(path=path, content=file.read())
@@ -38,7 +38,7 @@ class FileWriteAction(ExecutableAction):
     content: str
     action: str = ActionType.WRITE
 
-    def run(self, controller) -> FileWriteObservation:
+    async def run(self, controller) -> FileWriteObservation:
         whole_path = resolve_path(self.path)
         with open(whole_path, 'w', encoding='utf-8') as file:
             file.write(self.content)

--- a/opendevin/action/tasks.py
+++ b/opendevin/action/tasks.py
@@ -1,15 +1,23 @@
 from dataclasses import dataclass, field
 
-from .base import NotExecutableAction
+from .base import ExecutableAction
 from opendevin.schema import ActionType
+from opendevin.observation import NullObservation
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from opendevin.controller import AgentController
 
 
 @dataclass
-class AddTaskAction(NotExecutableAction):
+class AddTaskAction(ExecutableAction):
     parent: str
     goal: str
     subtasks: list = field(default_factory=list)
     action: str = ActionType.ADD_TASK
+
+    async def run(self, controller: 'AgentController') -> NullObservation:  # type: ignore
+        controller.state.plan.add_subtask(self.parent, self.goal, self.subtasks)
 
     @property
     def message(self) -> str:
@@ -17,10 +25,14 @@ class AddTaskAction(NotExecutableAction):
 
 
 @dataclass
-class ModifyTaskAction(NotExecutableAction):
+class ModifyTaskAction(ExecutableAction):
     id: str
     state: str
     action: str = ActionType.MODIFY_TASK
+
+    async def run(self, controller: 'AgentController') -> NullObservation:  # type: ignore
+        controller.state.plan.set_subtask_state(self.id, self.state)
+        return NullObservation('')
 
     @property
     def message(self) -> str:

--- a/opendevin/action/tasks.py
+++ b/opendevin/action/tasks.py
@@ -18,6 +18,7 @@ class AddTaskAction(ExecutableAction):
 
     async def run(self, controller: 'AgentController') -> NullObservation:  # type: ignore
         controller.state.plan.add_subtask(self.parent, self.goal, self.subtasks)
+        return NullObservation('')
 
     @property
     def message(self) -> str:

--- a/opendevin/controller/__init__.py
+++ b/opendevin/controller/__init__.py
@@ -1,7 +1,7 @@
 from .agent_controller import AgentController
-from .command_manager import CommandManager
+from .action_manager import ActionManager
 
 __all__ = [
     'AgentController',
-    'CommandManager'
+    'ActionManager'
 ]

--- a/opendevin/controller/action_manager.py
+++ b/opendevin/controller/action_manager.py
@@ -1,6 +1,5 @@
-from typing import List, Awaitable, cast
+from typing import List
 import traceback
-import inspect
 
 from opendevin import config
 from opendevin.observation import CmdOutputObservation
@@ -61,9 +60,7 @@ class ActionManager:
                 traceback.print_exc()
         elif action.executable:
             try:
-                observation = action.run(agent_controller)
-                if inspect.isawaitable(observation):
-                    observation = await cast(Awaitable[Observation], observation)
+                observation = await action.run(agent_controller)
             except Exception as e:
                 observation = AgentErrorObservation(str(e))
                 logger.error(e)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -1,8 +1,6 @@
 import asyncio
-import inspect
-import traceback
 import time
-from typing import List, Callable, Awaitable, cast
+from typing import List, Callable
 from opendevin.plan import Plan
 from opendevin.state import State
 from opendevin.agent import Agent
@@ -14,14 +12,12 @@ from opendevin import config
 from opendevin.logger import opendevin_logger as logger
 
 from opendevin.exceptions import MaxCharsExceedError
-from .command_manager import CommandManager
+from .action_manager import ActionManager
 
 from opendevin.action import (
     Action,
     NullAction,
     AgentFinishAction,
-    AddTaskAction,
-    ModifyTaskAction,
 )
 from opendevin.exceptions import AgentNoActionError
 
@@ -33,7 +29,7 @@ class AgentController:
     id: str
     agent: Agent
     max_iterations: int
-    command_manager: CommandManager
+    action_manager: ActionManager
     callbacks: List[Callable]
 
     def __init__(
@@ -48,13 +44,13 @@ class AgentController:
         self.id = sid
         self.agent = agent
         self.max_iterations = max_iterations
-        self.command_manager = CommandManager(self.id, container_image)
+        self.action_manager = ActionManager(self.id, container_image)
         self.max_chars = max_chars
         self.callbacks = callbacks
 
     def update_state_for_step(self, i):
         self.state.iteration = i
-        self.state.background_commands_obs = self.command_manager.get_background_obs()
+        self.state.background_commands_obs = self.action_manager.get_background_obs()
 
     def update_state_after_step(self):
         self.state.updated_info = []
@@ -91,7 +87,7 @@ class AgentController:
             raise MaxCharsExceedError(
                 self.state.num_of_chars, self.max_chars)
 
-        log_obs = self.command_manager.get_background_obs()
+        log_obs = self.action_manager.get_background_obs()
         for obs in log_obs:
             self.add_history(NullAction(), obs)
             await self._run_callbacks(obs)
@@ -130,31 +126,8 @@ class AgentController:
             logger.info(action, extra={'msg_type': 'INFO'})
             return True
 
-        if isinstance(action, AddTaskAction):
-            try:
-                self.state.plan.add_subtask(
-                    action.parent, action.goal, action.subtasks)
-            except Exception as e:
-                observation = AgentErrorObservation(str(e))
-                logger.error(e)
-                traceback.print_exc()
-        elif isinstance(action, ModifyTaskAction):
-            try:
-                self.state.plan.set_subtask_state(action.id, action.state)
-            except Exception as e:
-                observation = AgentErrorObservation(str(e))
-                logger.error(e)
-                traceback.print_exc()
-
-        if action.executable:
-            try:
-                observation = action.run(self)
-                if inspect.isawaitable(observation):
-                    observation = await cast(Awaitable[Observation], observation)
-            except Exception as e:
-                observation = AgentErrorObservation(str(e))
-                logger.error(e)
-                traceback.print_exc()
+        if isinstance(observation, NullObservation):
+            observation = await self.action_manager.run_action(action, self)
 
         if not isinstance(observation, NullObservation):
             logger.info(observation, extra={'msg_type': 'OBSERVATION'})

--- a/opendevin/server/agent/agent.py
+++ b/opendevin/server/agent/agent.py
@@ -173,4 +173,4 @@ class AgentUnit:
         if self.agent_task:
             self.agent_task.cancel()
         if self.controller is not None:
-            self.controller.command_manager.shell.close()
+            self.controller.action_manager.shell.close()


### PR DESCRIPTION
Went down this path while trying to address https://github.com/OpenDevin/OpenDevin/issues/1164 as well as some comments in the e2b PR

I think we will probably want to pull all the `run()` logic into the ActionManager, and make the actions just dataclasses. It's a little messy, but it'll be less leaky than passing the AgentController into `run`