### PR TITLE
refactor(frontend): fix test imports to make them pass

### DIFF
--- a/frontend/src/components/modals/settings/SettingsModal.test.tsx
+++ b/frontend/src/components/modals/settings/SettingsModal.test.tsx
@@ -1,17 +1,17 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { renderWithProviders } from "test-utils";
+import { Mock } from "vitest";
 import {
   fetchAgents,
   fetchModels,
   getCurrentSettings,
   saveSettings,
 } from "#/services/settingsService";
-import { act, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import React from "react";
-import { renderWithProviders } from "test-utils";
-import { Mock } from "vitest";
 import SettingsModal from "./SettingsModal";
 
-vi.mock("../../services/settingsService", async (importOriginal) => ({
+vi.mock("#/services/settingsService", async (importOriginal) => ({
   ...(await importOriginal<typeof import("#/services/settingsService")>()),
   getCurrentSettings: vi.fn().mockReturnValue({}),
   saveSettings: vi.fn(),


### PR DESCRIPTION
**Summary**
Tests fail because of incorrect imports defined in the mocks. These imports VSCode does not update these imports like the regular ones after renames/changes, so it is easy to miss.