### PR TITLE
Revert ssh box implemetation, fix multi-line command issues and add unit tests

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -37,8 +37,14 @@ jobs:
       - name: Build Environment
         run: make build
 
-      - name: Run Tests
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit
+      # Sandbox requires to import modules in fixture to change os.environ
+      # imports in other test files will cause issues, so we need to test sandbox separately
+      - name: Run Tests Except Sandbox
+        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit --ignore ./tests/unit/test_sandbox.py
+
+      - name: Run Tests For Sandbox
+        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml --cov-append ./tests/unit/test_sandbox.py
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:
@@ -68,8 +74,14 @@ jobs:
       - name: Build Environment
         run: make build
 
-      - name: Run Tests
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit
+      # Sandbox requires to import modules in fixture to change os.environ
+      # imports in other test files will cause issues, so we need to test sandbox separately
+      - name: Run Tests Except Sandbox
+        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit --ignore ./tests/unit/test_sandbox.py
+
+      - name: Run Tests For Sandbox
+        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml --cov-append ./tests/unit/test_sandbox.py
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -34,6 +34,10 @@ jobs:
           brew install colima docker
           colima start
 
+          # For testcontainers to find the Colima socket
+          # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
+          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+
       - name: Build Environment
         run: make build
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -41,13 +41,8 @@ jobs:
       - name: Build Environment
         run: make build
 
-      # Sandbox requires to import modules in fixture to change os.environ
-      # imports in other test files will cause issues, so we need to test sandbox separately
-      - name: Run Tests Except Sandbox
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit --ignore ./tests/unit/test_sandbox.py
-
-      - name: Run Tests For Sandbox
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml --cov-append ./tests/unit/test_sandbox.py
+      - name: Run Tests
+        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -78,13 +73,8 @@ jobs:
       - name: Build Environment
         run: make build
 
-      # Sandbox requires to import modules in fixture to change os.environ
-      # imports in other test files will cause issues, so we need to test sandbox separately
-      - name: Run Tests Except Sandbox
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit --ignore ./tests/unit/test_sandbox.py
-
-      - name: Run Tests For Sandbox
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml --cov-append ./tests/unit/test_sandbox.py
+      - name: Run Tests
+        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/Development.md
+++ b/Development.md
@@ -87,10 +87,7 @@ If you encounter any issues with the Language Model (LM) or you're simply curiou
 
 #### Unit tests
 
-**NOTE**: we need to run unit tests for `test_sandbox.py` separately. `test_sandbox.py` need to import OpenDevin modules in the fixture Running it together with other file will cause it to re-use the imported module and loaded config from other modules, hence causing errors.
-
 ```bash
-poetry run pytest ./tests/unit --ignore ./tests/unit/test_sandbox.py
 poetry run pytest ./tests/unit/test_sandbox.py
 ```
 

--- a/Development.md
+++ b/Development.md
@@ -82,3 +82,18 @@ If you encounter any issues with the Language Model (LM) or you're simply curiou
     ```bash
     make help
     ```
+
+### 8. Testing
+
+#### Unit tests
+
+**NOTE**: we need to run unit tests for `test_sandbox.py` separately. `test_sandbox.py` need to import OpenDevin modules in the fixture Running it together with other file will cause it to re-use the imported module and loaded config from other modules, hence causing errors.
+
+```bash
+poetry run pytest ./tests/unit --ignore ./tests/unit/test_sandbox.py
+poetry run pytest ./tests/unit/test_sandbox.py
+```
+
+#### Integration tests
+
+Please refer to [this README](./tests/integration/README.md) for details.

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -327,9 +327,10 @@ class DockerSSHBox(Sandbox):
             pass
 
     def get_working_directory(self):
-        self.ssh.sendline('pwd')
-        self.ssh.prompt(timeout=10)
-        return self.ssh.before.decode('utf-8').strip()
+        exit_code, result = self.execute('pwd')
+        if exit_code != 0:
+            raise Exception('Failed to get working directory')
+        return result.strip()
 
     def is_container_running(self):
         try:

--- a/opendevin/sandbox/docker/ssh_box.py
+++ b/opendevin/sandbox/docker/ssh_box.py
@@ -169,7 +169,7 @@ class DockerSSHBox(Sandbox):
 
     def start_ssh_session(self):
         # start ssh session at the background
-        self.ssh = pxssh.pxssh(echo=False)
+        self.ssh = pxssh.pxssh()
         hostname = SSH_HOSTNAME
         if RUN_AS_DEVIN:
             username = 'opendevin'
@@ -213,14 +213,36 @@ class DockerSSHBox(Sandbox):
             # send a SIGINT to the process
             self.ssh.sendintr()
             self.ssh.prompt()
-            command_output = self.ssh.before.decode('utf-8').strip()
+            command_output = self.ssh.before.decode(
+                'utf-8').lstrip(cmd).strip()
             return -1, f'Command: "{cmd}" timed out. Sending SIGINT to the process: {command_output}'
         command_output = self.ssh.before.decode('utf-8').strip()
 
+        # once out, make sure that we have *every* output, we while loop until we get an empty output
+        while True:
+            logger.debug('WAITING FOR .prompt()')
+            self.ssh.sendline('\n')
+            timeout_not_reached = self.ssh.prompt(timeout=1)
+            if not timeout_not_reached:
+                logger.debug('TIMEOUT REACHED')
+                break
+            logger.debug('WAITING FOR .before')
+            output = self.ssh.before.decode('utf-8').strip()
+            logger.debug(f'WAITING FOR END OF command output ({bool(output)}): {output}')
+            if output == '':
+                break
+            command_output += output
+        command_output = command_output.lstrip(cmd).strip()
+
         # get the exit code
         self.ssh.sendline('echo $?')
-        self.ssh.prompt(timeout=10)
-        exit_code = int(self.ssh.before.decode('utf-8').strip())
+        self.ssh.prompt()
+        exit_code = self.ssh.before.decode('utf-8')
+        while not exit_code.startswith('echo $?'):
+            self.ssh.prompt()
+            exit_code = self.ssh.before.decode('utf-8')
+            logger.debug(f'WAITING FOR exit code: {exit_code}')
+        exit_code = int(exit_code.lstrip('echo $?').strip())
         return exit_code, command_output
 
     def copy_to(self, host_src: str, sandbox_dest: str, recursive: bool = False):

--- a/tests/unit/test_arg_parser.py
+++ b/tests/unit/test_arg_parser.py
@@ -9,8 +9,8 @@ def test_help_message(capsys):
         parser.parse_args(['--help'])
     captured = capsys.readouterr()
     expected_help_message = """
-usage: pytest [-h] [-d DIRECTORY] [-t TASK] [-f FILE] [-c AGENT_CLS]
-[-m MODEL_NAME] [-i MAX_ITERATIONS] [-n MAX_CHARS]
+usage: pytest [-h] [-d DIRECTORY] [-t TASK] [-f FILE] [-c AGENT_CLS] [-m MODEL_NAME] [-i MAX_ITERATIONS]
+              [-n MAX_CHARS]
 
 Run an agent with a specific task
 
@@ -19,8 +19,7 @@ options:
   -d DIRECTORY, --directory DIRECTORY
                         The working directory for the agent
   -t TASK, --task TASK  The task for the agent to perform
-  -f FILE, --file FILE  Path to a file containing the task. Overrides -t if
-  both are provided.
+  -f FILE, --file FILE  Path to a file containing the task. Overrides -t if both are provided.
   -c AGENT_CLS, --agent-cls AGENT_CLS
                         The agent class to use
   -m MODEL_NAME, --model-name MODEL_NAME
@@ -28,8 +27,7 @@ options:
   -i MAX_ITERATIONS, --max-iterations MAX_ITERATIONS
                         The maximum number of iterations to run the agent
   -n MAX_CHARS, --max-chars MAX_CHARS
-                        The maximum number of characters to send to and
-                        receive from LLM per task
+                        The maximum number of characters to send to and receive from LLM per task
 """
     actual_lines = captured.out.strip().split('\n')
     expected_lines = expected_help_message.strip().split('\n')

--- a/tests/unit/test_arg_parser.py
+++ b/tests/unit/test_arg_parser.py
@@ -9,8 +9,8 @@ def test_help_message(capsys):
         parser.parse_args(['--help'])
     captured = capsys.readouterr()
     expected_help_message = """
-usage: pytest [-h] [-d DIRECTORY] [-t TASK] [-f FILE] [-c AGENT_CLS] [-m MODEL_NAME] [-i MAX_ITERATIONS]
-              [-n MAX_CHARS]
+usage: pytest [-h] [-d DIRECTORY] [-t TASK] [-f FILE] [-c AGENT_CLS]
+[-m MODEL_NAME] [-i MAX_ITERATIONS] [-n MAX_CHARS]
 
 Run an agent with a specific task
 
@@ -19,7 +19,8 @@ options:
   -d DIRECTORY, --directory DIRECTORY
                         The working directory for the agent
   -t TASK, --task TASK  The task for the agent to perform
-  -f FILE, --file FILE  Path to a file containing the task. Overrides -t if both are provided.
+  -f FILE, --file FILE  Path to a file containing the task. Overrides -t if
+  both are provided.
   -c AGENT_CLS, --agent-cls AGENT_CLS
                         The agent class to use
   -m MODEL_NAME, --model-name MODEL_NAME
@@ -27,7 +28,8 @@ options:
   -i MAX_ITERATIONS, --max-iterations MAX_ITERATIONS
                         The maximum number of iterations to run the agent
   -n MAX_CHARS, --max-chars MAX_CHARS
-                        The maximum number of characters to send to and receive from LLM per task
+                        The maximum number of characters to send to and
+                        receive from LLM per task
 """
     actual_lines = captured.out.strip().split('\n')
     expected_lines = expected_help_message.strip().split('\n')

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,0 +1,73 @@
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def ssh_box():
+    # get a temporary directory
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pathlib.Path().mkdir(parents=True, exist_ok=True)
+        os.environ['WORKSPACE_BASE'] = temp_dir
+        os.environ['RUN_AS_DEVIN'] = 'true'
+        os.environ['SANDBOX_TYPE'] = 'ssh'
+        from opendevin.sandbox.docker.ssh_box import DockerSSHBox
+        ssh_box = DockerSSHBox()
+        yield ssh_box
+
+    # cleanup the environment variables
+    del os.environ['WORKSPACE_BASE']
+    del os.environ['SANDBOX_TYPE']
+
+
+def test_ssh_box_run_as_devin(ssh_box):
+    # test the ssh box
+    exit_code, output = ssh_box.execute('ls -l')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert output.strip() == 'total 0'
+
+    exit_code, output = ssh_box.execute('mkdir test')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert output.strip() == ''
+
+    exit_code, output = ssh_box.execute('ls -l')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert 'opendevin' in output, "The output should contain username 'opendevin'"
+    assert 'test' in output, 'The output should contain the test directory'
+
+    exit_code, output = ssh_box.execute('touch test/foo.txt')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert output.strip() == ''
+
+    exit_code, output = ssh_box.execute('ls -l test')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert 'foo.txt' in output, 'The output should contain the foo.txt file'
+
+
+def test_ssh_box_multi_line_cmd_run_as_devin(ssh_box):
+    # test the ssh box
+    exit_code, output = ssh_box.execute('pwd\nls -l')
+    assert exit_code == 0, 'The exit code should be 0.'
+    expected_lines = ['/workspacels -l', 'total 0']
+    assert output.strip().splitlines() == expected_lines
+
+def test_ssh_box_stateful_cmd_run_as_devin(ssh_box):
+    # test the ssh box
+    exit_code, output = ssh_box.execute('mkdir test')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert output.strip() == ''
+
+    exit_code, output = ssh_box.execute('cd test')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert output.strip() == ''
+
+    exit_code, output = ssh_box.execute('pwd')
+    assert exit_code == 0, 'The exit code should be 0.'
+    assert output.strip() == '/workspace/test'
+
+def test_ssh_box_failed_cmd_run_as_devin(ssh_box):
+    # test the ssh box with a command that fails
+    exit_code, output = ssh_box.execute('non_existing_command')
+    assert exit_code != 0, 'The exit code should not be 0 for a failed command.'

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,73 +1,115 @@
-import os
 import pathlib
 import tempfile
+from unittest.mock import patch
 
 import pytest
 
+from opendevin import config
+from opendevin.sandbox.docker.ssh_box import DockerSSHBox
+
 
 @pytest.fixture
-def ssh_box():
+def temp_dir():
     # get a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
         pathlib.Path().mkdir(parents=True, exist_ok=True)
-        os.environ['WORKSPACE_BASE'] = temp_dir
-        os.environ['RUN_AS_DEVIN'] = 'true'
-        os.environ['SANDBOX_TYPE'] = 'ssh'
-        from opendevin.sandbox.docker.ssh_box import DockerSSHBox
+        yield temp_dir
+
+
+def test_ssh_box_run_as_devin(temp_dir):
+    # get a temporary directory
+    with patch.dict(
+        config.config,
+        {
+            config.ConfigType.WORKSPACE_BASE: temp_dir,
+            config.ConfigType.RUN_AS_DEVIN: 'true',
+            config.ConfigType.SANDBOX_TYPE: 'ssh',
+        },
+        clear=True
+    ):
         ssh_box = DockerSSHBox()
-        yield ssh_box
 
-    # cleanup the environment variables
-    del os.environ['WORKSPACE_BASE']
-    del os.environ['SANDBOX_TYPE']
+        # test the ssh box
+        exit_code, output = ssh_box.execute('ls -l')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert output.strip() == 'total 0'
 
+        exit_code, output = ssh_box.execute('mkdir test')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert output.strip() == ''
 
-def test_ssh_box_run_as_devin(ssh_box):
-    # test the ssh box
-    exit_code, output = ssh_box.execute('ls -l')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert output.strip() == 'total 0'
+        exit_code, output = ssh_box.execute('ls -l')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert 'opendevin' in output, "The output should contain username 'opendevin'"
+        assert 'test' in output, 'The output should contain the test directory'
 
-    exit_code, output = ssh_box.execute('mkdir test')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert output.strip() == ''
+        exit_code, output = ssh_box.execute('touch test/foo.txt')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert output.strip() == ''
 
-    exit_code, output = ssh_box.execute('ls -l')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert 'opendevin' in output, "The output should contain username 'opendevin'"
-    assert 'test' in output, 'The output should contain the test directory'
-
-    exit_code, output = ssh_box.execute('touch test/foo.txt')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert output.strip() == ''
-
-    exit_code, output = ssh_box.execute('ls -l test')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert 'foo.txt' in output, 'The output should contain the foo.txt file'
+        exit_code, output = ssh_box.execute('ls -l test')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert 'foo.txt' in output, 'The output should contain the foo.txt file'
 
 
-def test_ssh_box_multi_line_cmd_run_as_devin(ssh_box):
-    # test the ssh box
-    exit_code, output = ssh_box.execute('pwd\nls -l')
-    assert exit_code == 0, 'The exit code should be 0.'
-    expected_lines = ['/workspacels -l', 'total 0']
-    assert output.strip().splitlines() == expected_lines
+def test_ssh_box_multi_line_cmd_run_as_devin(temp_dir):
+    # get a temporary directory
+    with patch.dict(
+        config.config,
+        {
+            config.ConfigType.WORKSPACE_BASE: temp_dir,
+            config.ConfigType.RUN_AS_DEVIN: 'true',
+            config.ConfigType.SANDBOX_TYPE: 'ssh',
+        },
+        clear=True
+    ):
+        ssh_box = DockerSSHBox()
 
-def test_ssh_box_stateful_cmd_run_as_devin(ssh_box):
-    # test the ssh box
-    exit_code, output = ssh_box.execute('mkdir test')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert output.strip() == ''
+        # test the ssh box
+        exit_code, output = ssh_box.execute('pwd\nls -l')
+        assert exit_code == 0, 'The exit code should be 0.'
+        expected_lines = ['/workspacels -l', 'total 0']
+        assert output.strip().splitlines() == expected_lines
 
-    exit_code, output = ssh_box.execute('cd test')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert output.strip() == ''
+def test_ssh_box_stateful_cmd_run_as_devin(temp_dir):
+    # get a temporary directory
+    with patch.dict(
+        config.config,
+        {
+            config.ConfigType.WORKSPACE_BASE: temp_dir,
+            config.ConfigType.RUN_AS_DEVIN: 'true',
+            config.ConfigType.SANDBOX_TYPE: 'ssh',
+        },
+        clear=True
+    ):
+        ssh_box = DockerSSHBox()
 
-    exit_code, output = ssh_box.execute('pwd')
-    assert exit_code == 0, 'The exit code should be 0.'
-    assert output.strip() == '/workspace/test'
+        # test the ssh box
+        exit_code, output = ssh_box.execute('mkdir test')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert output.strip() == ''
 
-def test_ssh_box_failed_cmd_run_as_devin(ssh_box):
-    # test the ssh box with a command that fails
-    exit_code, output = ssh_box.execute('non_existing_command')
-    assert exit_code != 0, 'The exit code should not be 0 for a failed command.'
+        exit_code, output = ssh_box.execute('cd test')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert output.strip() == ''
+
+        exit_code, output = ssh_box.execute('pwd')
+        assert exit_code == 0, 'The exit code should be 0.'
+        assert output.strip() == '/workspace/test'
+
+def test_ssh_box_failed_cmd_run_as_devin(temp_dir):
+    # get a temporary directory
+    with patch.dict(
+        config.config,
+        {
+            config.ConfigType.WORKSPACE_BASE: temp_dir,
+            config.ConfigType.RUN_AS_DEVIN: 'true',
+            config.ConfigType.SANDBOX_TYPE: 'ssh',
+        },
+        clear=True
+    ):
+        ssh_box = DockerSSHBox()
+
+        # test the ssh box with a command that fails
+        exit_code, output = ssh_box.execute('non_existing_command')
+        assert exit_code != 0, 'The exit code should not be 0 for a failed command.'


### PR DESCRIPTION
This PR is an updated version of https://github.com/OpenDevin/OpenDevin/pull/1432. The previous one had too many issues with rebase and merging with `main,` so I'd think just restart a clean one.


- Revert SSHBox implementation change in https://github.com/OpenDevin/OpenDevin/pull/1417, which does not pass all the unit tests (it causes failure for CodeActAgent when `source ~/.bashrc`.
- Add docs and instructions for unit tests.

**NOTE**: we need to run unit tests for `test_sandbox.py` separately. `test_sandbox.py` needs to import OpenDevin modules in the fixture. Running it together with another file will cause it to re-use the imported module and loaded config from other modules, hence causing errors.