### PR TITLE
Add back cache dir and default to /tmp

### DIFF
--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -25,7 +25,7 @@ DEFAULT_CONFIG: dict = {
     ConfigType.WORKSPACE_MOUNT_PATH: None,
     ConfigType.WORKSPACE_MOUNT_PATH_IN_SANDBOX: '/workspace',
     ConfigType.WORKSPACE_MOUNT_REWRITE: None,
-    ConfigType.CACHE_DIR: os.path.join(os.path.dirname(os.path.abspath(__file__)), '.cache'),
+    ConfigType.CACHE_DIR: '/tmp/cache',  # '/tmp/cache' is the default cache directory
     ConfigType.LLM_MODEL: 'gpt-3.5-turbo-1106',
     ConfigType.SANDBOX_CONTAINER_IMAGE: DEFAULT_CONTAINER_IMAGE,
     ConfigType.RUN_AS_DEVIN: 'true',
@@ -166,6 +166,6 @@ def get(key: str, required: bool = False):
     return value
 
 
-_cache_dir = config.get('CACHE_DIR')
+_cache_dir = config.get(ConfigType.CACHE_DIR)
 if _cache_dir:
     pathlib.Path(_cache_dir).mkdir(parents=True, exist_ok=True)

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -386,6 +386,11 @@ class DockerSSHBox(Sandbox):
                         'bind': SANDBOX_WORKSPACE_DIR,
                         'mode': 'rw'
                     },
+                    # mount cache directory to /home/opendevin/.cache for pip cache reuse
+                    config.get(ConfigType.CACHE_DIR): {
+                        'bind': '/home/opendevin/.cache' if RUN_AS_DEVIN else '/root/.cache',
+                        'mode': 'rw'
+                    },
                 },
             )
             logger.info('Container started')


### PR DESCRIPTION
For some reason, without cache dir, `python3 opendevin/sandbox/docker/ssh_box.py` will timeout during `~/.bashrc`.

<img width="1705" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/38853559/c9b19350-53d9-4922-83f2-56aa988befbd">
