### PR TITLE
less debug info when errors happen

### DIFF
--- a/opendevin/controller/action_manager.py
+++ b/opendevin/controller/action_manager.py
@@ -48,7 +48,7 @@ class ActionManager:
         except Exception as e:
             observation = AgentErrorObservation(str(e))
             logger.error(e)
-            traceback.print_exc()
+            logger.debug(traceback.format_exc())
         return observation
 
     def run_command(self, command: str, background=False) -> CmdOutputObservation:

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -169,9 +169,9 @@ class AgentController:
         observation: Observation = NullObservation('')
         try:
             action = self.agent.step(self.state)
+            logger.info(action, extra={'msg_type': 'ACTION'})
             if action is None:
                 raise AgentNoActionError()
-            logger.info(action, extra={'msg_type': 'ACTION'})
         except Exception as e:
             observation = AgentErrorObservation(str(e))
             logger.error(e)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import traceback
 from typing import Callable, List
 
 from litellm.exceptions import APIConnectionError
@@ -175,6 +176,7 @@ class AgentController:
         except Exception as e:
             observation = AgentErrorObservation(str(e))
             logger.error(e)
+            logger.debug(traceback.format_exc())
 
             if isinstance(e, APIConnectionError):
                 time.sleep(3)

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -46,7 +46,10 @@ class LLM:
                 messages = kwargs['messages']
             else:
                 messages = args[1]
-            llm_prompt_logger.debug(messages)
+            debug_message = ''
+            for message in messages:
+                debug_message += '\n\n----------\n\n' + message['content']
+            llm_prompt_logger.debug(debug_message)
             resp = completion_unwrapped(*args, **kwargs)
             message_back = resp['choices'][0]['message']['content']
             llm_response_logger.debug(message_back)

--- a/opendevin/main.py
+++ b/opendevin/main.py
@@ -27,12 +27,6 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description='Run an agent with a specific task')
     parser.add_argument(
-        '-d',
-        '--directory',
-        type=str,
-        help='The working directory for the agent',
-    )
-    parser.add_argument(
         '-t', '--task', type=str, default='', help='The task for the agent to perform'
     )
     parser.add_argument(
@@ -89,7 +83,7 @@ async def main():
             'No task provided. Please specify a task through -t, -f.')
 
     print(
-        f'Running agent {args.agent_cls} (model: {args.model_name}, directory: {args.directory}) with task: "{task}"'
+        f'Running agent {args.agent_cls} (model: {args.model_name}) with task: "{task}"'
     )
     llm = LLM(args.model_name)
     AgentCls: Type[Agent] = Agent.get_cls(args.agent_cls)


### PR DESCRIPTION
The agent often encounters errors, and we're showing a traceback every time. This hides it unless debug logs are on