### PR TITLE
fix(sandbox): `mount_dir` for ssh_box

### DIFF
--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -134,6 +134,9 @@ def finalize_config():
         parts = config[ConfigType.WORKSPACE_MOUNT_REWRITE].split(':')
         config[ConfigType.WORKSPACE_MOUNT_PATH] = base.replace(parts[0], parts[1])
 
+    if config.get(ConfigType.WORKSPACE_MOUNT_PATH) is None:
+        config[ConfigType.WORKSPACE_MOUNT_PATH] = config.get(ConfigType.WORKSPACE_BASE)
+
 
 finalize_config()
 

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -373,8 +373,10 @@ class DockerSSHBox(Sandbox):
                      )
                 )
 
-            mount_dir = config.get('WORKSPACE_MOUNT_PATH')
-            print('Mounting workspace directory: ', mount_dir)
+            mount_dir = config.get(ConfigType.WORKSPACE_MOUNT_PATH)
+            if not mount_dir:
+                mount_dir = os.path.abspath(config.get(ConfigType.WORKSPACE_BASE))
+            logger.info(f'Mounting workspace directory: {mount_dir}')
             # start the container
             self.container = self.docker_client.containers.run(
                 self.container_image,

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -374,8 +374,6 @@ class DockerSSHBox(Sandbox):
                 )
 
             mount_dir = config.get(ConfigType.WORKSPACE_MOUNT_PATH)
-            if not mount_dir:
-                mount_dir = os.path.abspath(config.get(ConfigType.WORKSPACE_BASE))
             logger.info(f'Mounting workspace directory: {mount_dir}')
             # start the container
             self.container = self.docker_client.containers.run(


### PR DESCRIPTION
The default for `WORKSPACE_MOUNT_PATH` is None, which causes issues when try to map it into SSHBox.
Right now, `SSHBox` first read for `WORKSPACE_MOUNT_PATH` then `WORKSPACE_BASE`.

Based on our README.md, it seems to me that both of these variable means the same thing. Can we merge them together into one variable (i.e., we keep `WORKSPACE_MOUNT_PATH` and remove `WORKSPACE_BASE`)?

```
...
    -e WORKSPACE_MOUNT_PATH=$WORKSPACE_BASE \
    -v $WORKSPACE_BASE:/opt/workspace_base \
...
```