### PR TITLE
fix: sweagent prompt message SYSTEM_MESSAGE role set to user bug.

### DIFF
--- a/agenthub/SWE_agent/agent.py
+++ b/agenthub/SWE_agent/agent.py
@@ -75,7 +75,7 @@ class SWEAgent(Agent):
         )
 
         msgs = [
-            {'content': SYSTEM_MESSAGE, 'role': 'user'},
+            {'content': SYSTEM_MESSAGE, 'role': 'system'},
             {'content': prompt, 'role': 'user'}
         ]
 


### PR DESCRIPTION
SYSTEM_MESSAGE role should be set to system, not user.