### PR TITLE
Bump doc to 0.4.1

### DIFF
--- a/docs/src/components/Code/Code.tsx
+++ b/docs/src/components/Code/Code.tsx
@@ -17,7 +17,7 @@ export WORKSPACE_BASE=$(pwd)/workspace`;
     -v /var/run/docker.sock:/var/run/docker.sock \\
     -p 3000:3000 \\
     --add-host host.docker.internal=host-gateway \\
-    ghcr.io/opendevin/opendevin:0.3.1`;
+    ghcr.io/opendevin/opendevin:0.4.1`;
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
Currently our docs say to install 0.3.1, but 0.4.1 is the most recent release, so this PR bumps to 0.4.1.

More generally, it'd be nice to auto-update this on a new release.