### PR TITLE
Disable additional Docker metadata to more compatible with OCI spec.

### DIFF
--- a/containers/build.sh
+++ b/containers/build.sh
@@ -50,4 +50,5 @@ fi
 docker buildx build \
   $args \
   --platform linux/amd64,linux/arm64 \
+  --provenance=false \
   -f $dir/Dockerfile $DOCKER_BASE_DIR


### PR DESCRIPTION
this PR will resolve the unknown os/arch in ghcr.io

![image](https://github.com/OpenDevin/OpenDevin/assets/16201837/acb7b97b-b4ec-43e3-ac58-1d1025f0136a)

to

![image](https://github.com/OpenDevin/OpenDevin/assets/16201837/4f6c565b-62f4-49ac-93a4-019c599b6123)
