### PR TITLE
test(frontend): refactor tests to pass since changes, remove console logs, use toast …

### DIFF
--- a/frontend/src/components/Browser.test.tsx
+++ b/frontend/src/components/Browser.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders } from "../../test-utils";
 
 describe("Browser", () => {
   it("renders a message if no screenshotSrc is provided", () => {
-    const { getByText, getByAltText } = renderWithProviders(<Browser />, {
+    const { getByText } = renderWithProviders(<Browser />, {
       preloadedState: {
         browser: {
           url: "https://example.com",
@@ -13,8 +13,8 @@ describe("Browser", () => {
       },
     });
 
-    expect(getByText(/OpenDevin: Code Less, Make More./i)).toBeInTheDocument();
-    expect(getByAltText(/Blank Page/i)).toBeInTheDocument();
+    // i18n empty message key
+    expect(getByText(/BROWSER\$EMPTY_MESSAGE/i)).toBeInTheDocument();
   });
 
   it("renders the url and a screenshot", () => {

--- a/frontend/src/components/file-explorer/FileExplorer.tsx
+++ b/frontend/src/components/file-explorer/FileExplorer.tsx
@@ -14,6 +14,7 @@ import {
 import IconButton from "../IconButton";
 import ExplorerTree from "./ExplorerTree";
 import { removeEmptyNodes } from "./utils";
+import toast from "#/utils/toast";
 
 interface ExplorerActionsProps {
   onRefresh: () => void;
@@ -104,17 +105,13 @@ function FileExplorer({ onFileClick }: FileExplorerProps) {
 
   const uploadFileData = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files ? event.target.files[0] : null;
-    if (!file) {
-      console.log("No file selected.");
-      return;
-    }
-    console.log("File selected:", file);
+    if (!file) return;
+
     try {
-      const response = await uploadFile(file);
-      console.log(response);
+      await uploadFile(file);
       await getWorkspaceData(); // Refresh the workspace to show the new file
     } catch (error) {
-      console.error("Error uploading file:", error);
+      toast.stickyError("ws", "Error uploading file");
     }
   };
 
@@ -150,6 +147,7 @@ function FileExplorer({ onFileClick }: FileExplorerProps) {
         />
       </div>
       <input
+        data-testid="file-input"
         type="file"
         ref={fileInputRef}
         style={{ display: "none" }}

--- a/frontend/src/services/fileService.ts
+++ b/frontend/src/services/fileService.ts
@@ -12,7 +12,7 @@ export async function selectFile(file: string): Promise<string> {
   return data.code as string;
 }
 
-export async function uploadFile(file: File): Promise<string> {
+export async function uploadFile(file: File) {
   const formData = new FormData();
   formData.append("file", file);
 
@@ -26,8 +26,6 @@ export async function uploadFile(file: File): Promise<string> {
   if (res.status !== 200) {
     throw new Error(data.error || "Failed to upload file.");
   }
-
-  return `File uploaded: ${data.filename}, Location: ${data.location}`;
 }
 
 export async function getWorkspace(): Promise<WorkspaceFile> {


### PR DESCRIPTION
## Summary
Update failing tests since browser updates and file upload updates.

## Changes
- Removed `console.log`s from file upload-related functions
- Replace `console.error` with `toast.stickyError`
- Extend tests for file uploader