### PR TITLE
fix: fix docker command env arg error

### DIFF
--- a/docs/modules/usage/intro.mdx
+++ b/docs/modules/usage/intro.mdx
@@ -79,7 +79,7 @@ OpenDevin runs bash commands within a Docker sandbox, so it should not affect yo
 
 ```
 docker run \
-    -e LLM_API_KEY \
+    -e LLM_API_KEY=$LLM_API_KEY \
     -e WORKSPACE_MOUNT_PATH=$WORKSPACE_BASE \
     -v $WORKSPACE_BASE:/opt/workspace_base \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/docs/src/components/Code/Code.tsx
+++ b/docs/src/components/Code/Code.tsx
@@ -11,7 +11,7 @@ export LLM_API_KEY="sk-..."`;
 export WORKSPACE_BASE=$(pwd)/workspace`;
 
   const dockerCode = `docker run \\
-    -e LLM_API_KEY \\
+    -e LLM_API_KEY=$LLM_API_KEY \\
     -e WORKSPACE_MOUNT_PATH=$WORKSPACE_BASE \\
     -v $WORKSPACE_BASE:/opt/workspace_base \\
     -v /var/run/docker.sock:/var/run/docker.sock \\


### PR DESCRIPTION
#1509 
change the docker command env arg 
from `-e LLM_API_KEY` to `-e LLM_API_KEY=$LLM_API_KEY`