### PR TITLE
Property 'message' sent to llm

### DIFF
--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -188,7 +188,7 @@ class MonologueAgent(Agent):
                     output_type = ActionType.BROWSE
                 else:
                     action = AgentThinkAction(thought=thought)
-                self._add_event(action.to_dict())
+                self._add_event(action.to_memory())
         self._initialized = True
 
     def step(self, state: State) -> Action:
@@ -203,7 +203,7 @@ class MonologueAgent(Agent):
         """
         self._initialize(state.plan.main_goal)
         for prev_action, obs in state.updated_info:
-            self._add_event(prev_action.to_dict())
+            self._add_event(prev_action.to_memory())
             self._add_event(obs.to_dict())
 
         state.updated_info = []

--- a/agenthub/planner_agent/prompt.py
+++ b/agenthub/planner_agent/prompt.py
@@ -149,7 +149,7 @@ def get_prompt(plan: Plan, history: List[Tuple[Action, Observation]]) -> str:
     latest_action: Action = NullAction()
     for action, observation in sub_history:
         if not isinstance(action, NullAction):
-            history_dicts.append(action.to_dict())
+            history_dicts.append(action.to_memory())
             latest_action = action
         if not isinstance(observation, NullObservation):
             observation_dict = observation.to_dict()

--- a/opendevin/action/base.py
+++ b/opendevin/action/base.py
@@ -20,6 +20,11 @@ class Action:
             raise NotImplementedError(f'{self=} does not have action attribute set')
         return {'action': v, 'args': d, 'message': self.message}
 
+    def to_memory(self):
+        d = self.to_dict()
+        d.pop('message', None)
+        return d
+
     @property
     def executable(self) -> bool:
         raise NotImplementedError

--- a/opendevin/action/base.py
+++ b/opendevin/action/base.py
@@ -12,17 +12,17 @@ class Action:
     async def run(self, controller: 'AgentController') -> 'Observation':
         raise NotImplementedError
 
-    def to_dict(self):
+    def to_memory(self):
         d = asdict(self)
         try:
             v = d.pop('action')
         except KeyError:
             raise NotImplementedError(f'{self=} does not have action attribute set')
-        return {'action': v, 'args': d, 'message': self.message}
+        return {'action': v, 'args': d}
 
-    def to_memory(self):
-        d = self.to_dict()
-        d.pop('message', None)
+    def to_dict(self):
+        d = self.to_memory()
+        d['message'] = self.message
         return d
 
     @property

--- a/tests/test_action_serialization.py
+++ b/tests/test_action_serialization.py
@@ -21,8 +21,10 @@ def serialization_deserialization(original_action_dict, cls):
     assert isinstance(
         action_instance, cls), f'The action instance should be an instance of {cls.__name__}.'
     serialized_action_dict = action_instance.to_dict()
+    serialized_action_memory = action_instance.to_memory()
     serialized_action_dict.pop('message')
     assert serialized_action_dict == original_action_dict, 'The serialized action should match the original action dict.'
+    assert serialized_action_memory == original_action_dict, 'The serialized action in memory should match the original action dict.'
 
 
 def test_agent_think_action_serialization_deserialization():


### PR DESCRIPTION
When we compute embeddings, we're sending duplicate text to get embeddings for. The text of the document looks like this:
`{"action": "think", "args": {"thought": "But I should only use the finish action when I'm absolutely certain that I've completed my task and have tested my work."}, "message": "But I should only use the finish action when I'm absolutely certain that I've completed my task and have tested my work."}`

During a task:
`'{"action": "think", "args": {"thought": "Upon reviewing the script, I suspect there might be an issue either with how the array indices or the element access is done in the bash script. Bash arrays can be finicky and may not support multidimensional arrays directly like other programming languages. I should modify the script to use a different method for representing the board."}, "message": "Upon reviewing the script, I suspect there might be an issue either with how the array indices or the element access is done in the bash script. Bash arrays can be finicky and may not support multidimensional arrays directly like other programming languages. I should modify the script to use a different method for representing the board."}'`

This was unexpected, and this PR proposes to remove the 'message' property from the text we send.

I also include the removal of 'message' from the prompt to completion, although I might be incorrect. I'm not sure how useful it is there. It might depend on the action. GPT-4 didn't seem to care. If it is useful though, couldn't it be in a field? I didn't look closely at observations on this, they're not included.

Please note that it can get large fast, affecting context limits, local processing of embeddings; I don't know, examples that llms see as good format?