### PR TITLE
Fix docker push for non-forks

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -59,12 +59,12 @@ jobs:
           swap-storage: true
 
       - name: Build and push ${{ matrix.image }}
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: "!github.event.pull_request.head.repo.fork"
         run: |
           ./containers/build.sh ${{ matrix.image }} ${{ github.repository_owner }} --push
 
       - name: Build ${{ matrix.image }}
-        if: github.event.pull_request.head.repo.full_name != github.repository
+        if: "github.event.pull_request.head.repo.fork"
         run: |
           ./containers/build.sh ${{ matrix.image }} ${{ github.repository_owner }}
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -42,22 +42,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: true
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
       - name: Build and push ${{ matrix.image }}
         if: "!github.event.pull_request.head.repo.fork"
         run: |

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -67,7 +67,7 @@ RUN playwright install --with-deps chromium
 COPY --chown=opendevin --from=frontend-builder /app/dist ./frontend/dist
 
 # change ownership of the app directory to the sandbox user
-COPY ./containers/app/entrypoint.sh /app/entrypoint.sh
+COPY --chown=opendevin ./containers/app/entrypoint.sh /app/entrypoint.sh
 
 USER root
 CMD ["/app/entrypoint.sh"]

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY ./frontend/package.json frontend/package-lock.json ./
 RUN npm install -g npm@10.5.1
-RUN npm install
+RUN npm ci
 
 COPY ./frontend ./
 RUN npm run make-i18n && npm run build
@@ -43,7 +43,7 @@ RUN mkdir -p $WORKSPACE_BASE
 RUN apt-get update -y \
     && apt-get install -y curl ssh sudo
 
-RUN useradd -m -u $SANDBOX_USER_ID -s /bin/bash opendevin && \
+RUN useradd -l -m -u $SANDBOX_USER_ID -s /bin/bash opendevin && \
     usermod -aG sudo opendevin && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R opendevin:opendevin /app

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -66,11 +66,12 @@ RUN playwright install --with-deps chromium
 
 COPY --from=frontend-builder /app/dist ./frontend/dist
 
-USER root
-RUN chown -R opendevin:opendevin /app
+# FIXME: this causes issues with push, and makes the build take forever
+#USER root
+#RUN chown -R opendevin:opendevin /app
 # make group permissions the same as user permissions
-RUN chmod -R g=u /app
-USER opendevin
+#RUN chmod -R g=u /app
+#USER opendevin
 
 # change ownership of the app directory to the sandbox user
 COPY ./containers/app/entrypoint.sh /app/entrypoint.sh

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -53,31 +53,20 @@ ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH" \
     PYTHONPATH='/app'
 
-COPY --from=backend-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --chown=opendevin --from=backend-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 # change ownership of the virtual environment to the sandbox user
 USER root
 RUN chown -R opendevin:opendevin ${VIRTUAL_ENV}
 USER opendevin
 
-COPY ./opendevin ./opendevin
-COPY ./agenthub ./agenthub
+COPY --chown=opendevin ./opendevin ./opendevin
+COPY --chown=opendevin ./agenthub ./agenthub
 RUN python opendevin/download.py # No-op to download assets
 RUN playwright install --with-deps chromium
 
-COPY --from=frontend-builder /app/dist ./frontend/dist
-
-# FIXME: this causes issues with push, and makes the build take forever
-#USER root
-#RUN chown -R opendevin:opendevin /app
-# make group permissions the same as user permissions
-#RUN chmod -R g=u /app
-#USER opendevin
+COPY --chown=opendevin --from=frontend-builder /app/dist ./frontend/dist
 
 # change ownership of the app directory to the sandbox user
-COPY ./containers/app/entrypoint.sh /app/entrypoint.sh
+COPY --chown=opendevin ./containers/app/entrypoint.sh /app/entrypoint.sh
 
-# run the script as root
-USER root
-RUN chown opendevin:opendevin /app/entrypoint.sh
-RUN chmod 777 /app/entrypoint.sh
 CMD ["/app/entrypoint.sh"]

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -54,7 +54,6 @@ ENV VIRTUAL_ENV=/app/.venv \
     PYTHONPATH='/app'
 
 COPY --chown=opendevin --from=backend-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
-# change ownership of the virtual environment to the sandbox user
 USER root
 RUN chown -R opendevin:opendevin ${VIRTUAL_ENV}
 USER opendevin
@@ -66,7 +65,6 @@ RUN playwright install --with-deps chromium
 
 COPY --chown=opendevin --from=frontend-builder /app/dist ./frontend/dist
 
-# change ownership of the app directory to the sandbox user
 COPY --chown=opendevin ./containers/app/entrypoint.sh /app/entrypoint.sh
 
 USER root

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -67,6 +67,7 @@ RUN playwright install --with-deps chromium
 COPY --chown=opendevin --from=frontend-builder /app/dist ./frontend/dist
 
 # change ownership of the app directory to the sandbox user
-COPY --chown=opendevin ./containers/app/entrypoint.sh /app/entrypoint.sh
+COPY ./containers/app/entrypoint.sh /app/entrypoint.sh
 
+USER root
 CMD ["/app/entrypoint.sh"]

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # check user is root
 if [ "$(id -u)" -ne 0 ]; then
-  echo "Please run as root"
+  echo "The OpenDevin entrypoint.sh must run as root"
   exit 1
 fi
 

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -54,11 +54,14 @@ for tag in ${tags[@]}; do
 done
 if [[ $push -eq 1 ]]; then
   args+=" --push"
+  args+=" --cache-to=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag,mode=max"
 fi
 
 docker buildx build \
   $args \
   --build-arg OPEN_DEVIN_BUILD_VERSION=$OPEN_DEVIN_BUILD_VERSION \
+  --cache-from=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag \
+  --cache-from=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag_base-main \
   --platform linux/amd64,linux/arm64 \
   --provenance=false \
   -f $dir/Dockerfile $DOCKER_BASE_DIR

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -54,14 +54,11 @@ for tag in ${tags[@]}; do
 done
 if [[ $push -eq 1 ]]; then
   args+=" --push"
-  args+=" --cache-to=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag,mode=max"
 fi
 
 docker buildx build \
   $args \
   --build-arg OPEN_DEVIN_BUILD_VERSION=$OPEN_DEVIN_BUILD_VERSION \
-  --cache-from=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag \
-  --cache-from=type=registry,ref=$DOCKER_REPOSITORY:$cache_tag_base-main \
   --platform linux/amd64,linux/arm64 \
   --provenance=false \
   -f $dir/Dockerfile $DOCKER_BASE_DIR


### PR DESCRIPTION
Apparently the existing check to see if we were on a fork was always (?) false--don't believe everything you read on Stack Overflow!

Seems there might be some flaky issues with `--push`, I believe as a result of https://github.com/OpenDevin/OpenDevin/pull/1426

From what I've gathered, running `chown` on a big directory creates a huge layer, and big layers seem to cause issues w/ GitHub actions. This uses the more efficient `COPY --chown` method

I'm also removing the "Free Disk Space" bit, because it _shouldn't_ be necessary (we have 20GB), and takes a little while. 