### PR TITLE
feat(frontend): syntax highlighting switches to whichever language matches the selected file

### DIFF
--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -61,7 +61,11 @@ function CodeEditor(): JSX.Element {
         <div className="flex grow">
           <Editor
             height="100%"
-            defaultLanguage="python"
+            path={
+              selectedFileName === ""
+                ? "welcome.txt"
+                : selectedFileName.toLocaleLowerCase()
+            }
             defaultValue="# Welcome to OpenDevin!"
             value={code}
             onMount={handleEditorDidMount}


### PR DESCRIPTION
Syntax highlighting changes based on the extension of the selected file. Uses Monaco editor's path URI field.

(It appears I am unable to add label but "frontend" would be appropriate) 