### PR TITLE
fix: reset context between tasks

### DIFF
--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -233,3 +233,7 @@ class MonologueAgent(Agent):
         - List[str]: A list of top 10 text results that matched the query
         """
         return self.memory.search(query)
+
+    def reset(self) -> None:
+        super().reset()
+        self.monologue = Monologue()

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -79,6 +79,7 @@ class AgentController:
                 break
         if not finished:
             logger.info('Exited before finishing the task.')
+        self.agent.reset()
 
     async def step(self, i: int):
         logger.info(f'STEP {i}', extra={'msg_type': 'STEP'})


### PR DESCRIPTION
Closes #399.

Suggesting to use the `reset()` method of the agent to solve this.
I chose not to reset the long term memory, with the thought it could be interesting for subsequent tasks. We may want to change this in the future.