### PR TITLE
Go back to not using host network by default

### DIFF
--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -43,7 +43,7 @@ DEFAULT_CONFIG: dict = {
     ConfigType.AGENT: 'MonologueAgent',
     ConfigType.E2B_API_KEY: '',
     ConfigType.SANDBOX_TYPE: 'ssh',  # Can be 'ssh', 'exec', or 'e2b'
-    ConfigType.USE_HOST_NETWORK: 'true',
+    ConfigType.USE_HOST_NETWORK: 'false',
     ConfigType.SSH_HOSTNAME: 'localhost',
     ConfigType.DISABLE_COLOR: 'false',
 }


### PR DESCRIPTION
I'm unable to get `main` to work with host network, even on the lastest Docker Desktop `4.29.0`.

I think we need to revert this until it's out of beta.