### PR TITLE
make default WORKSPACE_MOUNT_PATH as abspath

### DIFF
--- a/opendevin/config.py
+++ b/opendevin/config.py
@@ -141,6 +141,9 @@ def finalize_config():
         parts = config[ConfigType.WORKSPACE_MOUNT_REWRITE].split(':')
         config[ConfigType.WORKSPACE_MOUNT_PATH] = base.replace(parts[0], parts[1])
 
+    if config.get(ConfigType.WORKSPACE_MOUNT_PATH) is None:
+        config[ConfigType.WORKSPACE_MOUNT_PATH] = os.path.abspath(config[ConfigType.WORKSPACE_BASE])
+
     USE_HOST_NETWORK = config[ConfigType.USE_HOST_NETWORK].lower() != 'false'
     if USE_HOST_NETWORK and platform.system() == 'Darwin':
         logger.warning(


### PR DESCRIPTION
Docker will throw errors if the default `WORKSPACE_MOUNT_PATH` is not abspath

![image](https://github.com/OpenDevin/OpenDevin/assets/38853559/2b047cf7-153f-4d32-a293-8a711d3202d2)
