### PR TITLE
fix: file in _instructions directory not set correctly.

### DIFF
--- a/agenthub/micro/instructions.py
+++ b/agenthub/micro/instructions.py
@@ -7,13 +7,16 @@ base_dir = os.path.dirname(os.path.abspath(__file__)) + '/_instructions'
 for root, dirs, files in os.walk(base_dir):
     if len(files) == 0:
         continue
-    rel_base = os.path.relpath(root, base_dir)
-    keys = rel_base.split('/')
-    obj = instructions
-    for key in keys:
-        if key not in obj:
-            obj[key] = {}
-        obj = obj[key]
+    if root == base_dir:
+        obj = instructions
+    else:
+        rel_base = os.path.relpath(root, base_dir)
+        keys = rel_base.split('/')
+        obj = instructions
+        for key in keys:
+            if key not in obj:
+                obj[key] = {}
+            obj = obj[key]
     for file in files:
         without_ext = os.path.splitext(file)[0]
         with open(os.path.join(root, file), 'r') as f:


### PR DESCRIPTION
For file (not directory) in _instructions, right now just `history_truncated.md`, the `instructions` is not set correctly: 
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/360c82d5-4950-4ccc-b41b-942def1d0602)

and the `{{ instructions.history_truncated }}` in prompt template will not be rendered.