### PR TITLE
Bug with sshd

### DIFF
--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -18,5 +18,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
     && rm -rf /var/lib/apt/lists/*
 
+RUN service ssh start
+
 # symlink python3 to python
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
     sudo \
     && rm -rf /var/lib/apt/lists/*
 
-RUN service ssh start
+RUN mkdir -p -m0755 /var/run/sshd
 
 # symlink python3 to python
 RUN ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
Got an error when trying to run the sandbox today:
ssh_box.py:325 - b'Missing privilege separation directory: /run/sshd\r\n'

There is a bug with the sandbox, and rebuilding it with the ssh service start line, for no apparent reason, worked. (forcing sshd to make that directory, presumably)

Needs confirmation, it's a weird one, and I also did other things when my system didn't want to start opendevin. 

https://askubuntu.com/questions/1110828/ssh-failed-to-start-missing-privilege-separation-directory-var-run-sshd

https://askubuntu.com/questions/1109934/ssh-server-stops-working-after-reboot-caused-by-missing-var-run-sshd/1110843#1110843

May fix #1294 