### PR TITLE
Default for sandbox to use the host network

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -31,7 +31,7 @@ FROM python:3.12-slim as runtime
 WORKDIR /app
 
 ENV RUN_AS_DEVIN=false
-ENV USE_HOST_NETWORK=false
+ENV USE_HOST_NETWORK=true
 ENV SSH_HOSTNAME=host.docker.internal
 ENV WORKSPACE_BASE=/opt/workspace_base
 RUN mkdir -p $WORKSPACE_BASE

--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import toml
 import pathlib
+import platform
 from dotenv import load_dotenv
 
 from opendevin.schema import ConfigType
@@ -133,6 +134,14 @@ def finalize_config():
         base = config.get(ConfigType.WORKSPACE_BASE) or os.getcwd()
         parts = config[ConfigType.WORKSPACE_MOUNT_REWRITE].split(':')
         config[ConfigType.WORKSPACE_MOUNT_PATH] = base.replace(parts[0], parts[1])
+
+    USE_HOST_NETWORK = config[ConfigType.USE_HOST_NETWORK].lower() != 'false'
+    if USE_HOST_NETWORK and platform.system() == 'Darwin':
+        logger.warning(
+            'Please upgrade to Docker Desktop 4.29.0 or later to use host network mode on macOS. '
+            'See https://github.com/docker/roadmap/issues/238#issuecomment-2044688144 for more information.'
+        )
+    config[ConfigType.USE_HOST_NETWORK] = USE_HOST_NETWORK
 
 
 finalize_config()

--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -36,7 +36,7 @@ DEFAULT_CONFIG: dict = {
     ConfigType.AGENT: 'MonologueAgent',
     ConfigType.E2B_API_KEY: '',
     ConfigType.SANDBOX_TYPE: 'ssh',  # Can be 'ssh', 'exec', or 'e2b'
-    ConfigType.USE_HOST_NETWORK: 'false',
+    ConfigType.USE_HOST_NETWORK: 'true',
     ConfigType.SSH_HOSTNAME: 'localhost',
     ConfigType.DISABLE_COLOR: 'false',
 }

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -1,6 +1,5 @@
 import atexit
 import os
-import platform
 import sys
 import time
 import uuid
@@ -31,11 +30,7 @@ CONTAINER_IMAGE = config.get(ConfigType.SANDBOX_CONTAINER_IMAGE)
 
 SSH_HOSTNAME = config.get(ConfigType.SSH_HOSTNAME)
 
-USE_HOST_NETWORK = config.get(ConfigType.USE_HOST_NETWORK).lower() != 'false'
-if USE_HOST_NETWORK and platform.system() != 'Linux':
-    logger.warning(
-        'Host network is not supported on non-Linux platforms. Using port forwarding instead.')
-    USE_HOST_NETWORK = False
+USE_HOST_NETWORK = config.get(ConfigType.USE_HOST_NETWORK)
 
 # FIXME: On some containers, the devin user doesn't have enough permission, e.g. to install packages
 # How do we make this more flexible?

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -31,10 +31,11 @@ CONTAINER_IMAGE = config.get(ConfigType.SANDBOX_CONTAINER_IMAGE)
 
 SSH_HOSTNAME = config.get(ConfigType.SSH_HOSTNAME)
 
-USE_HOST_NETWORK = platform.system() == 'Linux'
-if config.get(ConfigType.USE_HOST_NETWORK) is not None:
-    USE_HOST_NETWORK = config.get(
-        ConfigType.USE_HOST_NETWORK).lower() != 'false'
+USE_HOST_NETWORK = config.get(ConfigType.USE_HOST_NETWORK).lower() != 'false'
+if USE_HOST_NETWORK and platform.system() != 'Linux':
+    logger.warning(
+        'Host network is not supported on non-Linux platforms. Using port forwarding instead.')
+    USE_HOST_NETWORK = False
 
 # FIXME: On some containers, the devin user doesn't have enough permission, e.g. to install packages
 # How do we make this more flexible?


### PR DESCRIPTION
This PR switch back to using `--network=host` as a default.

The `--network=host` is now supported with the newest version of Docker Desktop for MacOS - this was the only reason iirc that stopped us from using it before.

> Version Docker Desktop 4.29.0
Settings ⇒ Features in development ⇒ Enable host networking
Host networking allows containers that are started with --net=host to use localhost to connect to TCP and UDP services on the host. It will automatically allow software on the host to use localhost to connect to TCP and UDP services in the container. Sign in required.

![Enable host networking](https://github.com/docker/roadmap/assets/46166740/7ed61aec-690e-47e0-8ebb-9539c1f72104)

_Originally posted by @4-FLOSS-Free-Libre-Open-Source-Software in https://github.com/docker/roadmap/issues/238#issuecomment-2044688144_
            