### PR TITLE
docs(readme): remove demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@
 
 ## 🎯 Mission
 
-[Project Demo Video](./docs/static/img/teaser.mp4)
-
 Welcome to OpenDevin, an open-source project aiming to replicate Devin, an autonomous AI software engineer who is capable of executing complex engineering tasks and collaborating actively with users on software development projects. This project aspires to replicate, enhance, and innovate upon Devin through the power of the open-source community.
 
 To learn more and to use OpenDevin, check out our [documentation](https://opendevin.github.io/OpenDevin/).


### PR DESCRIPTION
The demo video is included in our homepage now. If we're linking to a video file local to the repository from the README, it does not get displayed. Instead, there is just a link to it. I don't think it's a good idea to always have to update both the readme video and the website video, so I am removing the readme video.