### PR TITLE
precommit: remove unused `setup-cfg-fmt`

### DIFF
--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -7,13 +7,6 @@ repos:
       - id: check-yaml
       - id: debug-statements
 
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.5.0
-    hooks:
-      - id: setup-cfg-fmt
-        always_run: true
-        pass_filenames: false
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.3.7


### PR DESCRIPTION
The project does not have any `setup.cfg` (look for it with `find . -name "setup"`) so there is no need to keep this hook

cc: @rbren, @li-boxuan 