### PR TITLE
Pin macos to 13

### DIFF
--- a/.github/workflows/build_run-tests.yml
+++ b/.github/workflows/build_run-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   on-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         python-version: ["3.11"]


### PR DESCRIPTION
macos builds are broken, seems like maybe there were recent changes to 14: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md