### PR TITLE
Send JSON parsing exception

### DIFF
--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -172,10 +172,14 @@ def parse_action_response(response: str) -> Action:
             return len(match[2]) if match[1] == 'think' else 130  # Crudely rank multiple responses by length
         try:
             action_dict = json.loads(max(response_json_matches, key=rank)[0])  # Use the highest ranked response
-        except ValueError as e:
+        except (ValueError, JSONDecodeError):
             raise LLMOutputError(
-                "Output from the LLM isn't properly formatted. The model may be misconfigured."
-            ) from e
+                'Invalid JSON, the response must be well-formed JSON as specified in the prompt.'
+            )
+    except ValueError:
+        raise LLMOutputError(
+            'Invalid JSON, the response must be well-formed JSON as specified in the prompt.'
+        )
     if 'content' in action_dict:
         # The LLM gets confused here. Might as well be robust
         action_dict['contents'] = action_dict.pop('content')

--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -172,11 +172,11 @@ def parse_action_response(response: str) -> Action:
             return len(match[2]) if match[1] == 'think' else 130  # Crudely rank multiple responses by length
         try:
             action_dict = json.loads(max(response_json_matches, key=rank)[0])  # Use the highest ranked response
-        except (ValueError, JSONDecodeError):
+        except Exception:
             raise LLMOutputError(
                 'Invalid JSON, the response must be well-formed JSON as specified in the prompt.'
             )
-    except ValueError:
+    except Exception:
         raise LLMOutputError(
             'Invalid JSON, the response must be well-formed JSON as specified in the prompt.'
         )

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -9,7 +9,7 @@ from opendevin.action import (
     NullAction,
 )
 from opendevin.agent import Agent
-from opendevin.exceptions import AgentMalformedActionError, AgentNoActionError, MaxCharsExceedError
+from opendevin.exceptions import AgentMalformedActionError, AgentNoActionError, MaxCharsExceedError, LLMOutputError
 from opendevin.logger import opendevin_logger as logger
 from opendevin.observation import AgentErrorObservation, NullObservation, Observation
 from opendevin.plan import Plan
@@ -168,7 +168,7 @@ class AgentController:
             action = self.agent.step(self.state)
             if action is None:
                 raise AgentNoActionError('No action was returned')
-        except (AgentMalformedActionError, AgentNoActionError) as e:
+        except (AgentMalformedActionError, AgentNoActionError, LLMOutputError) as e:
             observation = AgentErrorObservation(str(e))
         logger.info(action, extra={'msg_type': 'ACTION'})
 


### PR DESCRIPTION
We can send JSON parsing exceptions, in an error message tailored a bit for that. It can matter, because we already have exceptions raised there, which now fall outside, plus we don't catch certain errors from JSON decoding like TypeError, so some or all of these would otherwise fail badly.