### PR TITLE
Fix output strip behavior discrepancy among sandboxes

### DIFF
--- a/opendevin/sandbox/docker/exec_box.py
+++ b/opendevin/sandbox/docker/exec_box.py
@@ -122,7 +122,7 @@ class DockerExecBox(Sandbox):
                     self.container.exec_run(
                         f'kill -9 {pid}', workdir=SANDBOX_WORKSPACE_DIR)
                 return -1, f'Command: "{cmd}" timed out'
-        return exit_code, logs.decode('utf-8')
+        return exit_code, logs.decode('utf-8').strip()
 
     def copy_to(self, host_src: str, sandbox_dest: str, recursive: bool = False):
         # mkdir -p sandbox_dest if it doesn't exist

--- a/opendevin/sandbox/docker/local_box.py
+++ b/opendevin/sandbox/docker/local_box.py
@@ -35,7 +35,7 @@ class LocalBox(Sandbox):
                 cmd, shell=True, text=True, capture_output=True,
                 timeout=self.timeout, cwd=config.get('WORKSPACE_BASE')
             )
-            return completed_process.returncode, completed_process.stdout
+            return completed_process.returncode, completed_process.stdout.strip()
         except subprocess.TimeoutExpired:
             return -1, 'Command timed out'
 


### PR DESCRIPTION
I found this while working on #1301. #1304 includes a minor change to ssh sandbox: the command output is stripped before returning. Meanwhile, other sandboxes don't strip the output. This PR fixes this trivial behavior difference, which is not important to most people.

