### PR TITLE
Remove screenshot from microagent prompt

### DIFF
--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -42,14 +42,32 @@ def my_encoder(obj):
         return obj.to_dict()
 
 
+def _remove_fields(obj, fields: set[str]):
+    """
+    Remove fields from an object
+
+    Parameters:
+    - obj (Object): The object to remove fields from
+    - fields (set[str]): A set of field names to remove from the object
+    """
+    if isinstance(obj, dict):
+        for field in fields:
+            if field in obj:
+                del obj[field]
+        for key, value in obj.items():
+            _remove_fields(value, fields)
+    elif isinstance(obj, list):
+        for item in obj:
+            _remove_fields(item, fields)
+
+
 def to_json(obj, **kwargs):
     """
     Serialize an object to str format
     """
     # Remove things like screenshots that shouldn't be in a prompt
     sanitized_obj = copy.deepcopy(obj)
-    if 'extras' in sanitized_obj and 'screenshot' in sanitized_obj['extras']:
-        del sanitized_obj['extras']['screenshot']
+    _remove_fields(sanitized_obj, {'screenshot'})
     return json.dumps(sanitized_obj, default=my_encoder, **kwargs)
 
 

--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from typing import Dict, List
 
@@ -45,7 +46,11 @@ def to_json(obj, **kwargs):
     """
     Serialize an object to str format
     """
-    return json.dumps(obj, default=my_encoder, **kwargs)
+    # Remove things like screenshots that shouldn't be in a prompt
+    sanitized_obj = copy.deepcopy(obj)
+    if 'extras' in sanitized_obj and 'screenshot' in sanitized_obj['extras']:
+        del sanitized_obj['extras']['screenshot']
+    return json.dumps(sanitized_obj, default=my_encoder, **kwargs)
 
 
 class MicroAgent(Agent):

--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -54,11 +54,17 @@ def _remove_fields(obj, fields: set[str]):
         for field in fields:
             if field in obj:
                 del obj[field]
-        for key, value in obj.items():
+        for _, value in obj.items():
             _remove_fields(value, fields)
-    elif isinstance(obj, list):
+    elif isinstance(obj, list) or isinstance(obj, tuple):
         for item in obj:
             _remove_fields(item, fields)
+    elif hasattr(obj, '__dataclass_fields__'):
+        for field in fields:
+            if field in obj.__dataclass_fields__:
+                setattr(obj, field, None)
+        for value in obj.__dict__.values():
+            _remove_fields(value, fields)
 
 
 def to_json(obj, **kwargs):


### PR DESCRIPTION
This removes the `BrowserObservation` screenshot from the microagent prompt.

Fixes https://github.com/OpenDevin/OpenDevin/issues/1545

This is based on what we do in MonologueAgent:
https://github.com/OpenDevin/OpenDevin/blob/91c8f1cb3f16904bac79f548bc1474c8601403f8/agenthub/monologue_agent/agent.py#L117

We might also consider making this a more general utility function in the future (converting history to text).

UPDATE: This is still buggy, will convert to an issue and ping when it's fixed.