### PR TITLE
fix(sandbox): SSH box `.execute` misalign issue

### DIFF
--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -205,6 +205,7 @@ class DockerSSHBox(Sandbox):
         return bg_cmd.read_logs()
 
     def execute(self, cmd: str) -> Tuple[int, str]:
+        cmd = cmd.strip()
         # use self.ssh
         self.ssh.sendline(cmd)
         success = self.ssh.prompt(timeout=self.timeout)
@@ -217,13 +218,26 @@ class DockerSSHBox(Sandbox):
             command_output = self.ssh.before.decode(
                 'utf-8').lstrip(cmd).strip()
             return -1, f'Command: "{cmd}" timed out. Sending SIGINT to the process: {command_output}'
-        command_output = self.ssh.before.decode('utf-8').lstrip(cmd).strip()
+        command_output = self.ssh.before.decode('utf-8').strip()
+
+        # NOTE: there's some weird behavior with the prompt (it may come AFTER the command output)
+        # so we need to check if the command is in the output
+        n_trires = 5
+        while not command_output.startswith(cmd) and n_trires > 0:
+            self.ssh.prompt()
+            command_output = self.ssh.before.decode('utf-8').strip()
+            time.sleep(0.5)
+            n_trires -= 1
+        if n_trires == 0 and not command_output.startswith(cmd):
+            raise Exception(
+                f'Something went wrong with the SSH sanbox, cannot get output for command [{cmd}] after 5 retries'
+            )
+        command_output = command_output.lstrip(cmd).strip()
 
         # get the exit code
         self.ssh.sendline('echo $?')
         self.ssh.prompt()
         exit_code = self.ssh.before.decode('utf-8')
-        # remove the echo $? itself
         exit_code = int(exit_code.lstrip('echo $?').strip())
         return exit_code, command_output
 

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -222,7 +222,7 @@ class DockerSSHBox(Sandbox):
 
         # NOTE: there's some weird behavior with the prompt (it may come AFTER the command output)
         # so we need to check if the command is in the output
-        n_trires = 5
+        n_tries = 5
         while not command_output.startswith(cmd) and n_trires > 0:
             self.ssh.prompt()
             command_output = self.ssh.before.decode('utf-8').strip()

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -223,12 +223,12 @@ class DockerSSHBox(Sandbox):
         # NOTE: there's some weird behavior with the prompt (it may come AFTER the command output)
         # so we need to check if the command is in the output
         n_tries = 5
-        while not command_output.startswith(cmd) and n_trires > 0:
+        while not command_output.startswith(cmd) and n_tries > 0:
             self.ssh.prompt()
             command_output = self.ssh.before.decode('utf-8').strip()
             time.sleep(0.5)
-            n_trires -= 1
-        if n_trires == 0 and not command_output.startswith(cmd):
+            n_tries -= 1
+        if n_tries == 0 and not command_output.startswith(cmd):
             raise Exception(
                 f'Something went wrong with the SSH sanbox, cannot get output for command [{cmd}] after 5 retries'
             )


### PR DESCRIPTION
In `DockerSSHBox,` sometimes the previous execution observation will come out in subsequent `ssh.before.decode`, which causes (1) exit code reading sometime to fail, and/or (2) output of a previous command to come out in a subsequent command. This PR tries to fix it.