### PR TITLE
Temporarily remove CACHE_DIR from sandbox

### DIFF
--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -386,11 +386,6 @@ class DockerSSHBox(Sandbox):
                         'bind': SANDBOX_WORKSPACE_DIR,
                         'mode': 'rw'
                     },
-                    # mount cache directory to /home/opendevin/.cache for pip cache reuse
-                    config.get('CACHE_DIR'): {
-                        'bind': '/home/opendevin/.cache' if RUN_AS_DEVIN else '/root/.cache',
-                        'mode': 'rw'
-                    },
                 },
             )
             logger.info('Container started')


### PR DESCRIPTION
CC @xingyaoww 

I think this mount breaks the DOOD setup that we recommend in the README. I'm going to remove it for now, but let's talk about what a better solution looks like. Maybe we can mount to `/tmp` by default?