### PR TITLE
fix(backend): Prevent llm path traversal with fileop actions.

### DIFF
--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -1,0 +1,21 @@
+from opendevin import config
+from opendevin.action import fileop
+from pathlib import Path
+import pytest
+
+
+def test_resolve_path():
+    assert fileop.resolve_path('test.txt') == Path(config.get('WORKSPACE_BASE')) / 'test.txt'
+    assert fileop.resolve_path('subdir/test.txt') == Path(config.get('WORKSPACE_BASE')) / 'subdir' / 'test.txt'
+    assert fileop.resolve_path(Path(fileop.SANDBOX_PATH_PREFIX) / 'test.txt') == \
+        Path(config.get('WORKSPACE_BASE')) / 'test.txt'
+    assert fileop.resolve_path(Path(fileop.SANDBOX_PATH_PREFIX) / 'subdir' / 'test.txt') == \
+        Path(config.get('WORKSPACE_BASE')) / 'subdir' / 'test.txt'
+    assert fileop.resolve_path(Path(fileop.SANDBOX_PATH_PREFIX) / 'subdir' / '..' / 'test.txt') == \
+        Path(config.get('WORKSPACE_BASE')) / 'test.txt'
+    with pytest.raises(PermissionError):
+        fileop.resolve_path(Path(fileop.SANDBOX_PATH_PREFIX) / '..' / 'test.txt')
+    with pytest.raises(PermissionError):
+        fileop.resolve_path(Path('..') / 'test.txt')
+    with pytest.raises(PermissionError):
+        fileop.resolve_path(Path('/') / 'test.txt')


### PR DESCRIPTION
Without this the LLM is free to write or read any file accessible by the back-end process, even those outside of the workspace. This is less of a concern when the back-end is used inside of a docker container, but can be seriously damaging when run in a dev environment outside of a container.