### PR TITLE
DogFood: instruct agent to read from diff file

### DIFF
--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -34,23 +34,22 @@ jobs:
 
     - name: Write Task File
       run: |
-        echo "Your coworker wants to apply a pull request to this project. Read and review it, and write your concise comments and suggestions to review-${{ github.event.pull_request.number }}.txt" > task.txt
-        echo "TITLE:" >> task.txt
+        echo "Your coworker wants to apply a pull request to this project. Read and review ${{ github.event.pull_request.number }}.diff file. Create a review-${{ github.event.pull_request.number }}.txt and write your concise comments and suggestions there." > task.txt
+        echo "" >> task.txt
+        echo "Title" >> task.txt
         echo "${{ github.event.pull_request.title }}" >> task.txt
         echo "" >> task.txt
-        echo "BODY:" >> task.txt
+        echo "Description" >> task.txt
         echo "${{ github.event.pull_request.body }}" >> task.txt
         echo "" >> task.txt
-        echo "The diff is:" >> task.txt
-        cat ${{ github.event.pull_request.number }}.diff >> task.txt
-        rm ${{ github.event.pull_request.number }}.diff
+        echo "Diff file is: ${{ github.event.pull_request.number }}.diff" >> task.txt
 
     - name: Run OpenDevin
       env:
         LLM_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         SANDBOX_TYPE: exec
       run: |
-        python ./opendevin/main.py -i 50 -f task.txt -d ./
+        WORKSPACE_MOUNT_PATH=$GITHUB_WORKSPACE python ./opendevin/main.py -i 50 -f task.txt -d $GITHUB_WORKSPACE
         rm task.txt
 
     - name: Check if review file is non-empty

--- a/.github/workflows/solve-issue.yml
+++ b/.github/workflows/solve-issue.yml
@@ -43,7 +43,7 @@ jobs:
         LLM_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         SANDBOX_TYPE: exec
       run: |
-        python ./opendevin/main.py -i 50 -f task.txt -d $GITHUB_WORKSPACE
+        WORKSPACE_MOUNT_PATH=$GITHUB_WORKSPACE python ./opendevin/main.py -i 50 -f task.txt -d $GITHUB_WORKSPACE
         rm task.txt
 
     - name: Setup Git, Create Branch, and Commit Changes


### PR DESCRIPTION
This PR aims to improve the OpenDevin-powered reviewer bot. Previously, we include the PR diff in the task (prompt), and now we instruct the agent to read from the diff file. This brings the following benefits:

1) The log is now much more concise. Previously, every step would print out the task info, which includes the whole diff that could be large.
2) Interestingly, it seems the agent is better at understanding the content if it's in the diff file, not in the task itself. In my previous PR https://github.com/OpenDevin/OpenDevin/pull/1223, I mentioned that OpenDevin couldn't manage to review https://github.com/li-boxuan/OpenDevin/pull/4, likely because the diff itself contained a lot of prompts and confused the agent. With this new change, OpenDevin is able to provide a [review](https://github.com/li-boxuan/OpenDevin/pull/4#pullrequestreview-2013329608) of mediocre quality.
3) There's a potential to let the agent apply the diff to the project and test the changes.

In an [example](https://github.com/li-boxuan/OpenDevin/actions/runs/8770612940/job/24067374371?pr=4) run, OpenDevin decides to:
1) FileReadAction(path='4.diff', start=0, end=-1, thoughts='', action=<ActionType.READ: 'read'>)
2) FileWriteAction(path='review-4.txt', content='The changes in the 4.diff file appear to improve the readability and maintainability of the get_prompt function. The addition of the get_hint function seems to help in organizing and clarifying the code. Overall, the changes look good and seem to align with the goals of the project.', start=0, end=-1, thoughts='', action=<ActionType.WRITE: 'write'>)
3) AgentFinishAction(action=<ActionType.FINISH: 'finish'>)

I attempted this approach in the previous PR too but failed because the agent was having a hard time understanding the current working directory. Specifically, whenever the agent attempts to do `ls`, it always returns nothing. This PR fixes this problem by setting `WORKSPACE_MOUNT_PATH` environment variable.