### PR TITLE
i18n: translation of zh-TW

### DIFF
--- a/frontend/src/i18n/translation.json
+++ b/frontend/src/i18n/translation.json
@@ -243,16 +243,20 @@
     "es": "Guardar"
   },
   "LOAD_SESSION$MODAL_TITLE": {
-    "en": "Unfinished Session Detected"
+    "en": "Unfinished Session Detected",
+    "zh-TW": "偵測到未完成的會話"
   },
   "LOAD_SESSION$MODAL_CONTENT": {
-    "en": "You seem to have an unfinished task. Would you like to pick up where you left off or start fresh?"
+    "en": "You seem to have an unfinished task. Would you like to pick up where you left off or start fresh?",
+    "zh-TW": "您似乎有一個未完成的任務。您想從上次離開的地方繼續還是重新開始？"
   },
   "LOAD_SESSION$RESUME_SESSION_MODAL_ACTION_LABEL": {
-    "en": "Resume Session"
+    "en": "Resume Session",
+    "zh-TW": "恢復會話"
   },
   "LOAD_SESSION$START_NEW_SESSION_MODAL_ACTION_LABEL": {
-    "en": "Start New Session"
+    "en": "Start New Session",
+    "zh-TW": "開始新會話"
   },
   "CHAT_INTERFACE$INITIALZING_AGENT_LOADING_MESSAGE": {
     "en": "Initializing agent (may take up to 10 seconds)...",
@@ -301,7 +305,7 @@
     "de": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
     "ko-KR": "안녕하세요! 저는 오픈데빈(OpenDevin), AI 소프트웨어 엔지니어입니다. 오늘은 저와 함께 무엇을 만들어 볼까요?",
     "no": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
-    "zh-TW": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
+    "zh-TW": "嗨！我是 OpenDevin，一位人工智慧軟體工程師。你今天想和我一起建造什麼？",
     "it": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
     "pt": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
     "es": "Hi! I'm OpenDevin, an AI Software Engineer. What would you like to build with me today?",
@@ -314,7 +318,7 @@
     "ko-KR": "어시스턴트",
     "de": "Assistant",
     "no": "Assistant",
-    "zh-TW": "Assistant",
+    "zh-TW": "助理",
     "it": "Assistant",
     "pt": "Assistant",
     "es": "Assistant",
@@ -324,34 +328,42 @@
   },
   "SETTINGS$MODEL_TOOLTIP": {
     "en": "Select the language model to use.",
+    "zh-TW": "選擇要使用的語言模型。",
     "de": "Wähle das zu verwendende Model."
   },
   "SETTINGS$AGENT_TOOLTIP": {
     "en": "Select the agent to use.",
+    "zh-TW": "選擇要使用的智能體。",
     "de": "Wähle den zu verwendenden Agent."
   },
   "SETTINGS$LANGUAGE_TOOLTIP": {
     "en": "Select the language for the UI.",
+    "zh-TW": "選擇 UI 的語言。",
     "de": "Wähle die Sprache für das Interface."
   },
   "SETTINGS$DISABLED_RUNNING": {
     "en": "Cannot be changed while the agent is running.",
+    "zh-TW": "智能體正在執行時無法更改。",
     "de": "Kann nicht geändert werden während ein Task ausgeführt wird."
   },
   "SETTINGS$API_KEY_PLACEHOLDER": {
     "en": "Enter your API key.",
+    "zh-TW": "輸入您的 API 金鑰。",
     "de": "Model API key."
   },
   "CODE_EDITOR$EMPTY_MESSAGE": {
     "en": "No file selected.",
+    "zh-TW": "未選取任何文件。",
     "de": "Keine Datei ausgewählt."
   },
   "BROWSER$EMPTY_MESSAGE": {
     "en": "No page loaded.",
+    "zh-TW": "未加載任何頁面。",
     "de": "Keine Seite geladen."
   },
   "PLANNER$EMPTY_MESSAGE": {
     "en": "No plan created.",
+    "zh-TW": "未創建任何計劃。",
     "de": "Kein Plan erstellt."
   }
 }


### PR DESCRIPTION
Hello, like #1157, this PR adds the translation of Traditional Chinese.

(It seems that some sentences were translated in #947, but due to changes in the source file, some additional sentences were not translated.)

Also, I'm not quite sure why "Agent" should be translated as "智能體" (intelligent body), but since that's how it was translated before and in zh-CN, for the sake of consistency, I decided to stick with this translation for the term.

Thank you for review this PR! Hope it can be merged quickly!