### PR TITLE
Send the failed decoding back to the LLM

### DIFF
--- a/opendevin/action/__init__.py
+++ b/opendevin/action/__init__.py
@@ -40,7 +40,11 @@ def action_from_dict(action: dict) -> Action:
             f"'{action['action']=}' is not defined. Available actions: {ACTION_TYPE_TO_CLASS.keys()}"
         )
     args = action.get('args', {})
-    return action_class(**args)
+    try:
+        decoded_action = action_class(**args)
+    except TypeError:
+        raise AgentMalformedActionError(f"action={action} has the wrong arguments")
+    return decoded_action
 
 
 __all__ = [

--- a/opendevin/exceptions.py
+++ b/opendevin/exceptions.py
@@ -7,11 +7,6 @@ class MaxCharsExceedError(Exception):
         super().__init__(message)
 
 
-class AgentNoActionError(Exception):
-    def __init__(self, message='Agent must return an action'):
-        super().__init__(message)
-
-
 class AgentNoInstructionError(Exception):
     def __init__(self, message='Instruction must be provided'):
         super().__init__(message)
@@ -19,11 +14,6 @@ class AgentNoInstructionError(Exception):
 
 class AgentEventTypeError(Exception):
     def __init__(self, message='Event must be a dictionary'):
-        super().__init__(message)
-
-
-class AgentMalformedActionError(Exception):
-    def __init__(self, message='Malformed response'):
         super().__init__(message)
 
 
@@ -65,4 +55,15 @@ class PlanInvalidStateError(Exception):
             message = f'Invalid state {state}'
         else:
             message = 'Invalid state'
+        super().__init__(message)
+
+
+# These exceptions get sent back to the LLM
+class AgentMalformedActionError(Exception):
+    def __init__(self, message='Malformed response'):
+        super().__init__(message)
+
+
+class AgentNoActionError(Exception):
+    def __init__(self, message='Agent must return an action'):
         super().__init__(message)


### PR DESCRIPTION
Send the failed decoding of an action, probably missing an argument, back to the LLM