### PR TITLE
fix: conftest.py comment bug.

### DIFF
--- a/evaluation/regression/conftest.py
+++ b/evaluation/regression/conftest.py
@@ -68,7 +68,7 @@ def model(request):
 
     Returns:
         The model name, defaulting to "gpt-3.5-turbo-1106".
-    ""
+    """
     return request.config.getoption("model", default="gpt-3.5-turbo-1106")
 
 @pytest.fixture


### PR DESCRIPTION
fix conftest.py compile bug, comment close """ wrong：
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/e95a6e27-256e-49de-a25c-6f00b2ff708a)


