### PR TITLE
Fix user permissions in docker

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -33,7 +33,7 @@ FROM python:3.12-slim as runtime
 WORKDIR /app
 
 ENV RUN_AS_DEVIN=true
-ENV SANDBOX_USER_ID=1000
+ENV OPENDEVIN_USER_ID=1000
 ENV USE_HOST_NETWORK=false
 ENV SSH_HOSTNAME=host.docker.internal
 ENV WORKSPACE_BASE=/opt/workspace_base
@@ -43,29 +43,33 @@ RUN mkdir -p $WORKSPACE_BASE
 RUN apt-get update -y \
     && apt-get install -y curl ssh sudo
 
-RUN useradd -l -m -u $SANDBOX_USER_ID -s /bin/bash opendevin && \
+RUN sed -i 's/^UID_MIN.*/UID_MIN 499/' /etc/login.defs # Default is 1000, but OSX is often 501
+
+RUN groupadd app
+RUN useradd -l -m -u $OPENDEVIN_USER_ID -s /bin/bash opendevin && \
+    usermod -aG app opendevin && \
     usermod -aG sudo opendevin && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN chown -R opendevin:opendevin /app
+RUN chown -R opendevin:app /app && chmod -R 770 /app
 USER opendevin
 
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH" \
     PYTHONPATH='/app'
 
-COPY --chown=opendevin --from=backend-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
-USER root
-RUN chown -R opendevin:opendevin ${VIRTUAL_ENV}
-USER opendevin
-
-COPY --chown=opendevin ./opendevin ./opendevin
-COPY --chown=opendevin ./agenthub ./agenthub
-RUN python opendevin/core/download.py # No-op to download assets
+COPY --chown=opendevin:app --chmod=770 --from=backend-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 RUN playwright install --with-deps chromium
 
-COPY --chown=opendevin --from=frontend-builder /app/dist ./frontend/dist
+COPY --chown=opendevin:app --chmod=770 ./opendevin ./opendevin
+COPY --chown=opendevin:app --chmod=777 ./opendevin/runtime/plugins ./opendevin/runtime/plugins
+COPY --chown=opendevin:app --chmod=770 ./agenthub ./agenthub
 
-COPY --chown=opendevin ./containers/app/entrypoint.sh /app/entrypoint.sh
+RUN python opendevin/core/download.py # No-op to download assets
+RUN chown -R opendevin:app /app/logs && chmod -R 770 /app/logs # This gets created by the download.py script
+
+
+COPY --chown=opendevin:app --chmod=770 --from=frontend-builder /app/dist ./frontend/dist
+COPY --chown=opendevin:app --chmod=770 ./containers/app/entrypoint.sh /app/entrypoint.sh
 
 USER root
 CMD ["/app/entrypoint.sh"]

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -14,6 +14,8 @@ fi
 # but the group id is not changed, so the user can still access everything under /app
 useradd -l -m -u $SANDBOX_USER_ID -s /bin/bash enduser
 usermod -aG app enduser
+mkdir -p /home/enduser/.cache/ms-playwright/
+mv /home/opendevin/.cache/ms-playwright/ /home/enduser/.cache/
 
 # get the user group of /var/run/docker.sock and set opendevin to that group
 DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -12,12 +12,13 @@ fi
 
 # change uid of opendevin user to match the host user
 # but the group id is not changed, so the user can still access everything under /app
-usermod -u $SANDBOX_USER_ID opendevin
+useradd -l -m -u $SANDBOX_USER_ID -s /bin/bash enduser
+usermod -aG app enduser
 
 # get the user group of /var/run/docker.sock and set opendevin to that group
 DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
 echo "Docker socket group id: $DOCKER_SOCKET_GID"
-usermod -aG $DOCKER_SOCKET_GID opendevin
+usermod -aG $DOCKER_SOCKET_GID enduser
 
 # switch to the user and start the server
-su opendevin -c "cd /app && uvicorn opendevin.server.listen:app --host 0.0.0.0 --port 3000"
+su enduser -c "cd /app && uvicorn opendevin.server.listen:app --host 0.0.0.0 --port 3000"

--- a/opendevin/runtime/plugins/jupyter/__init__.py
+++ b/opendevin/runtime/plugins/jupyter/__init__.py
@@ -9,6 +9,6 @@ class JupyterRequirement(PluginRequirement):
     name: str = 'jupyter'
     host_src: str = os.path.dirname(
         os.path.abspath(__file__)
-    )  # The directory of this file (sandbox/plugins/jupyter)
+    )  # The directory of this file (opendevin/runtime/plugins/jupyter)
     sandbox_dest: str = '/opendevin/plugins/jupyter'
     bash_script_path: str = 'setup.sh'


### PR DESCRIPTION
Was trying out `main` but running into UID issues.

This PR makes a few changes:
* create a separate `enduser` user, which uses the UID passed in at runtime
* create an `app` group, which both `opendevin` and `enduser` belong to
* change UID_MIN to something compatible with OS X
* chmod everything so that it's group-readable

I've verified that:
* App starts in docker
* Browser starts up OK
* Files created by agent have the end-user's UID