### PR TITLE
fix: check action['action'] instance type before parsing action cls

### DIFF
--- a/opendevin/events/action/__init__.py
+++ b/opendevin/events/action/__init__.py
@@ -47,6 +47,10 @@ def action_from_dict(action: dict) -> Action:
     action = action.copy()
     if 'action' not in action:
         raise AgentMalformedActionError(f"'action' key is not found in {action=}")
+    if not isinstance(action['action'], str):
+        raise AgentMalformedActionError(
+            f"'{action['action']=}' is not defined. Available actions: {ACTION_TYPE_TO_CLASS.keys()}"
+        )
     action_class = ACTION_TYPE_TO_CLASS.get(action['action'])
     if action_class is None:
         raise AgentMalformedActionError(


### PR DESCRIPTION
Check action['action'] instance type to avoid undesired llm outputs, which may cause runtime type error.