### PR TITLE
fix ghcr workflow throw error when in the fork repo.

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -32,4 +32,6 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push ${{ matrix.image }}
-        run: ./containers/build.sh ${{ matrix.image }} --push
+        run: |
+          ORG_NAME=$(echo "${{ github.repository }}" | tr '[A-Z]' '[a-z]' | cut -d '/' -f 1)
+          ./containers/build.sh ${{ matrix.image }} $ORG_NAME --push

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -2,6 +2,7 @@
 set -eo pipefail
 
 image_name=$1
+org_name=$2
 push=0
 if [[ $2 == "--push" ]]; then
   push=1
@@ -31,6 +32,10 @@ if [ ! -f $dir/config.sh ]; then
   exit 1
 fi
 source $dir/config.sh
+if [[ -n "$org_name" ]]; then
+  DOCKER_REPOSITORY="${DOCKER_REPOSITORY/\/*\//\/$org_name\/}"
+  echo "Using org name: $org_name"
+fi
 echo "Repo: $DOCKER_REPOSITORY"
 echo "Base dir: $DOCKER_BASE_DIR"
 #docker pull $DOCKER_REPOSITORY:main || true # try to get any cached layers


### PR DESCRIPTION
if we aren't compatible, it will send too many workflow errors to email when push in fork repo.

![image](https://github.com/OpenDevin/OpenDevin/assets/16201837/3550bc06-4dff-4217-a6f1-4984b5d793f1)


![image](https://github.com/OpenDevin/OpenDevin/assets/16201837/20147498-3f82-4b34-aa40-cfac9b2be7b9)

![image](https://github.com/OpenDevin/OpenDevin/assets/16201837/c41960bb-239c-4e63-8258-f894e2a3746d)

