### PR TITLE
fix the issue where session id might be duplicated

### DIFF
--- a/opendevin/runtime/docker/exec_box.py
+++ b/opendevin/runtime/docker/exec_box.py
@@ -61,7 +61,7 @@ class DockerExecBox(Sandbox):
             )
             raise ex
 
-        self.instance_id = sid if sid is not None else str(uuid.uuid4())
+        self.instance_id = sid + str(uuid.uuid4()) if sid is not None else str(uuid.uuid4())
 
         # TODO: this timeout is actually essential - need a better way to set it
         # if it is too short, the container may still waiting for previous

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -77,7 +77,7 @@ class DockerSSHBox(Sandbox):
             )
             raise ex
 
-        self.instance_id = sid if sid is not None else str(uuid.uuid4())
+        self.instance_id = sid + str(uuid.uuid4()) if sid is not None else str(uuid.uuid4())
 
         # TODO: this timeout is actually essential - need a better way to set it
         # if it is too short, the container may still waiting for previous


### PR DESCRIPTION
When multiple users are debugging OpenDevin on the same machine, operations on the same instance may occur due to identical sid. Therefore, random unique identifiers are applied to sid here to avoid such conflicts.