### PR TITLE
Fixed typo in integration tests README.md

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -60,7 +60,7 @@ Note: in order to run integration tests correctly, please ensure your workspace 
 
 ## Write Integration Tests
 
-To write an integraion test, there are essentially two steps:
+To write an integration test, there are essentially two steps:
 
 1. Decide your task prompt, and the result you want to verify.
 2. Either construct LLM responses by yourself, or run OpenDevin with a real LLM. The system prompts and
@@ -80,7 +80,7 @@ You can choose any model you'd like to generate the mock responses.
 You can even handcraft mock responses, especially when you would like to test the behaviour of agent for corner cases. If you use a very weak model (e.g. 8B params), chance is most agents won't be able to finish the task.
 
 ```bash
-# Remove logs iff you are okay to lose logs. This helps us locate the prompts and responses quickly, but is NOT a must.
+# Remove logs if you are okay to lose logs. This helps us locate the prompts and responses quickly, but is NOT a must.
 rm -rf logs
 # Clear the workspace, otherwise OpenDevin might not be able to reproduce your prompts in CI environment. Feel free to change the workspace name and path. Be sure to set `WORKSPACE_MOUNT_PATH` to the same absolute path.
 rm -rf workspace
@@ -99,3 +99,4 @@ That's it, you are good to go! When you launch an integration test, mock
 responses are loaded and used to replace a real LLM, so that we get
 deterministic and consistent behavior, and most importantly, without spending real
 money.
+

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -99,4 +99,3 @@ That's it, you are good to go! When you launch an integration test, mock
 responses are loaded and used to replace a real LLM, so that we get
 deterministic and consistent behavior, and most importantly, without spending real
 money.
-


### PR DESCRIPTION
This PR fixes a typo in the integration tests README.md.

The first draft was entirely authored and pushed to github by OpenDevin! :) For proof, see the video below:

Video:
https://drive.google.com/file/d/1qCJzKARAV-6JRd-9fRwyV5G9K7c3ytLP/view?usp=sharing

Fixes: https://github.com/OpenDevin/OpenDevin/issues/1433