### PR TITLE
test(frontend): update unit tests

### DIFF
--- a/frontend/src/components/chat/ChatInterface.test.tsx
+++ b/frontend/src/components/chat/ChatInterface.test.tsx
@@ -21,18 +21,9 @@ const socketSpy = vi.spyOn(Socket, "send");
 // TODO: Move this into test setup
 HTMLElement.prototype.scrollIntoView = vi.fn();
 
-const renderChatInterface = () =>
-  renderWithProviders(<ChatInterface />, {
-    preloadedState: {
-      task: {
-        completed: false,
-      },
-    },
-  });
-
 describe("ChatInterface", () => {
   it("should render the messages and input", () => {
-    renderChatInterface();
+    renderWithProviders(<ChatInterface />);
     expect(screen.queryAllByTestId("message")).toHaveLength(1); // initial welcome message only
   });
 
@@ -80,9 +71,6 @@ describe("ChatInterface", () => {
   it("should send the a start event to the Socket", () => {
     renderWithProviders(<ChatInterface />, {
       preloadedState: {
-        task: {
-          completed: false,
-        },
         agent: {
           curAgentState: AgentState.INIT,
         },
@@ -101,9 +89,6 @@ describe("ChatInterface", () => {
   it("should send the a user message event to the Socket", () => {
     renderWithProviders(<ChatInterface />, {
       preloadedState: {
-        task: {
-          completed: false,
-        },
         agent: {
           curAgentState: AgentState.AWAITING_USER_INPUT,
         },
@@ -125,9 +110,6 @@ describe("ChatInterface", () => {
   it("should disable the user input if agent is not initialized", () => {
     renderWithProviders(<ChatInterface />, {
       preloadedState: {
-        task: {
-          completed: false,
-        },
         agent: {
           curAgentState: AgentState.LOADING,
         },

--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -1,18 +1,21 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { IoMdChatbubbles } from "react-icons/io";
 import ChatInput from "./ChatInput";
 import Chat from "./Chat";
 import { RootState } from "#/store";
 import AgentState from "#/types/AgentState";
 import { sendChatMessage } from "#/services/chatService";
+import { addUserMessage } from "#/state/chatSlice";
 
 function ChatInterface() {
+  const dispatch = useDispatch();
   const { messages } = useSelector((state: RootState) => state.chat);
   const { curAgentState } = useSelector((state: RootState) => state.agent);
 
   const handleSendMessage = (content: string) => {
     const isTask = curAgentState === AgentState.INIT;
+    dispatch(addUserMessage(content));
     sendChatMessage(content, isTask);
   };
 

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -6,7 +6,6 @@ import Socket from "./socket";
 import { addUserMessage } from "#/state/chatSlice";
 
 export function sendChatMessage(message: string, isTask: boolean = true): void {
-  store.dispatch(addUserMessage(message));
   let event;
   if (isTask) {
     event = { action: ActionType.START, args: { task: message } };


### PR DESCRIPTION
## Summary
Updates the tests according to changes made in #1538.

## Fixes
The test `it("should render the new message the user has typed")` no longer fails due to the Redux store not updating. The dispatch was called outside the component with the `store` object directly. We end up have more than one store in the app, [which is not advised](https://redux.js.org/faq/store-setup#can-or-should-i-create-multiple-stores-can-i-import-my-store-directly-and-use-it-in-components-myself).

## Improvements
- Removed the need for preloaded task state (removal of `initialized` from `taskSlice`)