### PR TITLE
refactor: remove the previously implemented shallow file fetch

### DIFF
--- a/frontend/src/services/fileService.ts
+++ b/frontend/src/services/fileService.ts
@@ -17,21 +17,3 @@ export async function getWorkspace(): Promise<WorkspaceFile> {
   const data = await res.json();
   return data as WorkspaceFile;
 }
-
-export type WorkspaceItem = {
-  name: string;
-  isBranch: boolean;
-  relativePath: string;
-  id: string;
-  parent: string | null;
-  children: string[];
-};
-
-export async function getWorkspaceDepthOne(
-  relpath: string,
-): Promise<WorkspaceItem[]> {
-  const res = await fetch(`/api/list-files?relpath=${relpath}`);
-  const json = await res.json();
-  const files = json.files as WorkspaceItem[];
-  return files;
-}

--- a/opendevin/files.py
+++ b/opendevin/files.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Any, Dict, List
-from pydantic import BaseModel
 
 
 class WorkspaceFile:
@@ -41,29 +40,3 @@ def get_folder_structure(workdir: Path) -> WorkspaceFile:
         else:
             root.children.append(WorkspaceFile(name=item.name, children=[]))
     return root
-
-
-class WorkspaceItem(BaseModel):
-    name: str
-    isBranch: bool
-    relativePath: str
-    id: str
-    parent: str | None
-    children: List['WorkspaceItem'] = []
-
-
-def get_single_level_folder_structure(base_path: Path, workdir: Path) -> List[WorkspaceItem]:
-    """Generate a list of files and directories at the current level with type indicator, relative paths, and tree metadata."""
-    entries = []
-    for item in workdir.iterdir():
-        item_relative_path = item.relative_to(base_path).as_posix()
-        # Using the relative path as an 'id' ensuring uniqueness within the workspace context
-        parent_path = workdir.relative_to(base_path).as_posix() if workdir != base_path else 'root'
-        entries.append(WorkspaceItem(
-            name=item.name,
-            isBranch=item.is_dir(),
-            relativePath=item_relative_path,
-            id=item_relative_path,
-            parent=parent_path
-        ))
-    return entries

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -3,7 +3,7 @@ import uuid
 from pathlib import Path
 
 import litellm
-from fastapi import Depends, FastAPI, HTTPException, Query, Response, WebSocket, status
+from fastapi import Depends, FastAPI, Response, WebSocket, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -117,30 +117,6 @@ async def del_messages(
 def refresh_files():
     structure = files.get_folder_structure(Path(str(config.get('WORKSPACE_BASE'))))
     return structure.to_dict()
-
-
-@app.get('/api/list-files')
-def list_files(
-    relpath: str = Query(None, description='Relative path from workspace base')
-):
-    """Refreshes and returns the files and directories from a specified subdirectory or the base directory if no subdirectory is specified, limited to one level deep."""
-    base_path = Path(config.get('WORKSPACE_BASE')).resolve()
-    full_path = (base_path / relpath).resolve() if relpath is not None else base_path
-
-    logger.debug(f'Listing files at {full_path}')
-
-    # Ensure path exists, is a directory,
-    # And is within the workspace base directory - to prevent directory traversal attacks
-    # https://owasp.org/www-community/attacks/Path_Traversal
-    if (
-        not full_path.exists()
-        or not full_path.is_dir()
-        or not str(full_path).startswith(str(base_path))
-    ):
-        raise HTTPException(status_code=400, detail='Invalid path provided.')
-
-    structure = files.get_single_level_folder_structure(base_path, full_path)
-    return {'files': structure}
 
 
 @app.get('/api/select-file')


### PR DESCRIPTION
Removing because the new filetree implementation is fast enough as is and fetching partial trees adds a lot of complexity that we probably don't need. For example, if we still want to automatically open the tree location of a changed file, we need to make sure all the parent folders are fetched first.