### PR TITLE
Introduce TypoFixerAgent for in-place typo corrections in agenthub/micro

### DIFF
--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -6,7 +6,7 @@ from jinja2 import BaseLoader, Environment
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
 from opendevin.core.exceptions import LLMOutputError
-from opendevin.events.action import Action
+from opendevin.events.action import Action, action_from_dict
 from opendevin.llm.llm import LLM
 
 from .instructions import instructions
@@ -27,13 +27,13 @@ def parse_response(orig_response: str):
                 response = orig_response[start : i + 1]
                 try:
                     action_dict = json.loads(response)
-                    return action_dict
+                    action = action_from_dict(action_dict)
+                    return action
                 except json.JSONDecodeError as e:
                     raise LLMOutputError(
                         'Invalid JSON in response. Please make sure the response is a valid JSON object.'
                     ) from e
     raise LLMOutputError('No valid JSON object found in response.')
-
 
 def my_encoder(obj):
     """

--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -13,7 +13,7 @@ from .instructions import instructions
 from .registry import all_microagents
 
 
-def parse_response(orig_response: str):
+def parse_response(orig_response: str) -> Action:
     depth = 0
     start = -1
     for i, char in enumerate(orig_response):
@@ -34,6 +34,7 @@ def parse_response(orig_response: str):
                         'Invalid JSON in response. Please make sure the response is a valid JSON object.'
                     ) from e
     raise LLMOutputError('No valid JSON object found in response.')
+
 
 def my_encoder(obj):
     """

--- a/agenthub/micro/typo_fixer_agent/agent.yaml
+++ b/agenthub/micro/typo_fixer_agent/agent.yaml
@@ -1,0 +1,5 @@
+name: TypoFixerAgent
+description: Fixes typos in files in the current working directory
+inputs: {}
+outputs:
+  summary: string

--- a/agenthub/micro/typo_fixer_agent/prompt.md
+++ b/agenthub/micro/typo_fixer_agent/prompt.md
@@ -1,0 +1,46 @@
+# Task
+You are a proofreader tasked with fixing typos in the files in your current working directory. Your goal is to:
+1. Scan the files for typos
+2. Overwrite the files with the typos fixed
+3. Provide a summary of the typos fixed
+
+## Available Actions
+{{ instructions.actions.read }}
+{{ instructions.actions.write }}
+{{ instructions.actions.run }}
+{{ instructions.actions.think }}
+{{ instructions.actions.finish }}
+
+To complete this task:
+1. Use the `read` action to read the contents of the files in your current working directory. Make sure to provide the file path in the format `'./file_name.ext'`.
+2. Use the `think` action to analyze the contents and identify typos.
+3. Use the `write` action to create new versions of the files with the typos fixed.
+  - Overwrite the original files with the corrected content. Make sure to provide the file path in the format `'./file_name.ext'`.
+4. Use the `think` action to generate a summary of the typos fixed, including the original and fixed versions of each typo, and the file(s) they were found in.
+5. Use the `finish` action to return the summary in the `outputs.summary` field.
+
+Do NOT finish until you have fixed all the typos and generated a summary.
+
+## History
+{{ instructions.history_truncated }}
+{{ to_json(state.history[-5:]) }}
+
+## Format
+{{ instructions.format.action }}
+
+For example, if you want to use the read action to read the contents of a file named example.txt, your response should look like this:
+{
+  "action": "read",
+  "args": {
+    "path": "./example.txt"
+  }
+}
+
+Similarly, if you want to use the write action to write content to a file named output.txt, your response should look like this:
+{
+  "action": "write",
+  "args": {
+    "path": "./output.txt",
+    "content": "This is the content to be written to the file."
+  }
+}

--- a/tests/unit/test_response_parsing.py
+++ b/tests/unit/test_response_parsing.py
@@ -1,0 +1,72 @@
+import pytest
+from agenthub.micro.agent import parse_response, LLMOutputError
+
+def test_parse_single_complete_json():
+    input_response = """
+    {
+        "action": "think",
+        "args": {
+            "thought": "The following typos were fixed:\\n* 'futur' -> 'future'\\n* 'imagin' -> 'imagine'\\n* 'techological' -> 'technological'\\n* 'responsability' -> 'responsibility'\\nThe corrected file is ./short_essay.txt."
+        }
+    }
+    """
+    expected = {
+        "action": "think",
+        "args": {
+            "thought": "The following typos were fixed:\n* 'futur' -> 'future'\n* 'imagin' -> 'imagine'\n* 'techological' -> 'technological'\n* 'responsability' -> 'responsibility'\nThe corrected file is ./short_essay.txt."
+        }
+    }
+    assert parse_response(input_response) == expected
+
+def test_parse_json_with_surrounding_text():
+    input_response = """
+    Some initial text that is not JSON formatted.
+    {
+        "action": "update",
+        "args": {
+            "path": "./updated_file.txt",
+            "content": "Updated text content here..."
+        }
+    }
+    Some trailing text that is also not JSON formatted.
+    """
+    expected = {
+        "action": "update",
+        "args": {
+            "path": "./updated_file.txt",
+            "content": "Updated text content here..."
+        }
+    }
+    assert parse_response(input_response) == expected
+
+def test_parse_first_of_multiple_jsons():
+    input_response = """
+    I will firstly do
+    {
+        "action": "write",
+        "args": {
+            "path": "./short_essay.txt",
+            "content": "Text content here..."
+        }
+    }
+    Then I will continue with
+    {
+        "action": "think",
+        "args": {
+            "thought": "This should not be parsed."
+        }
+    }
+    """
+    expected = {
+        "action": "write",
+        "args": {
+            "path": "./short_essay.txt",
+            "content": "Text content here..."
+        }
+    }
+    assert parse_response(input_response) == expected
+
+def test_invalid_json_raises_error():
+    input_response = '{"action": "write", "args": { "path": "./short_essay.txt", "content": "Missing closing brace"'
+    with pytest.raises(LLMOutputError):
+        parse_response(input_response)

--- a/tests/unit/test_response_parsing.py
+++ b/tests/unit/test_response_parsing.py
@@ -5,6 +5,7 @@ from opendevin.events.action import (
     FileWriteAction,
 )
 
+
 def test_parse_single_complete_json():
     input_response = """
     {
@@ -16,6 +17,7 @@ def test_parse_single_complete_json():
     """
     expected = AgentThinkAction(thought="The following typos were fixed:\n* 'futur' -> 'future'\n* 'imagin' -> 'imagine'\n* 'techological' -> 'technological'\n* 'responsability' -> 'responsibility'\nThe corrected file is ./short_essay.txt.")
     assert parse_response(input_response) == expected
+
 
 def test_parse_json_with_surrounding_text():
     input_response = """
@@ -31,6 +33,7 @@ def test_parse_json_with_surrounding_text():
     """
     expected = FileWriteAction(path="./updated_file.txt", content="Updated text content here...")
     assert parse_response(input_response) == expected
+
 
 def test_parse_first_of_multiple_jsons():
     input_response = """
@@ -52,6 +55,7 @@ def test_parse_first_of_multiple_jsons():
     """
     expected = FileWriteAction(path="./short_essay.txt", content="Text content here...")
     assert parse_response(input_response) == expected
+
 
 def test_invalid_json_raises_error():
     input_response = '{"action": "write", "args": { "path": "./short_essay.txt", "content": "Missing closing brace"'

--- a/tests/unit/test_response_parsing.py
+++ b/tests/unit/test_response_parsing.py
@@ -1,5 +1,9 @@
 import pytest
 from agenthub.micro.agent import parse_response, LLMOutputError
+from opendevin.events.action import (
+    AgentThinkAction,
+    FileWriteAction,
+)
 
 def test_parse_single_complete_json():
     input_response = """
@@ -10,19 +14,14 @@ def test_parse_single_complete_json():
         }
     }
     """
-    expected = {
-        "action": "think",
-        "args": {
-            "thought": "The following typos were fixed:\n* 'futur' -> 'future'\n* 'imagin' -> 'imagine'\n* 'techological' -> 'technological'\n* 'responsability' -> 'responsibility'\nThe corrected file is ./short_essay.txt."
-        }
-    }
+    expected = AgentThinkAction(thought="The following typos were fixed:\n* 'futur' -> 'future'\n* 'imagin' -> 'imagine'\n* 'techological' -> 'technological'\n* 'responsability' -> 'responsibility'\nThe corrected file is ./short_essay.txt.")
     assert parse_response(input_response) == expected
 
 def test_parse_json_with_surrounding_text():
     input_response = """
     Some initial text that is not JSON formatted.
     {
-        "action": "update",
+        "action": "write",
         "args": {
             "path": "./updated_file.txt",
             "content": "Updated text content here..."
@@ -30,13 +29,7 @@ def test_parse_json_with_surrounding_text():
     }
     Some trailing text that is also not JSON formatted.
     """
-    expected = {
-        "action": "update",
-        "args": {
-            "path": "./updated_file.txt",
-            "content": "Updated text content here..."
-        }
-    }
+    expected = FileWriteAction(path="./updated_file.txt", content="Updated text content here...")
     assert parse_response(input_response) == expected
 
 def test_parse_first_of_multiple_jsons():
@@ -57,13 +50,7 @@ def test_parse_first_of_multiple_jsons():
         }
     }
     """
-    expected = {
-        "action": "write",
-        "args": {
-            "path": "./short_essay.txt",
-            "content": "Text content here..."
-        }
-    }
+    expected = FileWriteAction(path="./short_essay.txt", content="Text content here...")
     assert parse_response(input_response) == expected
 
 def test_invalid_json_raises_error():


### PR DESCRIPTION
## Description
This pull request introduces a new micro-agent named TypoFixerAgent that scans file(s) with the given path and corrects typos in-place. The agent completely rewrites the document to ensure all identified typos are corrected.

## Implementation
- Added `TypoFixerAgent` in `agenthub/micro/typo_fixer_agent/agent.py`.
- Implemented the agent using an approach where the document is completely rewritten with typos fixed.
- Modified the `parse_response` function in `agenthub/micro/agent.py` to more accurately extract the first complete JSON object from responses. This change improves the agent's ability to handle multiple JSON objects, ensuring more reliable parsing and processing.

## Related Issue
Fixes #1514

## Testing
- [x] Verified that the agent successfully identifies and fixes typos in sample documents.
- [x] Ensured that the modified `parse_response` function accurately handles varied JSON response scenarios with tests.
- [x] Test with **groq/llama3-70b-8192**.

https://github.com/OpenDevin/OpenDevin/assets/5805397/3826bee4-dfeb-4937-af60-219b25aa16d1


- [x] Test with **llama3:8b-instruct-q8_0**. It wasn't really able to get to fix the file. I try twice and it manage to read it and to try to find the typos, but got stuck trying to many times.
<img width="1348" alt="test_llama-8B" src="https://github.com/OpenDevin/OpenDevin/assets/5805397/6679556f-e203-40e7-ac7e-0f713d386a7d">

## Note for the `parse_response` change:
The earlier version of parse_response struggled with handling responses that included multiple JSON objects intermixed with text. This often happens when an LLM generates output as part of a complex planning process, leading to outputs that combine several actionable JSONs in one response. Here's a simplified example:
```json
Here's my next action:
{
  "action": "write",
  "args": {
    "path": "./short_essay.txt",
    "content": "Some updated content..."
  }
}
Next, I'll summarize the changes:
{
  "action": "think",
  "args": {
    "thought": "Summarizing recent updates."
  }
}
```
### Issue with Previous Parser
The original implementation of `parse_response` used `find()` and `rfind()` to locate the first opening brace `{` and the last closing brace `}` within the string. This approach assumed there was only one JSON object in the entire response and that it spanned from the first { to the last }. This method would fail in cases where multiple JSON objects are present, or where additional text outside the JSON objects includes braces.

### Suggested Improvement
The revised version of `parse_response` iterates through the response character by character, maintaining a depth count to identify complete JSON objects. This approach correctly handles multiple JSON objects in a single response by identifying and processing only the first complete JSON object, thus avoiding the issues with the original method.

Please let me know if you have any questions or suggestions!
