### PR TITLE
Add checks to stop infinite loops

### DIFF
--- a/opendevin/action/fileop.py
+++ b/opendevin/action/fileop.py
@@ -81,7 +81,7 @@ class FileWriteAction(ExecutableAction):
 
     def _insert_lines(self, to_insert: list[str], original: list[str]):
         """
-        Insert the new conent to the original content based on self.start and self.end
+        Insert the new content to the original content based on self.start and self.end
         """
         new_lines = [''] if self.start == 0 else original[:self.start]
         new_lines += [i + '\n' for i in to_insert]

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -18,9 +18,9 @@ from opendevin.observation import AgentErrorObservation, NullObservation, Observ
 from opendevin.plan import Plan
 from opendevin.state import State
 
-from ..action.tasks import TaskStateChangedAction
-from ..schema import TaskState
-from .action_manager import ActionManager
+from opendevin.action.tasks import TaskStateChangedAction
+from opendevin.schema import TaskState
+from opendevin.controller.action_manager import ActionManager
 
 MAX_ITERATIONS = config.get('MAX_ITERATIONS')
 MAX_CHARS = config.get('MAX_CHARS')
@@ -110,6 +110,11 @@ class AgentController:
                 logger.info('Task paused')
                 self._cur_step = i + 1
                 await self.notify_task_state_changed()
+                break
+
+            if self._is_stuck():
+                logger.info('Loop detected, stopping task')
+                await self.set_task_state_to(TaskState.STOPPED)
                 break
 
     async def start(self, task: str):
@@ -221,3 +226,30 @@ class AgentController:
 
     def get_state(self):
         return self.state
+
+    def _is_stuck(self):
+        if self.state is None or self.state.history is None or len(self.state.history) < 3:
+            return False
+
+        # if the last three (Action, Observation) tuples are too repetitive
+        # the agent got stuck in a loop
+        if (all(isinstance(self.state.history[-i][0], NullAction) for i in range(1, 4))) and all(
+            [self.state.history[-i][1] == self.state.history[-3][1] for i in range(1, 3)]
+        ):
+            # same (NullAction, Observation): the same error coming from an exception
+            logger.debug('NullAction, Observation loop detected')
+            return True
+        elif all(
+            [self.state.history[-i][0] == self.state.history[-3][0] for i in range(1, 3)]
+        ):
+            # it repeats same action, give it a chance, but not if:
+            if (all(isinstance(self.state.history[-i][1], NullObservation) for i in range(1, 4))):
+                # same (Action, NullObservation): like 'think' the same thought over and over
+                logger.debug('Action, NullObservation loop detected')
+                return True
+            elif (all(isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))):
+                # (Action, AgentErrorObservation): the same action getting an error, even if not necessarily the same error
+                logger.debug('Action, AgentErrorObservation loop detected')
+                return True
+
+        return False

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -114,6 +114,8 @@ class AgentController:
 
             if self._is_stuck():
                 logger.info('Loop detected, stopping task')
+                observation = AgentErrorObservation('I got stuck into a loop, the task has stopped.')
+                await self._run_callbacks(observation)
                 await self.set_task_state_to(TaskState.STOPPED)
                 break
 

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -235,21 +235,24 @@ class AgentController:
 
         # if the last three (Action, Observation) tuples are too repetitive
         # the agent got stuck in a loop
-        if (all(isinstance(self.state.history[-i][0], NullAction) for i in range(1, 4))) and all(
-            [self.state.history[-i][1] == self.state.history[-3][1] for i in range(1, 3)]
+        if (
+            all(isinstance(self.state.history[-i][0], NullAction) for i in range(1, 4))
+            and all(isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))
+            and all([self.state.history[-i][1] == self.state.history[-3][1] for i in range(1, 3)])
         ):
-            # same (NullAction, Observation): the same error coming from an exception
+            # same (NullAction, error Observation): the same error coming from an exception
             logger.debug('NullAction, Observation loop detected')
             return True
         elif all(
-            [self.state.history[-i][0] == self.state.history[-3][0] for i in range(1, 3)]
-        ):
+                [self.state.history[-i][0] == self.state.history[-3][0] for i in range(1, 3)]):
             # it repeats same action, give it a chance, but not if:
-            if (all(isinstance(self.state.history[-i][1], NullObservation) for i in range(1, 4))):
+            if (
+                    all(isinstance(self.state.history[-i][1], NullObservation) for i in range(1, 4))):
                 # same (Action, NullObservation): like 'think' the same thought over and over
                 logger.debug('Action, NullObservation loop detected')
                 return True
-            elif (all(isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))):
+            elif (
+                    all(isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))):
                 # (Action, AgentErrorObservation): the same action getting an error, even if not necessarily the same error
                 logger.debug('Action, AgentErrorObservation loop detected')
                 return True

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -246,7 +246,7 @@ class AgentController:
                 return True
             elif (all
                   (isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))):
-                # (NullAction, AgentErrorObservation): the same error coming from an exception
+                # (NullAction, AgentErrorObservation): errors coming from an exception
                 # (Action, AgentErrorObservation): the same action getting an error, even if not necessarily the same error
                 logger.debug('Action, AgentErrorObservation loop detected')
                 return True

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -235,24 +235,18 @@ class AgentController:
 
         # if the last three (Action, Observation) tuples are too repetitive
         # the agent got stuck in a loop
-        if (
-            all(isinstance(self.state.history[-i][0], NullAction) for i in range(1, 4))
-            and all(isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))
-            and all([self.state.history[-i][1] == self.state.history[-3][1] for i in range(1, 3)])
+        if all(
+            [self.state.history[-i][0] == self.state.history[-3][0] for i in range(1, 3)]
         ):
-            # same (NullAction, error Observation): the same error coming from an exception
-            logger.debug('NullAction, Observation loop detected')
-            return True
-        elif all(
-                [self.state.history[-i][0] == self.state.history[-3][0] for i in range(1, 3)]):
             # it repeats same action, give it a chance, but not if:
-            if (
-                    all(isinstance(self.state.history[-i][1], NullObservation) for i in range(1, 4))):
+            if (all
+                    (isinstance(self.state.history[-i][1], NullObservation) for i in range(1, 4))):
                 # same (Action, NullObservation): like 'think' the same thought over and over
                 logger.debug('Action, NullObservation loop detected')
                 return True
-            elif (
-                    all(isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))):
+            elif (all
+                  (isinstance(self.state.history[-i][1], AgentErrorObservation) for i in range(1, 4))):
+                # (NullAction, AgentErrorObservation): the same error coming from an exception
                 # (Action, AgentErrorObservation): the same action getting an error, even if not necessarily the same error
                 logger.debug('Action, AgentErrorObservation loop detected')
                 return True


### PR DESCRIPTION
Fixes #326 

Added checks for some common cases of infinite loops. If any of these are repeated three times, call it stuck and stop the task.
- (NullAction, same Observation)
- (same Action, NullObservation)
- (same Action, AgentErrorObservation)
 
The first two are too common. Not too sure about the third, but I didn't add (same Action, any Observation) because it seemed it might catch too much 🤔 

Notes:
- tested with console alone atm.
- it's easy to get the 2nd with GPT-3.5, and in that case it doesn't actually mean infinite. Sure, it won't solve the task if it's having such trouble, but it could still change next step. Maybe make it 5 times instead of 3?