### PR TITLE
Fix linting on main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit==3.7.0
       - name: Run pre-commit hooks
+        if: github.ref != 'refs/heads/main'
         run: |
           git fetch https://github.com/OpenDevin/OpenDevin.git main:main && \
           pre-commit run \


### PR DESCRIPTION
https://github.com/OpenDevin/OpenDevin/pull/1457 made a change so that we only lint changed files. But the logic isn't happy when running on the main branch--we get this error: https://github.com/OpenDevin/OpenDevin/actions/runs/8923448020/job/24507727023

This PR disables pre-commit checks on the main branch. Not ideal, but good enough for now