### PR TITLE
Update README.md:--add-host host.docker.internal=host-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ docker run \
     -v $WORKSPACE_DIR:/opt/workspace_base \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -p 3000:3000 \
+    --add-host host.docker.internal=host-gateway \
     ghcr.io/opendevin/opendevin:0.3.1
 ```
 You'll find opendevin running at `http://localhost:3000`.


### PR DESCRIPTION
fixes #1156 on Ubuntu 22.04, please test on WSL?