### PR TITLE
fix(agenthub) : limit context size send to llm api

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -105,9 +105,9 @@ class CodeActAgent(Agent):
                     obs, AgentMessageObservation
                 ):  # warning message from itself
                     self.messages.append(
-                        {'role': 'user', 'content': obs.content})
+                        {'role': 'user', 'content': obs.content[0:10000]})
                 elif isinstance(obs, CmdOutputObservation):
-                    content = 'OBSERVATION:\n' + obs.content
+                    content = 'OBSERVATION:\n' + obs.content[0:10000]
                     content += f'\n[Command {obs.command_id} finished with exit code {obs.exit_code}]]'
                     self.messages.append({'role': 'user', 'content': content})
                 else:


### PR DESCRIPTION
## What?

When observation becoming bigger like more than 16385 words like when developing environment, the LLM API (in my case chatGPT-3.5) throws error like below image.

<img width="495" alt="スクリーンショット 2024-04-30 19 50 48" src="https://github.com/OpenDevin/OpenDevin/assets/136598145/eadf1ffc-3a18-4525-afd2-25ea4664d082">

I think If we can limit the context size send to LLM api, we don't have to worry about the above 400 error.
I did't try using Gemini or Vertex LLM, and even for GPT I didn't try using GPT4, so maybe there are improvement to have conditional branch that supports each LLM.

Thank you for reading my PR.