### PR TITLE
Fix for setting LLM model, frontend settings refactor

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,9 +10,10 @@ import SettingModal from "./components/SettingModal";
 import Terminal from "./components/Terminal";
 import Workspace from "./components/Workspace";
 import { fetchMsgTotal } from "./services/session";
-import { fetchConfigurations, saveSettings } from "./services/settingsService";
+import { getSettingsForInitialize } from "./services/settingsService";
 import Socket from "./services/socket";
 import { ResConfigurations, ResFetchMsgTotal } from "./types/ResponseType";
+import ActionType from "./types/ActionType";
 import { getCachedConfig } from "./utils/storage";
 
 interface Props {
@@ -39,22 +40,6 @@ function App(): JSX.Element {
   const [settingOpen, setSettingOpen] = useState(false);
   const [loadMsgWarning, setLoadMsgWarning] = useState(false);
 
-  const getConfigurations = () => {
-    fetchConfigurations()
-      .then((data: ResConfigurations) => {
-        const settings = getCachedConfig();
-
-        saveSettings(
-          Object.fromEntries(
-            Object.entries(data).map(([key, value]) => [key, String(value)]),
-          ),
-          settings,
-          true,
-        );
-      })
-      .catch();
-  };
-
   const getMsgTotal = () => {
     fetchMsgTotal()
       .then((data: ResFetchMsgTotal) => {
@@ -69,9 +54,12 @@ function App(): JSX.Element {
     if (initOnce) return;
     initOnce = true;
 
-    Socket.registerCallback("open", [getConfigurations, getMsgTotal]);
+    const event = { action: ActionType.INIT, args: getSettingsForInitialize() };
+    const eventString = JSON.stringify(event);
+    Socket.send(eventString);
 
-    getConfigurations();
+    Socket.registerCallback("open", [getMsgTotal]);
+
     getMsgTotal();
   }, []);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import SettingModal from "./components/SettingModal";
 import Terminal from "./components/Terminal";
 import Workspace from "./components/Workspace";
 import { fetchMsgTotal } from "./services/session";
-import { getCurrentSettings } from "./services/settingsService";
+import { initializeAgent } from "./services/settingsService";
 import Socket from "./services/socket";
 import { ResConfigurations, ResFetchMsgTotal } from "./types/ResponseType";
 import ActionType from "./types/ActionType";
@@ -54,9 +54,7 @@ function App(): JSX.Element {
     if (initOnce) return;
     initOnce = true;
 
-    const event = { action: ActionType.INIT, args: getCurrentSettings() };
-    const eventString = JSON.stringify(event);
-    Socket.send(eventString);
+    initializeAgent();
 
     Socket.registerCallback("open", [getMsgTotal]);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import SettingModal from "./components/SettingModal";
 import Terminal from "./components/Terminal";
 import Workspace from "./components/Workspace";
 import { fetchMsgTotal } from "./services/session";
-import { getSettingsForInitialize } from "./services/settingsService";
+import { getCurrentSettings } from "./services/settingsService";
 import Socket from "./services/socket";
 import { ResConfigurations, ResFetchMsgTotal } from "./types/ResponseType";
 import ActionType from "./types/ActionType";
@@ -54,7 +54,7 @@ function App(): JSX.Element {
     if (initOnce) return;
     initOnce = true;
 
-    const event = { action: ActionType.INIT, args: getSettingsForInitialize() };
+    const event = { action: ActionType.INIT, args: getCurrentSettings() };
     const eventString = JSON.stringify(event);
     Socket.send(eventString);
 

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -31,7 +31,9 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
     settings.get(ArgConfigType.LLM_MODEL),
   );
   const [agent, setAgent] = useState(settings.get(ArgConfigType.AGENT));
-  const [language, setLanguage] = useState(settings.get(ArgConfigType.LANGUAGE));
+  const [language, setLanguage] = useState(
+    settings.get(ArgConfigType.LANGUAGE)
+  );
 
   const { t } = useTranslation();
 
@@ -128,7 +130,7 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
         <Select
           selectionMode="single"
           onChange={(e) => setLanguage(e.target.value)}
-          selectedKeys={[language || '']}
+          selectedKeys={[language || ""]}
           label={t(I18nKey.CONFIGURATION$LANGUAGE_SELECT_LABEL)}
         >
           {AvailableLanguages.map((lang) => (

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 import {
   Autocomplete,
   AutocompleteItem,
@@ -15,7 +14,6 @@ import {
   saveSettings,
   getCurrentSettings,
 } from "../services/settingsService";
-import { RootState } from "../store";
 import { I18nKey } from "../i18n/declaration";
 import { AvailableLanguages } from "../i18n";
 import { ArgConfigType } from "../types/ConfigType";
@@ -52,13 +50,11 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
   }, []);
 
   const handleSaveCfg = () => {
-    saveSettings(
-      {
+    saveSettings({
         [ArgConfigType.LLM_MODEL]: model ?? inputModel,
         [ArgConfigType.AGENT]: agent,
         [ArgConfigType.LANGUAGE]: language,
-      },
-    );
+    });
     onClose();
   };
 

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -13,6 +13,7 @@ import {
   fetchModels,
   saveSettings,
   getCurrentSettings,
+  Settings,
 } from "../services/settingsService";
 import { I18nKey } from "../i18n/declaration";
 import { AvailableLanguages } from "../i18n";
@@ -25,14 +26,14 @@ interface Props {
 }
 
 function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
-  const settings = getCurrentSettings();
-  const [model, setModel] = useState(settings.get(ArgConfigType.LLM_MODEL));
+  const currentSettings: Settings = getCurrentSettings();
+  const [model, setModel] = useState(currentSettings[ArgConfigType.LLM_MODEL]);
   const [inputModel, setInputModel] = useState(
-    settings.get(ArgConfigType.LLM_MODEL),
+    currentSettings[ArgConfigType.LLM_MODEL],
   );
-  const [agent, setAgent] = useState(settings.get(ArgConfigType.AGENT));
+  const [agent, setAgent] = useState(currentSettings[ArgConfigType.AGENT]);
   const [language, setLanguage] = useState(
-    settings.get(ArgConfigType.LANGUAGE),
+    currentSettings[ArgConfigType.LANGUAGE],
   );
 
   const { t } = useTranslation();

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -13,6 +13,7 @@ import {
   fetchAgents,
   fetchModels,
   saveSettings,
+  getCurrentSettings,
 } from "../services/settingsService";
 import { RootState } from "../store";
 import { I18nKey } from "../i18n/declaration";
@@ -26,7 +27,7 @@ interface Props {
 }
 
 function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
-  const settings = useSelector((state: RootState) => state.settings);
+  const settings = getCurrentSettings();
   const [model, setModel] = useState(settings[ArgConfigType.LLM_MODEL]);
   const [inputModel, setInputModel] = useState(
     settings[ArgConfigType.LLM_MODEL],
@@ -57,10 +58,6 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
         [ArgConfigType.AGENT]: agent,
         [ArgConfigType.LANGUAGE]: language,
       },
-      Object.fromEntries(
-        Object.entries(settings).map(([key, value]) => [key, value]),
-      ),
-      false,
     );
     onClose();
   };

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -25,13 +25,6 @@ interface Props {
   onClose: () => void;
 }
 
-const cachedModels = JSON.parse(
-  localStorage.getItem("supportedModels") || "[]",
-);
-const cachedAgents = JSON.parse(
-  localStorage.getItem("supportedAgents") || "[]",
-);
-
 function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
   const settings = useSelector((state: RootState) => state.settings);
   const [model, setModel] = useState(settings[ArgConfigType.LLM_MODEL]);

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -26,12 +26,12 @@ interface Props {
 
 function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
   const settings = getCurrentSettings();
-  const [model, setModel] = useState(settings[ArgConfigType.LLM_MODEL]);
+  const [model, setModel] = useState(settings.get(ArgConfigType.LLM_MODEL));
   const [inputModel, setInputModel] = useState(
-    settings[ArgConfigType.LLM_MODEL],
+    settings.get(ArgConfigType.LLM_MODEL),
   );
-  const [agent, setAgent] = useState(settings[ArgConfigType.AGENT]);
-  const [language, setLanguage] = useState(settings[ArgConfigType.LANGUAGE]);
+  const [agent, setAgent] = useState(settings.get(ArgConfigType.AGENT));
+  const [language, setLanguage] = useState(settings.get(ArgConfigType.LANGUAGE));
 
   const { t } = useTranslation();
 
@@ -128,7 +128,7 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
         <Select
           selectionMode="single"
           onChange={(e) => setLanguage(e.target.value)}
-          selectedKeys={[language]}
+          selectedKeys={[language || '']}
           label={t(I18nKey.CONFIGURATION$LANGUAGE_SELECT_LABEL)}
         >
           {AvailableLanguages.map((lang) => (

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -32,7 +32,7 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
   );
   const [agent, setAgent] = useState(settings.get(ArgConfigType.AGENT));
   const [language, setLanguage] = useState(
-    settings.get(ArgConfigType.LANGUAGE)
+    settings.get(ArgConfigType.LANGUAGE),
   );
 
   const { t } = useTranslation();

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -12,8 +12,6 @@ import { useTranslation } from "react-i18next";
 import {
   fetchAgents,
   fetchModels,
-  INITIAL_AGENTS,
-  INITIAL_MODELS,
   saveSettings,
 } from "../services/settingsService";
 import { RootState } from "../store";
@@ -45,23 +43,17 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
 
   const { t } = useTranslation();
 
-  const [supportedModels, setSupportedModels] = useState(
-    cachedModels.length > 0 ? cachedModels : INITIAL_MODELS,
-  );
-  const [supportedAgents, setSupportedAgents] = useState(
-    cachedAgents.length > 0 ? cachedAgents : INITIAL_AGENTS,
-  );
+  const [supportedModels, setSupportedModels] = useState([]);
+  const [supportedAgents, setSupportedAgents] = useState([]);
 
   useEffect(() => {
     fetchModels().then((fetchedModels) => {
       const sortedModels = fetchedModels.sort(); // Sorting the models alphabetically
       setSupportedModels(sortedModels);
-      localStorage.setItem("supportedModels", JSON.stringify(sortedModels));
     });
 
     fetchAgents().then((fetchedAgents) => {
       setSupportedAgents(fetchedAgents);
-      localStorage.setItem("supportedAgents", JSON.stringify(fetchedAgents));
     });
   }, []);
 

--- a/frontend/src/components/SettingModal.tsx
+++ b/frontend/src/components/SettingModal.tsx
@@ -51,9 +51,9 @@ function InnerSettingModal({ isOpen, onClose }: Props): JSX.Element {
 
   const handleSaveCfg = () => {
     saveSettings({
-        [ArgConfigType.LLM_MODEL]: model ?? inputModel,
-        [ArgConfigType.AGENT]: agent,
-        [ArgConfigType.LANGUAGE]: language,
+      [ArgConfigType.LLM_MODEL]: model ?? inputModel,
+      [ArgConfigType.AGENT]: agent,
+      [ArgConfigType.LANGUAGE]: language,
     });
     onClose();
   };

--- a/frontend/src/services/settingsService.test.ts
+++ b/frontend/src/services/settingsService.test.ts
@@ -1,10 +1,6 @@
 import { getUpdatedSettings } from "./settingsService";
 import { ArgConfigType } from "../types/ConfigType";
 
-// We need to mock this to avoid `SyntaxError` from using `Socket` in `settingsService` during testing
-jest.mock("./socket", () => ({
-  send: jest.fn(),
-}));
 
 describe("mergeAndUpdateSettings", () => {
   it("should return initial settings if newSettings is empty", () => {

--- a/frontend/src/services/settingsService.test.ts
+++ b/frontend/src/services/settingsService.test.ts
@@ -15,7 +15,7 @@ describe("getUpdatedSettings", () => {
     expect(result).toEqual({});
   });
 
-  it("should add new keys to mergedSettings and updatedSettings", () => {
+  it("should add new keys to updatedSettings", () => {
     const oldSettings = { key1: "value1" };
     const newSettings = { key2: "value2" };
 
@@ -35,7 +35,7 @@ describe("getUpdatedSettings", () => {
     expect(result).toEqual({});
   });
 
-  it("should keep old values in mergedSettings if they are equal", () => {
+  it("should show no values if they are equal", () => {
     const oldSettings = {
       [ArgConfigType.LLM_MODEL]: "gpt-4-0125-preview",
       [ArgConfigType.AGENT]: "MonologueAgent",
@@ -49,22 +49,7 @@ describe("getUpdatedSettings", () => {
     expect(result).toEqual({});
   });
 
-  it("should keep old values in mergedSettings if isInit is true and old value is not empty", () => {
-    const oldSettings = {
-      [ArgConfigType.LLM_MODEL]: "gpt-4-0125-preview",
-      [ArgConfigType.AGENT]: "MonologueAgent",
-    };
-    const newSettings = {
-      [ArgConfigType.AGENT]: "MonologueAgent",
-    };
-    const isInit = true;
-
-    const result = getUpdatedSettings(newSettings, oldSettings);
-
-    expect(result).toEqual({});
-  });
-
-  it("should update mergedSettings, updatedSettings and set needToSend to true for relevant changes", () => {
+  it("should update all settings", () => {
     const oldSettings = {
       [ArgConfigType.LLM_MODEL]: "gpt-4-0125-preview",
       [ArgConfigType.AGENT]: "MonologueAgent",

--- a/frontend/src/services/settingsService.test.ts
+++ b/frontend/src/services/settingsService.test.ts
@@ -7,7 +7,6 @@ jest.mock("./socket", () => ({
 }));
 
 describe("mergeAndUpdateSettings", () => {
-
   it("should return initial settings if newSettings is empty", () => {
     const oldSettings = { key1: "value1" };
 

--- a/frontend/src/services/settingsService.test.ts
+++ b/frontend/src/services/settingsService.test.ts
@@ -1,7 +1,6 @@
 import { getUpdatedSettings } from "./settingsService";
 import { ArgConfigType } from "../types/ConfigType";
 
-
 describe("mergeAndUpdateSettings", () => {
   it("should return initial settings if newSettings is empty", () => {
     const oldSettings = { key1: "value1" };

--- a/frontend/src/services/settingsService.test.ts
+++ b/frontend/src/services/settingsService.test.ts
@@ -9,7 +9,6 @@ jest.mock("./socket", () => ({
 describe("getUpdatedSettings", () => {
   it("should return initial settings if newSettings is empty", () => {
     const oldSettings = { key1: "value1" };
-    const isInit = false;
 
     const result = getUpdatedSettings({}, oldSettings);
 
@@ -19,7 +18,6 @@ describe("getUpdatedSettings", () => {
   it("should add new keys to mergedSettings and updatedSettings", () => {
     const oldSettings = { key1: "value1" };
     const newSettings = { key2: "value2" };
-    const isInit = false;
 
     const result = getUpdatedSettings(newSettings, oldSettings);
 
@@ -31,7 +29,6 @@ describe("getUpdatedSettings", () => {
   it("should overwrite non-DISPLAY_MAP keys in mergedSettings", () => {
     const oldSettings = { key1: "value1" };
     const newSettings = { key1: "newvalue1" };
-    const isInit = false;
 
     const result = getUpdatedSettings(newSettings, oldSettings);
 
@@ -46,7 +43,6 @@ describe("getUpdatedSettings", () => {
     const newSettings = {
       [ArgConfigType.AGENT]: "MonologueAgent",
     };
-    const isInit = false;
 
     const result = getUpdatedSettings(newSettings, oldSettings);
 
@@ -80,7 +76,6 @@ describe("getUpdatedSettings", () => {
       key1: "newvalue1",
       key2: "value2",
     };
-    const isInit = false;
 
     const result = getUpdatedSettings(newSettings, oldSettings);
 

--- a/frontend/src/services/settingsService.test.ts
+++ b/frontend/src/services/settingsService.test.ts
@@ -1,4 +1,4 @@
-import { mergeAndUpdateSettings } from "./settingsService";
+import { getUpdatedSettings } from "./settingsService";
 import { ArgConfigType } from "../types/ConfigType";
 
 // We need to mock this to avoid `SyntaxError` from using `Socket` in `settingsService` during testing
@@ -6,15 +6,14 @@ jest.mock("./socket", () => ({
   send: jest.fn(),
 }));
 
-describe("mergeAndUpdateSettings", () => {
+describe("getUpdatedSettings", () => {
   it("should return initial settings if newSettings is empty", () => {
     const oldSettings = { key1: "value1" };
     const isInit = false;
 
-    const result = mergeAndUpdateSettings({}, oldSettings, isInit);
+    const result = getUpdatedSettings({}, oldSettings);
 
-    expect(result.mergedSettings).toEqual(oldSettings);
-    expect(result.updatedSettings).toEqual({});
+    expect(result).toEqual({});
   });
 
   it("should add new keys to mergedSettings and updatedSettings", () => {
@@ -22,13 +21,9 @@ describe("mergeAndUpdateSettings", () => {
     const newSettings = { key2: "value2" };
     const isInit = false;
 
-    const result = mergeAndUpdateSettings(newSettings, oldSettings, isInit);
+    const result = getUpdatedSettings(newSettings, oldSettings);
 
-    expect(result.mergedSettings).toEqual({
-      key1: "value1",
-      key2: "value2",
-    });
-    expect(result.updatedSettings).toEqual({
+    expect(result).toEqual({
       key2: "value2", // New key
     });
   });
@@ -38,10 +33,9 @@ describe("mergeAndUpdateSettings", () => {
     const newSettings = { key1: "newvalue1" };
     const isInit = false;
 
-    const result = mergeAndUpdateSettings(newSettings, oldSettings, isInit);
+    const result = getUpdatedSettings(newSettings, oldSettings);
 
-    expect(result.mergedSettings).toEqual({ key1: "newvalue1" });
-    expect(result.updatedSettings).toEqual({});
+    expect(result).toEqual({});
   });
 
   it("should keep old values in mergedSettings if they are equal", () => {
@@ -54,10 +48,9 @@ describe("mergeAndUpdateSettings", () => {
     };
     const isInit = false;
 
-    const result = mergeAndUpdateSettings(newSettings, oldSettings, isInit);
+    const result = getUpdatedSettings(newSettings, oldSettings);
 
-    expect(result.mergedSettings).toEqual(oldSettings);
-    expect(result.updatedSettings).toEqual({});
+    expect(result).toEqual({});
   });
 
   it("should keep old values in mergedSettings if isInit is true and old value is not empty", () => {
@@ -70,10 +63,9 @@ describe("mergeAndUpdateSettings", () => {
     };
     const isInit = true;
 
-    const result = mergeAndUpdateSettings(newSettings, oldSettings, isInit);
+    const result = getUpdatedSettings(newSettings, oldSettings);
 
-    expect(result.mergedSettings).toEqual(oldSettings);
-    expect(result.updatedSettings).toEqual({});
+    expect(result).toEqual({});
   });
 
   it("should update mergedSettings, updatedSettings and set needToSend to true for relevant changes", () => {
@@ -90,20 +82,12 @@ describe("mergeAndUpdateSettings", () => {
     };
     const isInit = false;
 
-    const result = mergeAndUpdateSettings(newSettings, oldSettings, isInit);
+    const result = getUpdatedSettings(newSettings, oldSettings);
 
-    expect(result.mergedSettings).toEqual({
-      [ArgConfigType.LLM_MODEL]: "gpt-4-0125-preview",
-      [ArgConfigType.AGENT]: "CodeActAgent", // Updated value
-      [ArgConfigType.LANGUAGE]: "es", // New key added
-      key1: "newvalue1", // Updated value
-      key2: "value2", // New key added
-    });
-    expect(result.updatedSettings).toEqual({
+    expect(result).toEqual({
       [ArgConfigType.AGENT]: "CodeActAgent",
       [ArgConfigType.LANGUAGE]: "es",
       key2: "value2",
     });
-    expect(result.needToSend).toBe(true);
   });
 });

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -13,7 +13,7 @@ export async function fetchModels() {
 }
 
 export async function fetchAgents() {
-  const response = await fetch(`/api/litellm-agents`);
+  const response = await fetch(`/api/agents`);
   return response.json();
 }
 

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -6,7 +6,7 @@ import Socket from "./socket";
 import { setByKey } from "../state/settingsSlice";
 import toast from "../utils/toast";
 
-type Settings = { [key: string]: string };
+export type Settings = { [key: string]: string };
 
 export async function fetchModels() {
   const response = await fetch(`/api/litellm-models`);

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -33,12 +33,12 @@ const DEFAULT_SETTINGS = new Map<string, string>([
 const getSettingOrDefault = (key: string) => {
   const value = localStorage.getItem(key);
   return value || DEFAULT_SETTINGS.get(key);
-}
+};
 
 export const getCurrentSettings = () => ({
-    LLM_MODEL: getSettingOrDefault("LLM_MODEL"),
-    AGENT: getSettingOrDefault("AGENT"),
-    LANGUAGE: getSettingOrDefault("LANGUAGE"),
+  LLM_MODEL: getSettingOrDefault("LLM_MODEL"),
+  AGENT: getSettingOrDefault("AGENT"),
+  LANGUAGE: getSettingOrDefault("LANGUAGE"),
 });
 
 // Function to merge and update settings

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -1,6 +1,7 @@
 import { setInitialized } from "../state/taskSlice";
 import store from "../store";
 import ActionType from "../types/ActionType";
+import { SupportedSettings } from "../types/ConfigType";
 import Socket from "./socket";
 import { setAllSettings, setByKey } from "../state/settingsSlice";
 import { ArgConfigType } from "../types/ConfigType";
@@ -21,67 +22,40 @@ export async function fetchAgents() {
 const DISPLAY_MAP = new Map<string, string>([
   [ArgConfigType.LLM_MODEL, "model"],
   [ArgConfigType.AGENT, "agent"],
-  [ArgConfigType.WORKSPACE_DIR, "directory"],
   [ArgConfigType.LANGUAGE, "language"],
 ]);
 
-type SettingsUpdateInfo = {
-  mergedSettings: Record<string, string>;
-  updatedSettings: Record<string, string>;
-  needToSend: boolean;
-};
+const DEFAULT_SETTINGS = new Map<string, string>([
+  [ArgConfigType.LLM_MODEL, "gpt-3.5-turbo"],
+  [ArgConfigType.AGENT, "MonologueAgent"],
+  [ArgConfigType.LANGUAGE, "en"],
+]);
 
-export const getSettingsForInitialize = () => ({
-    LLM_MODEL: localStorage.getItem("LLM_MODEL") || undefined,
-    AGENT: localStorage.getItem("AGENT") || undefined,
+export const getCurrentSettings = () => ({
+    LLM_MODEL: localStorage.getItem("LLM_MODEL") || DEFAULT_SETTINGS.get(ArgConfigType.LLM_MODEL),
+    AGENT: localStorage.getItem("AGENT") || DEFAULT_SETTINGS.get(ArgConfigType.AGENT),
+    LANGUAGE: localStorage.getItem("LANGUAGE") || DEFAULT_SETTINGS.get(ArgConfigType.LANGUAGE),
 });
 
 // Function to merge and update settings
-export const mergeAndUpdateSettings = (
-  newSettings: Record<string, string>,
-  oldSettings: Record<string, string>,
-  isInit: boolean,
-) =>
-  Object.keys(newSettings).reduce(
-    (acc, key) => {
-      const newValue = String(newSettings[key]);
-      const oldValue = oldSettings[key];
-
-      // key doesn't exist in frontend settings will be overwritten by backend settings
-      if (oldValue === undefined) {
-        acc.mergedSettings[key] = newValue;
-        acc.updatedSettings[key] = newValue;
-        return acc;
-      }
-
-      if (!DISPLAY_MAP.has(key)) {
-        acc.mergedSettings[key] = newValue;
-        return acc;
-      }
-
-      if (oldValue === newValue || (isInit && oldValue !== "")) {
-        acc.mergedSettings[key] = oldValue;
-        return acc;
-      }
-
-      acc.mergedSettings[key] = newValue;
-      acc.updatedSettings[key] = newValue;
-      acc.needToSend = true;
-
-      return acc;
-    },
-    {
-      mergedSettings: { ...oldSettings },
-      updatedSettings: {},
-      needToSend: false,
-    } as SettingsUpdateInfo,
-  );
+export const getUpdatedSettings = (
+  newSettings: map<string, string>,
+) => {
+  const currentSettings = getCurrentSettings();
+  const updatedSettings = {};
+  SupportedSettings.forEach((setting) => {
+    if (newSettings[setting] !== currentSettings[setting]) {
+      updatedSettings[setting] = newSettings[setting];
+    }
+  });
+  return updatedSettings;
+};
 
 const dispatchSettings = (updatedSettings: Record<string, string>) => {
   let i = 0;
   for (const [key, value] of Object.entries(updatedSettings)) {
+    store.dispatch(setByKey({ key, value }));
     if (DISPLAY_MAP.has(key)) {
-      store.dispatch(setByKey({ key, value }));
       setTimeout(() => {
         toast.settingsChanged(`Set ${DISPLAY_MAP.get(key)} to "${value}"`);
       }, i * 500);
@@ -90,36 +64,23 @@ const dispatchSettings = (updatedSettings: Record<string, string>) => {
   }
 };
 
-const sendSettings = (
-  mergedSettings: Record<string, string>,
-  needToSend: boolean,
-  isInit: boolean,
-) => {
-  const settingsCopy = { ...mergedSettings };
-  delete settingsCopy.ALL_SETTINGS;
-
-  if (needToSend || isInit) {
-    const event = { action: ActionType.INIT, args: settingsCopy };
-    const eventString = JSON.stringify(event);
-    store.dispatch(setInitialized(false));
-    Socket.send(eventString);
-  }
+const initializeAgent = () => {
+  const event = { action: ActionType.INIT, args: getCurrentSettings() };
+  const eventString = JSON.stringify(event);
+  store.dispatch(setInitialized(false));
+  Socket.send(eventString);
 };
 
 // Save and send settings to the server
 export function saveSettings(
   newSettings: { [key: string]: string },
-  oldSettings: { [key: string]: string },
-  isInit: boolean = false,
 ): void {
-  const { mergedSettings, updatedSettings, needToSend } =
-    mergeAndUpdateSettings(newSettings, oldSettings, isInit);
+  const updatedSettings = getUpdatedSettings(newSettings);
 
-  dispatchSettings(updatedSettings);
-
-  if (isInit) {
-    store.dispatch(setAllSettings(JSON.stringify(newSettings)));
+  if (Object.keys(updatedSettings).length === 0) {
+    return;
   }
 
-  sendSettings(mergedSettings, needToSend, isInit);
+  dispatchSettings(updatedSettings);
+  initializeAgent();
 }

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -3,7 +3,6 @@ import store from "../store";
 import ActionType from "../types/ActionType";
 import Socket from "./socket";
 import { setAllSettings, setByKey } from "../state/settingsSlice";
-import { ResConfigurations } from "../types/ResponseType";
 import { ArgConfigType } from "../types/ConfigType";
 import toast from "../utils/toast";
 
@@ -32,12 +31,10 @@ type SettingsUpdateInfo = {
   needToSend: boolean;
 };
 
-export const getSettingsForInitialize = () => {
-  return {
+export const getSettingsForInitialize = () => ({
     LLM_MODEL: localStorage.getItem("LLM_MODEL") || undefined,
     AGENT: localStorage.getItem("AGENT") || undefined,
-  }
-}
+});
 
 // Function to merge and update settings
 export const mergeAndUpdateSettings = (

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -18,33 +18,32 @@ export async function fetchAgents() {
 
 // all available settings in the frontend
 // TODO: add the values to i18n to support multi languages
-const DISPLAY_MAP = new Map<string, string>([
-  [ArgConfigType.LLM_MODEL, "model"],
-  [ArgConfigType.AGENT, "agent"],
-  [ArgConfigType.LANGUAGE, "language"],
-]);
-
-const DEFAULT_SETTINGS = new Map<string, string>([
-  [ArgConfigType.LLM_MODEL, "gpt-3.5-turbo"],
-  [ArgConfigType.AGENT, "MonologueAgent"],
-  [ArgConfigType.LANGUAGE, "en"],
-]);
-
-const getSettingOrDefault = (key: string) => {
-  const value = localStorage.getItem(key);
-  return value || DEFAULT_SETTINGS.get(key);
+const DISPLAY_MAP: { [key: string]: string; } = {
+  LLM_MODEL: "model",
+  AGENT: "agent",
+  LANGUAGE: "language",
 };
 
-export const getCurrentSettings = () => ({
+const DEFAULT_SETTINGS: { [key: string]: any; } = {
+  LLM_MODEL: "gpt-3.5-turbo",
+  AGENT: "MonologueAgent",
+  LANGUAGE: "en",
+};
+
+const getSettingOrDefault = (key: string): any => {
+  const value = localStorage.getItem(key);
+  return value || DEFAULT_SETTINGS[key];
+};
+
+export const getCurrentSettings = (): { [key: string]: any; } => ({
   LLM_MODEL: getSettingOrDefault("LLM_MODEL"),
   AGENT: getSettingOrDefault("AGENT"),
   LANGUAGE: getSettingOrDefault("LANGUAGE"),
 });
 
 // Function to merge and update settings
-export const getUpdatedSettings = (newSettings: Map<string, string>) => {
-  const currentSettings = getCurrentSettings();
-  const updatedSettings: Map<string, string> = {};
+export const getUpdatedSettings = (newSettings: { [key: string]: any; }, currentSettings: { [key: string]: any; }) => {
+  const updatedSettings: { [key: string]: any; } = {};
   SupportedSettings.forEach((setting) => {
     if (newSettings[setting] !== currentSettings[setting]) {
       updatedSettings[setting] = newSettings[setting];
@@ -57,9 +56,9 @@ const dispatchSettings = (updatedSettings: Record<string, string>) => {
   let i = 0;
   for (const [key, value] of Object.entries(updatedSettings)) {
     store.dispatch(setByKey({ key, value }));
-    if (DISPLAY_MAP.has(key)) {
+    if (key in DISPLAY_MAP) {
       setTimeout(() => {
-        toast.settingsChanged(`Set ${DISPLAY_MAP.get(key)} to "${value}"`);
+        toast.settingsChanged(`Set ${DISPLAY_MAP[key]} to "${value}"`);
       }, i * 500);
       i += 1;
     }
@@ -74,8 +73,9 @@ export const initializeAgent = () => {
 };
 
 // Save and send settings to the server
-export function saveSettings(newSettings: { [key: string]: string }): void {
-  const updatedSettings = getUpdatedSettings(newSettings);
+export function saveSettings(newSettings: { [key: string]: any }): void {
+  const currentSettings = getCurrentSettings();
+  const updatedSettings = getUpdatedSettings(newSettings, currentSettings);
 
   if (Object.keys(updatedSettings).length === 0) {
     return;

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -1,10 +1,9 @@
 import { setInitialized } from "../state/taskSlice";
 import store from "../store";
 import ActionType from "../types/ActionType";
-import { SupportedSettings } from "../types/ConfigType";
+import { SupportedSettings, ArgConfigType } from "../types/ConfigType";
 import Socket from "./socket";
-import { setAllSettings, setByKey } from "../state/settingsSlice";
-import { ArgConfigType } from "../types/ConfigType";
+import { setByKey } from "../state/settingsSlice";
 import toast from "../utils/toast";
 
 export async function fetchModels() {
@@ -31,16 +30,19 @@ const DEFAULT_SETTINGS = new Map<string, string>([
   [ArgConfigType.LANGUAGE, "en"],
 ]);
 
+const getSettingOrDefault = (key: string) => {
+  const value = localStorage.getItem(key);
+  return value || DEFAULT_SETTINGS.get(key);
+}
+
 export const getCurrentSettings = () => ({
-    LLM_MODEL: localStorage.getItem("LLM_MODEL") || DEFAULT_SETTINGS.get(ArgConfigType.LLM_MODEL),
-    AGENT: localStorage.getItem("AGENT") || DEFAULT_SETTINGS.get(ArgConfigType.AGENT),
-    LANGUAGE: localStorage.getItem("LANGUAGE") || DEFAULT_SETTINGS.get(ArgConfigType.LANGUAGE),
+    LLM_MODEL: getSettingOrDefault("LLM_MODEL"),
+    AGENT: getSettingOrDefault("AGENT"),
+    LANGUAGE: getSettingOrDefault("LANGUAGE"),
 });
 
 // Function to merge and update settings
-export const getUpdatedSettings = (
-  newSettings: map<string, string>,
-) => {
+export const getUpdatedSettings = (newSettings: map<string, string>) => {
   const currentSettings = getCurrentSettings();
   const updatedSettings = {};
   SupportedSettings.forEach((setting) => {
@@ -72,9 +74,7 @@ const initializeAgent = () => {
 };
 
 // Save and send settings to the server
-export function saveSettings(
-  newSettings: { [key: string]: string },
-): void {
+export function saveSettings(newSettings: { [key: string]: string }): void {
   const updatedSettings = getUpdatedSettings(newSettings);
 
   if (Object.keys(updatedSettings).length === 0) {

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -66,7 +66,7 @@ const dispatchSettings = (updatedSettings: Record<string, string>) => {
   }
 };
 
-const initializeAgent = () => {
+export const initializeAgent = () => {
   const event = { action: ActionType.INIT, args: getCurrentSettings() };
   const eventString = JSON.stringify(event);
   store.dispatch(setInitialized(false));

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -1,7 +1,7 @@
 import { setInitialized } from "../state/taskSlice";
 import store from "../store";
 import ActionType from "../types/ActionType";
-import { SupportedSettings, ArgConfigType } from "../types/ConfigType";
+import { SupportedSettings } from "../types/ConfigType";
 import Socket from "./socket";
 import { setByKey } from "../state/settingsSlice";
 import toast from "../utils/toast";
@@ -18,13 +18,13 @@ export async function fetchAgents() {
 
 // all available settings in the frontend
 // TODO: add the values to i18n to support multi languages
-const DISPLAY_MAP: { [key: string]: string; } = {
+const DISPLAY_MAP: { [key: string]: string } = {
   LLM_MODEL: "model",
   AGENT: "agent",
   LANGUAGE: "language",
 };
 
-const DEFAULT_SETTINGS: { [key: string]: any; } = {
+const DEFAULT_SETTINGS: { [key: string]: any } = {
   LLM_MODEL: "gpt-3.5-turbo",
   AGENT: "MonologueAgent",
   LANGUAGE: "en",
@@ -42,7 +42,7 @@ export const getCurrentSettings = (): { [key: string]: any; } => ({
 });
 
 // Function to merge and update settings
-export const getUpdatedSettings = (newSettings: { [key: string]: any; }, currentSettings: { [key: string]: any; }) => {
+export const getUpdatedSettings = (newSettings: { [key: string]: any }, currentSettings: { [key: string]: any; }) => {
   const updatedSettings: { [key: string]: any; } = {};
   SupportedSettings.forEach((setting) => {
     if (newSettings[setting] !== currentSettings[setting]) {

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -7,18 +7,6 @@ import { ResConfigurations } from "../types/ResponseType";
 import { ArgConfigType } from "../types/ConfigType";
 import toast from "../utils/toast";
 
-export async function fetchConfigurations(): Promise<ResConfigurations> {
-  const headers = new Headers({
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${localStorage.getItem("token")}`,
-  });
-  const response = await fetch(`/api/configurations`, { headers });
-  if (response.status !== 200) {
-    throw new Error("Get configurations failed.");
-  }
-  return (await response.json()) as ResConfigurations;
-}
-
 export async function fetchModels() {
   const response = await fetch(`/api/litellm-models`);
   return response.json();
@@ -28,20 +16,6 @@ export async function fetchAgents() {
   const response = await fetch(`/api/litellm-agents`);
   return response.json();
 }
-
-export const INITIAL_MODELS = [
-  "gpt-3.5-turbo-1106",
-  "gpt-4-0125-preview",
-  "claude-3-haiku-20240307",
-  "claude-3-opus-20240229",
-  "claude-3-sonnet-20240229",
-];
-
-export type Model = (typeof INITIAL_MODELS)[number];
-
-export const INITIAL_AGENTS = ["MonologueAgent", "CodeActAgent"];
-
-export type Agent = (typeof INITIAL_AGENTS)[number];
 
 // all available settings in the frontend
 // TODO: add the values to i18n to support multi languages
@@ -57,6 +31,13 @@ type SettingsUpdateInfo = {
   updatedSettings: Record<string, string>;
   needToSend: boolean;
 };
+
+export const getSettingsForInitialize = () => {
+  return {
+    LLM_MODEL: localStorage.getItem("LLM_MODEL") || undefined,
+    AGENT: localStorage.getItem("AGENT") || undefined,
+  }
+}
 
 // Function to merge and update settings
 export const mergeAndUpdateSettings = (

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -42,9 +42,9 @@ export const getCurrentSettings = () => ({
 });
 
 // Function to merge and update settings
-export const getUpdatedSettings = (newSettings: map<string, string>) => {
+export const getUpdatedSettings = (newSettings: Map<string, string>) => {
   const currentSettings = getCurrentSettings();
-  const updatedSettings = {};
+  const updatedSettings: Map<string, string> = {};
   SupportedSettings.forEach((setting) => {
     if (newSettings[setting] !== currentSettings[setting]) {
       updatedSettings[setting] = newSettings[setting];

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -6,6 +6,8 @@ import Socket from "./socket";
 import { setByKey } from "../state/settingsSlice";
 import toast from "../utils/toast";
 
+type Settings = { [key: string]: string };
+
 export async function fetchModels() {
   const response = await fetch(`/api/litellm-models`);
   return response.json();
@@ -24,26 +26,29 @@ const DISPLAY_MAP: { [key: string]: string } = {
   LANGUAGE: "language",
 };
 
-const DEFAULT_SETTINGS: { [key: string]: any } = {
+const DEFAULT_SETTINGS: Settings = {
   LLM_MODEL: "gpt-3.5-turbo",
   AGENT: "MonologueAgent",
   LANGUAGE: "en",
 };
 
-const getSettingOrDefault = (key: string): any => {
+const getSettingOrDefault = (key: string): string => {
   const value = localStorage.getItem(key);
   return value || DEFAULT_SETTINGS[key];
 };
 
-export const getCurrentSettings = (): { [key: string]: any; } => ({
+export const getCurrentSettings = (): Settings => ({
   LLM_MODEL: getSettingOrDefault("LLM_MODEL"),
   AGENT: getSettingOrDefault("AGENT"),
   LANGUAGE: getSettingOrDefault("LANGUAGE"),
 });
 
 // Function to merge and update settings
-export const getUpdatedSettings = (newSettings: { [key: string]: any }, currentSettings: { [key: string]: any; }) => {
-  const updatedSettings: { [key: string]: any; } = {};
+export const getUpdatedSettings = (
+  newSettings: Settings,
+  currentSettings: Settings,
+) => {
+  const updatedSettings: Settings = {};
   SupportedSettings.forEach((setting) => {
     if (newSettings[setting] !== currentSettings[setting]) {
       updatedSettings[setting] = newSettings[setting];
@@ -73,7 +78,7 @@ export const initializeAgent = () => {
 };
 
 // Save and send settings to the server
-export function saveSettings(newSettings: { [key: string]: any }): void {
+export function saveSettings(newSettings: Settings): void {
   const currentSettings = getCurrentSettings();
   const updatedSettings = getUpdatedSettings(newSettings, currentSettings);
 

--- a/frontend/src/services/socket.ts
+++ b/frontend/src/services/socket.ts
@@ -19,8 +19,6 @@ class Socket {
     close: [],
   };
 
-  // prevent it failed in the first run, all related listen events never be called
-  private static isFirstRun = true;
   private static initializing = false;
 
   public static tryInitialize(): void {
@@ -33,11 +31,9 @@ class Socket {
         const msg = `Connection failed. Retry...`;
         toast.stickyError("ws", msg);
 
-        if (this.isFirstRun) {
-          setTimeout(() => {
-            this.tryInitialize();
-          }, 1500);
-        }
+        setTimeout(() => {
+          this.tryInitialize();
+        }, 1500);
       });
   }
 
@@ -70,8 +66,6 @@ class Socket {
         Socket.tryInitialize();
       }, 3000); // Reconnect after 3 seconds
     };
-
-    this.isFirstRun = false;
   }
 
   static isConnected(): boolean {

--- a/frontend/src/services/socket.ts
+++ b/frontend/src/services/socket.ts
@@ -24,11 +24,9 @@ class Socket {
   private static initializing = false;
 
   public static tryInitialize(): void {
-    console.log('try init');
     this.initializing = true;
     getToken()
       .then((token) => {
-        console.log('got tok');
         Socket._initialize(token);
         this.initializing = false;
       })
@@ -39,7 +37,7 @@ class Socket {
         if (this.isFirstRun) {
           setTimeout(() => {
             this.tryInitialize();
-          }, 3000);
+          }, 1500);
         }
       });
   }

--- a/frontend/src/services/socket.ts
+++ b/frontend/src/services/socket.ts
@@ -21,11 +21,16 @@ class Socket {
 
   // prevent it failed in the first run, all related listen events never be called
   private static isFirstRun = true;
+  private static initializing = false;
 
   public static tryInitialize(): void {
+    console.log('try init');
+    this.initializing = true;
     getToken()
       .then((token) => {
+        console.log('got tok');
         Socket._initialize(token);
+        this.initializing = false;
       })
       .catch(() => {
         const msg = `Connection failed. Retry...`;
@@ -78,6 +83,10 @@ class Socket {
   }
 
   static send(message: string): void {
+    if (Socket.initializing) {
+      setTimeout(() => Socket.send(message), 1000);
+      return;
+    }
     if (!Socket.isConnected()) Socket.tryInitialize();
 
     if (Socket.isConnected()) {

--- a/frontend/src/services/socket.ts
+++ b/frontend/src/services/socket.ts
@@ -22,6 +22,7 @@ class Socket {
   private static initializing = false;
 
   public static tryInitialize(): void {
+    if (Socket.initializing) return;
     Socket.initializing = true;
     getToken()
       .then((token) => {
@@ -75,12 +76,12 @@ class Socket {
   }
 
   static send(message: string): void {
+    if (!Socket.isConnected()) {
+      Socket.tryInitialize();
+    }
     if (Socket.initializing) {
       setTimeout(() => Socket.send(message), 1000);
       return;
-    }
-    if (!Socket.isConnected()) {
-      Socket.tryInitialize();
     }
 
     if (Socket.isConnected()) {

--- a/frontend/src/services/socket.ts
+++ b/frontend/src/services/socket.ts
@@ -24,11 +24,10 @@ class Socket {
   private static initializing = false;
 
   public static tryInitialize(): void {
-    this.initializing = true;
+    Socket.initializing = true;
     getToken()
       .then((token) => {
         Socket._initialize(token);
-        this.initializing = false;
       })
       .catch(() => {
         const msg = `Connection failed. Retry...`;
@@ -50,6 +49,7 @@ class Socket {
 
     Socket._socket.onopen = (e) => {
       toast.stickySuccess("ws", "Connected to server.");
+      Socket.initializing = false;
       Socket.callbacks.open?.forEach((callback) => {
         callback(e);
       });
@@ -85,7 +85,9 @@ class Socket {
       setTimeout(() => Socket.send(message), 1000);
       return;
     }
-    if (!Socket.isConnected()) Socket.tryInitialize();
+    if (!Socket.isConnected()) {
+      Socket.tryInitialize();
+    }
 
     if (Socket.isConnected()) {
       Socket._socket?.send(message);

--- a/frontend/src/types/ConfigType.tsx
+++ b/frontend/src/types/ConfigType.tsx
@@ -1,35 +1,13 @@
 enum ArgConfigType {
-  LLM_API_KEY = "LLM_API_KEY",
-  LLM_BASE_URL = "LLM_BASE_URL",
-  WORKSPACE_DIR = "WORKSPACE_DIR",
   LLM_MODEL = "LLM_MODEL",
-  SANDBOX_CONTAINER_IMAGE = "SANDBOX_CONTAINER_IMAGE",
-  RUN_AS_DEVIN = "RUN_AS_DEVIN",
-  LLM_EMBEDDING_MODEL = "LLM_EMBEDDING_MODEL",
-  LLM_NUM_RETRIES = "LLM_NUM_RETRIES",
-  LLM_COOLDOWN_TIME = "LLM_COOLDOWN_TIME",
-  DIRECTORY_REWRITE = "DIRECTORY_REWRITE",
-  MAX_ITERATIONS = "MAX_ITERATIONS",
-  MAX_CHARS = "MAX_CHARS",
   AGENT = "AGENT",
-
   LANGUAGE = "LANGUAGE",
 }
 
-const SupportedList: string[] = [
-  // ArgConfigType.LLM_API_KEY,
-  // ArgConfigType.LLM_BASE_URL,
-  // ArgConfigType.WORKSPACE_DIR,
+const SupportedSettings: string[] = [
   ArgConfigType.LLM_MODEL,
-  // ArgConfigType.SANDBOX_CONTAINER_IMAGE,
-  // ArgConfigType.RUN_AS_DEVIN,
-  // ArgConfigType.LLM_EMBEDDING_MODEL,
-  // ArgConfigType.LLM_NUM_RETRIES,
-  // ArgConfigType.LLM_COOLDOWN_TIME,
-  // ArgConfigType.DIRECTORY_REWRITE,
-  // ArgConfigType.MAX_ITERATIONS,
   ArgConfigType.AGENT,
   ArgConfigType.LANGUAGE,
 ];
 
-export { ArgConfigType, SupportedList };
+export { ArgConfigType, SupportedSettings };

--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -1,4 +1,3 @@
-import copy
 import os
 
 import argparse
@@ -85,12 +84,3 @@ def get(key: str, required: bool = False):
     if not value and required:
         raise KeyError(f"Please set '{key}' in `config.toml` or `.env`.")
     return value
-
-
-def get_fe_config() -> dict:
-    """
-    Get all the frontend configuration values by performing a deep copy.
-    """
-    fe_config = copy.deepcopy(config)
-    del fe_config['LLM_API_KEY']
-    return fe_config

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -22,6 +22,7 @@ class LLM:
                  num_retries=DEFAULT_LLM_NUM_RETRIES,
                  cooldown_time=DEFAULT_LLM_COOLDOWN_TIME,
                  ):
+        opendevin_logger.info(f'Initializing LLM with model: {model}')
         self.model_name = model if model else DEFAULT_MODEL_NAME
         self.api_key = api_key if api_key else DEFAULT_API_KEY
         self.base_url = base_url if base_url else DEFAULT_BASE_URL
@@ -33,7 +34,8 @@ class LLM:
 
         def my_wait(retry_state):
             seconds = (retry_state.attempt_number) * cooldown_time
-            opendevin_logger.info(f'Attempt #{retry_state.attempt_number} | Sleeping for {seconds}s for {retry_state.outcome.exception()}', )
+            opendevin_logger.warning(f'LLM error: {retry_state.outcome.exception()}')
+            opendevin_logger.info(f'Attempt #{retry_state.attempt_number} | Sleeping for {seconds}s')
             return seconds
 
         @retry(reraise=True,

--- a/opendevin/mock/listen.py
+++ b/opendevin/mock/listen.py
@@ -43,7 +43,7 @@ def read_llm_models():
     ]
 
 
-@app.get('/litellm-agents')
+@app.get('/agents')
 def read_llm_agents():
     return [
         'MonologueAgent',

--- a/opendevin/server/agent/agent.py
+++ b/opendevin/server/agent/agent.py
@@ -63,10 +63,6 @@ class AgentUnit:
 
         match action:
             case ActionType.INIT:
-                if self.controller is not None:
-                    # Agent already started, no need to create a new one
-                    await self.init_done()
-                    return
                 await self.create_controller(data)
             case ActionType.START:
                 await self.start_task(data)

--- a/opendevin/server/agent/manager.py
+++ b/opendevin/server/agent/manager.py
@@ -27,6 +27,7 @@ class AgentManager:
         """Dispatches actions to the agent from the client."""
         if sid not in self.sid_to_agent:
             # self.register_agent(sid)  # auto-register agent, may be opened later
+            logger.error(f'Agent not registered: {sid}')
             await session_manager.send_error(sid, 'Agent not registered')
             return
 

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -53,12 +53,13 @@ async def get_litellm_models():
     return list(set(litellm.model_list + list(litellm.model_cost.keys())))
 
 
-@app.get('/api/litellm-agents')
-async def get_litellm_agents():
+@app.get('/api/agents')
+async def get_agents():
     """
     Get all agents supported by LiteLLM.
     """
-    return Agent.list_agents()
+    agents = Agent.list_agents()
+    return agents
 
 
 @app.get('/api/auth')

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -36,7 +36,7 @@ async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     sid = get_sid_from_token(websocket.query_params.get('token') or '')
     if sid == '':
-        logger.error(f'Failed to decode token: {websocket.query_params.get('token')}')
+        logger.error('Failed to decode token')
         return
     session_manager.add_session(sid, websocket)
     # TODO: actually the agent_manager is created for each websocket connection, even if the session id is the same,

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -114,11 +114,6 @@ async def del_messages(
     )
 
 
-@app.get('/api/configurations')
-def read_default_model():
-    return config.get_fe_config()
-
-
 @app.get('/api/refresh-files')
 def refresh_files():
     structure = files.get_folder_structure(Path(str(config.get('WORKSPACE_BASE'))))

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -36,6 +36,7 @@ async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     sid = get_sid_from_token(websocket.query_params.get('token') or '')
     if sid == '':
+        logger.error(f'Failed to decode token: {websocket.query_params.get('token')}')
         return
     session_manager.add_session(sid, websocket)
     # TODO: actually the agent_manager is created for each websocket connection, even if the session id is the same,


### PR DESCRIPTION
Fixes https://github.com/OpenDevin/OpenDevin/issues/1167

This ended up being a much bigger change than I hoped. Fortunately most of it is deleted code.

* One really important change is that we always recreate the agent controller when we get an `initialize` event. This gives the frontend the ability to change settings during the same session
* There's a lot of cleanup on frontend localStorage mgmt. We were saving things there that don't really need to be saved (e.g. supportedModels).
* We were also downloading a configuration from the server, and setting that as the initial configuration, which isn't a great pattern--the server was overriding choices the user made in the FE.
* There was a bug where the session wasn't starting properly for brand new sessions, and you needed to refresh the page (you can see this by running `localStorage.clear()`

There's probably room to fix up some of my frontend work. Definitely open to feedback here