### PR TITLE
fix: action_from_dict shouldn't fail if there are extra values

### DIFF
--- a/opendevin/action/__init__.py
+++ b/opendevin/action/__init__.py
@@ -39,7 +39,10 @@ def action_from_dict(action: dict) -> Action:
             f"'{action['action']=}' is not defined. Available actions: {ACTION_TYPE_TO_CLASS.keys()}"
         )
     args = action.get('args', {})
-    return action_class(**args)
+    result = action_class()
+    for key, value in args.items():
+        setattr(result, key, value)
+    return result
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Just set all values without throwing an error if an llm hallucinates an extra parameter to an action