### PR TITLE
test(fronted): update chat input tests to according to new behavior

### DIFF
--- a/frontend/src/components/ChatInput.test.tsx
+++ b/frontend/src/components/ChatInput.test.tsx
@@ -27,7 +27,16 @@ describe("ChatInput", () => {
       <ChatInput disabled onSendMessage={onSendMessage} />,
     );
     const textarea = getByRole("textbox");
-    expect(textarea).toBeDisabled();
+    const button = getByRole("button");
+
+    expect(textarea).not.toBeDisabled(); // user can still type
+    expect(button).toBeDisabled(); // user cannot submit
+
+    act(() => {
+      userEvent.type(textarea, "Hello, world!{enter}");
+    });
+
+    expect(onSendMessage).not.toHaveBeenCalled();
   });
 
   // Note that this test only checks that the placeholder is rendered, not the actual value

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "OpenDevin",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
The behavior of how `ChatInput` disables the `textarea` element changed in #1353, resulting in a failing test. This PR updates the test to pass according to this new behavior.