### PR TITLE
fix: delegateAgent select micro agents name bug.

### DIFF
--- a/agenthub/delegator_agent/agent.py
+++ b/agenthub/delegator_agent/agent.py
@@ -42,8 +42,8 @@ class DelegatorAgent(Agent):
                 agent='StudyRepoForTaskAgent', inputs={'task': state.plan.main_goal}
             )
 
-        lastObservation = state.history[-1][1]
-        if not isinstance(lastObservation, AgentDelegateObservation):
+        last_observation = state.history[-1][1]
+        if not isinstance(last_observation, AgentDelegateObservation):
             raise Exception('Last observation is not an AgentDelegateObservation')
 
         if self.current_delegate == 'study':
@@ -52,7 +52,7 @@ class DelegatorAgent(Agent):
                 agent='CoderAgent',
                 inputs={
                     'task': state.plan.main_goal,
-                    'summary': lastObservation.outputs['summary'],
+                    'summary': last_observation.outputs['summary'],
                 },
             )
         elif self.current_delegate == 'coder':
@@ -65,8 +65,8 @@ class DelegatorAgent(Agent):
             )
         elif self.current_delegate == 'verifier':
             if (
-                'completed' in lastObservation.outputs
-                and lastObservation.outputs['completed']
+                'completed' in last_observation.outputs
+                and last_observation.outputs['completed']
             ):
                 return AgentFinishAction()
             else:
@@ -75,7 +75,7 @@ class DelegatorAgent(Agent):
                     agent='CoderAgent',
                     inputs={
                         'task': state.plan.main_goal,
-                        'summary': lastObservation.outputs['summary'],
+                        'summary': last_observation.outputs['summary'],
                     },
                 )
         else:

--- a/agenthub/delegator_agent/agent.py
+++ b/agenthub/delegator_agent/agent.py
@@ -49,7 +49,7 @@ class DelegatorAgent(Agent):
         if self.current_delegate == 'study':
             self.current_delegate = 'coder'
             return AgentDelegateAction(
-                agent='Coder',
+                agent='CoderAgent',
                 inputs={
                     'task': state.plan.main_goal,
                     'summary': lastObservation.outputs['summary'],
@@ -58,7 +58,7 @@ class DelegatorAgent(Agent):
         elif self.current_delegate == 'coder':
             self.current_delegate = 'verifier'
             return AgentDelegateAction(
-                agent='Verifier',
+                agent='VerifierAgent',
                 inputs={
                     'task': state.plan.main_goal,
                 },
@@ -72,7 +72,7 @@ class DelegatorAgent(Agent):
             else:
                 self.current_delegate = 'coder'
                 return AgentDelegateAction(
-                    agent='Coder',
+                    agent='CoderAgent',
                     inputs={
                         'task': state.plan.main_goal,
                         'summary': lastObservation.outputs['summary'],


### PR DESCRIPTION
Coder and Verifier isn't the correct name, it will throw exception like `opendevin.core.exceptions.AgentNotRegisteredError: No agent class registered under 'Coder'`  