### PR TITLE
Message property sent to llm

### DIFF
--- a/agenthub/SWE_agent/agent.py
+++ b/agenthub/SWE_agent/agent.py
@@ -38,7 +38,7 @@ class SWEAgent(Agent):
 
     def _remember(self, action: Action, observation: Observation) -> None:
         """Agent has a limited memory of the few steps implemented as a queue"""
-        memory = MEMORY_FORMAT(action.to_dict(), observation.to_dict())
+        memory = MEMORY_FORMAT(action.to_memory(), observation.to_memory())
         self.running_memory.append(memory)
 
     def _think_act(self, messages: List[dict]) -> tuple[Action, str]:

--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -161,7 +161,7 @@ class MonologueAgent(Agent):
                     observation = BrowserOutputObservation(
                         content=thought, url='', screenshot=''
                     )
-                self._add_event(observation.to_dict())
+                self._add_event(observation.to_memory())
                 output_type = ''
             else:
                 action: Action = NullAction()
@@ -204,7 +204,7 @@ class MonologueAgent(Agent):
         self._initialize(state.plan.main_goal)
         for prev_action, obs in state.updated_info:
             self._add_event(prev_action.to_memory())
-            self._add_event(obs.to_dict())
+            self._add_event(obs.to_memory())
 
         state.updated_info = []
 

--- a/agenthub/planner_agent/prompt.py
+++ b/agenthub/planner_agent/prompt.py
@@ -152,7 +152,7 @@ def get_prompt(plan: Plan, history: List[Tuple[Action, Observation]]) -> str:
             history_dicts.append(action.to_memory())
             latest_action = action
         if not isinstance(observation, NullObservation):
-            observation_dict = observation.to_dict()
+            observation_dict = observation.to_memory()
             if (
                 'extras' in observation_dict
                 and 'screenshot' in observation_dict['extras']

--- a/opendevin/observation/base.py
+++ b/opendevin/observation/base.py
@@ -15,6 +15,12 @@ class Observation:
         return self.content
 
     def to_dict(self) -> dict:
+        """Converts the observation to a dictionary and adds user message."""
+        memory_dict = self.to_memory()
+        memory_dict['message'] = self.message
+        return memory_dict
+
+    def to_memory(self) -> dict:
         """Converts the observation to a dictionary."""
         extras = copy.deepcopy(self.__dict__)
         content = extras.pop('content', '')
@@ -23,7 +29,6 @@ class Observation:
             'observation': observation,
             'content': content,
             'extras': extras,
-            'message': self.message,
         }
 
     @property

--- a/tests/test_observation_serialization.py
+++ b/tests/test_observation_serialization.py
@@ -1,5 +1,5 @@
-import pytest
 from opendevin.observation import observation_from_dict, Observation, CmdOutputObservation
+
 
 def test_observation_serialization_deserialization():
     original_observation_dict = {
@@ -12,6 +12,9 @@ def test_observation_serialization_deserialization():
     assert isinstance(observation_instance, Observation), 'The observation instance should be an instance of Action.'
     assert isinstance(observation_instance, CmdOutputObservation), 'The observation instance should be an instance of AgentThinkAction.'
     serialized_observation_dict = observation_instance.to_dict()
+    serialized_observation_memory = observation_instance.to_memory()
     assert serialized_observation_dict == original_observation_dict, 'The serialized observation should match the original observation dict.'
+    original_observation_dict.pop('message')
+    assert serialized_observation_memory == original_observation_dict, 'The serialized observation in memory should match the original observation dict.'
 
 # Additional tests for various observation subclasses can be included here


### PR DESCRIPTION
Following up on the 'message' property that was sent in actions: it is sent in observations as well. This PR proposes to remove it.
Also: send the dict of the action/observation attributes to SWE agent and planner.

I find more difficult than with actions to tell if sending 'message' in observation might be useful to the llm. The same considerations as before seem to apply though, particularly:
- 'message' was afaik intended for communication with the user, and with this PR, that's how it's used
- 'message' contains the same information stored in the Observation attributes, such as exit code
- if it is supposed to be useful, perhaps we can send the useful info in attributes?

Examples of text in embeddings:
`['type: observation id: ObservationType.RUN idx: 18  {"observation": "run", "content": "hello world", "extras": {"command_id": 0, "command": "", "exit_code": 0}, "message": "Command `` executed with exit code 0."}']`

Recall observation from step 3, contains 3 occurrences of 'message', including 2 identical ones saying 'The agent recalled memories'.

`{"observation": "recall", "content": "Recalling memories...", "extras": {"memories": ["{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"I should start by researching the four queens problem and understanding the rules and constraints before I attempt to solve it with a bash script.\\"}}", "{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"OK so my task is to write a bash script that solves the four queens problem. I haven\'t made any progress yet. Where should I start?\\"}}", "{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"Here\'s what I want to do: write a bash script that solves the four queens problem\\"}}", "{\\"observation\\": \\"recall\\", \\"content\\": \\"Here\'s what I want to do: write a bash script that solves the four queens problem\\", \\"extras\\": {\\"memories\\": [], \\"role\\": \\"assistant\\"}, \\"message\\": \\"The agent recalled memories.\\"}", "{\\"observation\\": \\"run\\", \\"content\\": \\"ThreeQueens.java          five_queens_solver.sh  nine_queens_solver.sh            hi_script.sh\\", \\"extras\\": {\\"command_id\\": -1, \\"command\\": \\"ls\\", \\"exit_code\\": 0}, \\"message\\": \\"Command `ls` executed with exit code 0.\\"}", "{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"It seems like there might be an existing project here. I should probably start by running `ls` to see what\'s here.\\"}}", "{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"I\'ll need a strategy. And as I make progress, I\'ll need to keep refining that strategy. I\'ll need to set goals, and break them into sub-goals.\\"}}", "{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"But I should only use the finish action when I\'m absolutely certain that I\'ve completed my task and have tested my work.\\"}}", "{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"In between actions, I must always take some time to think, strategize, and set new goals. I should never take two actions in a row.\\"}}", "{\\"action\\": \\"think\\", \\"args\\": {\\"thought\\": \\"And once I have completed my task, I can use the finish action to stop working.\\"}}"], "role": "assistant"}, "message": "The agent recalled memories."}`

There are other details that seem a little odd, like "role": "assistant"... Isn't this supposed to be a different parameter than the text? There's also in the first example an 'idx: 18' which I didn't expect, this text was in the openai module, shortly before being sent to /api/embeddings so I didn't think it knows about indexes and nodes, but I'll check.