### PR TITLE
refactor: use Pydantic `BaseModel` instead of `dataclass` in `events` folder files

### DIFF
--- a/opendevin/events/action/action.py
+++ b/opendevin/events/action/action.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from opendevin.events.event import Event
@@ -8,7 +7,6 @@ if TYPE_CHECKING:
     from opendevin.controller import AgentController
 
 
-@dataclass
 class Action(Event):
     async def run(self, controller: 'AgentController') -> 'Observation':
         return NullObservation('')

--- a/opendevin/events/action/agent.py
+++ b/opendevin/events/action/agent.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, ClassVar
+
+from pydantic import Field
 
 from opendevin.core.schema import ActionType
 from opendevin.events.observation import (
@@ -14,24 +15,22 @@ if TYPE_CHECKING:
     from opendevin.controller import AgentController
 
 
-@dataclass
 class ChangeAgentStateAction(Action):
     """Fake action, just to notify the client that a task state has changed."""
 
     agent_state: str
     thought: str = ''
-    action: str = ActionType.CHANGE_AGENT_STATE
+    action: ClassVar[str] = ActionType.CHANGE_AGENT_STATE
 
     @property
     def message(self) -> str:
         return f'Agent state changed to {self.agent_state}'
 
 
-@dataclass
 class AgentRecallAction(Action):
     query: str
     thought: str = ''
-    action: str = ActionType.RECALL
+    action: ClassVar[str] = ActionType.RECALL
 
     async def run(self, controller: 'AgentController') -> AgentRecallObservation:
         return AgentRecallObservation(
@@ -44,33 +43,30 @@ class AgentRecallAction(Action):
         return f"Let me dive into my memories to find what you're looking for! Searching for: '{self.query}'. This might take a moment."
 
 
-@dataclass
 class AgentSummarizeAction(Action):
     summary: str
-    action: str = ActionType.SUMMARIZE
+    action: ClassVar[str] = ActionType.SUMMARIZE
 
     @property
     def message(self) -> str:
         return self.summary
 
 
-@dataclass
 class AgentFinishAction(Action):
-    outputs: Dict = field(default_factory=dict)
+    outputs: dict = Field(default_factory=dict)
     thought: str = ''
-    action: str = ActionType.FINISH
+    action: ClassVar[str] = ActionType.FINISH
 
     @property
     def message(self) -> str:
         return "All done! What's next on the agenda?"
 
 
-@dataclass
 class AgentDelegateAction(Action):
     agent: str
     inputs: dict
     thought: str = ''
-    action: str = ActionType.DELEGATE
+    action: ClassVar[str] = ActionType.DELEGATE
 
     async def run(self, controller: 'AgentController') -> Observation:
         await controller.start_delegate(self)

--- a/opendevin/events/action/browse.py
+++ b/opendevin/events/action/browse.py
@@ -1,6 +1,5 @@
 import os
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from opendevin.core.schema import ActionType
 from opendevin.events.observation import BrowserOutputObservation
@@ -11,11 +10,10 @@ if TYPE_CHECKING:
     from opendevin.controller import AgentController
 
 
-@dataclass
 class BrowseURLAction(Action):
     url: str
     thought: str = ''
-    action: str = ActionType.BROWSE
+    action: ClassVar[str] = ActionType.BROWSE
 
     async def run(self, controller: 'AgentController') -> BrowserOutputObservation:  # type: ignore
         asked_url = self.url

--- a/opendevin/events/action/commands.py
+++ b/opendevin/events/action/commands.py
@@ -1,7 +1,6 @@
 import os
 import pathlib
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from opendevin.core import config
 from opendevin.core.schema import ActionType, ConfigType
@@ -15,12 +14,11 @@ if TYPE_CHECKING:
 from opendevin.events.observation import IPythonRunCellObservation
 
 
-@dataclass
 class CmdRunAction(Action):
     command: str
     background: bool = False
     thought: str = ''
-    action: str = ActionType.RUN
+    action: ClassVar[str] = ActionType.RUN
 
     async def run(self, controller: 'AgentController') -> 'Observation':
         return controller.action_manager.run_command(self.command, self.background)
@@ -37,11 +35,10 @@ class CmdRunAction(Action):
         return ret
 
 
-@dataclass
 class CmdKillAction(Action):
     id: int
     thought: str = ''
-    action: str = ActionType.KILL
+    action: ClassVar[str] = ActionType.KILL
 
     async def run(self, controller: 'AgentController') -> 'CmdOutputObservation':
         return controller.action_manager.kill_command(self.id)
@@ -54,11 +51,10 @@ class CmdKillAction(Action):
         return f'**CmdKillAction**\n{self.id}'
 
 
-@dataclass
 class IPythonRunCellAction(Action):
     code: str
     thought: str = ''
-    action: str = ActionType.RUN_IPYTHON
+    action: ClassVar[str] = ActionType.RUN_IPYTHON
 
     async def run(self, controller: 'AgentController') -> 'IPythonRunCellObservation':
         # echo "import math" | execute_cli

--- a/opendevin/events/action/empty.py
+++ b/opendevin/events/action/empty.py
@@ -1,15 +1,14 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ActionType
 
 from .action import Action
 
 
-@dataclass
 class NullAction(Action):
     """An action that does nothing."""
 
-    action: str = ActionType.NULL
+    action: ClassVar[str] = ActionType.NULL
 
     @property
     def message(self) -> str:

--- a/opendevin/events/action/files.py
+++ b/opendevin/events/action/files.py
@@ -1,6 +1,6 @@
 import os
-from dataclasses import dataclass
 from pathlib import Path
+from typing import ClassVar
 
 from opendevin.core import config
 from opendevin.core.schema import ActionType
@@ -46,7 +46,6 @@ def resolve_path(file_path, working_directory):
     return path_in_host_workspace
 
 
-@dataclass
 class FileReadAction(Action):
     """
     Reads a file from a given path.
@@ -58,7 +57,7 @@ class FileReadAction(Action):
     start: int = 0
     end: int = -1
     thought: str = ''
-    action: str = ActionType.READ
+    action: ClassVar[str] = ActionType.READ
 
     def _read_lines(self, all_lines: list[str]):
         if self.end == -1:
@@ -106,14 +105,13 @@ class FileReadAction(Action):
         return f'Reading file: {self.path}'
 
 
-@dataclass
 class FileWriteAction(Action):
     path: str
     content: str
     start: int = 0
     end: int = -1
     thought: str = ''
-    action: str = ActionType.WRITE
+    action: ClassVar[str] = ActionType.WRITE
 
     def _insert_lines(self, to_insert: list[str], original: list[str]):
         """

--- a/opendevin/events/action/github.py
+++ b/opendevin/events/action/github.py
@@ -1,7 +1,6 @@
 import random
 import string
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import requests
 
@@ -21,7 +20,6 @@ if TYPE_CHECKING:
     from opendevin.controller import AgentController
 
 
-@dataclass
 class GitHubPushAction(Action):
     """This pushes the current branch to github.
 
@@ -39,7 +37,7 @@ class GitHubPushAction(Action):
     owner: str
     repo: str
     branch: str
-    action: str = ActionType.PUSH
+    action: ClassVar[str] = ActionType.PUSH
 
     async def run(self, controller: 'AgentController') -> Observation:
         github_token = config.get(ConfigType.GITHUB_TOKEN)
@@ -85,7 +83,6 @@ class GitHubPushAction(Action):
         return f'Pushing branch {self.branch} to {self.owner}/{self.repo}'
 
 
-@dataclass
 class GitHubSendPRAction(Action):
     """An action to send a github PR.
 
@@ -108,7 +105,7 @@ class GitHubSendPRAction(Action):
     head_repo: str | None
     base: str
     body: str | None
-    action: str = ActionType.SEND_PR
+    action: ClassVar[str] = ActionType.SEND_PR
 
     async def run(self, controller: 'AgentController') -> Observation:
         github_token = config.get(ConfigType.GITHUB_TOKEN)

--- a/opendevin/events/action/message.py
+++ b/opendevin/events/action/message.py
@@ -1,15 +1,14 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ActionType
 
 from .action import Action
 
 
-@dataclass
 class MessageAction(Action):
     content: str
     wait_for_response: bool = False
-    action: str = ActionType.MESSAGE
+    action: ClassVar[str] = ActionType.MESSAGE
 
     @property
     def message(self) -> str:

--- a/opendevin/events/action/tasks.py
+++ b/opendevin/events/action/tasks.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
+
+from pydantic import Field
 
 from opendevin.core.schema import ActionType
 from opendevin.events.observation import NullObservation
@@ -10,13 +11,12 @@ if TYPE_CHECKING:
     from opendevin.controller import AgentController
 
 
-@dataclass
 class AddTaskAction(Action):
     parent: str
     goal: str
-    subtasks: list = field(default_factory=list)
+    subtasks: list = Field(default_factory=list)
     thought: str = ''
-    action: str = ActionType.ADD_TASK
+    action: ClassVar[str] = ActionType.ADD_TASK
 
     async def run(self, controller: 'AgentController') -> NullObservation:  # type: ignore
         if controller.state is not None:
@@ -28,12 +28,11 @@ class AddTaskAction(Action):
         return f'Added task: {self.goal}'
 
 
-@dataclass
 class ModifyTaskAction(Action):
     id: str
     state: str
     thought: str = ''
-    action: str = ActionType.MODIFY_TASK
+    action: ClassVar[str] = ActionType.MODIFY_TASK
 
     async def run(self, controller: 'AgentController') -> NullObservation:  # type: ignore
         if controller.state is not None:

--- a/opendevin/events/event.py
+++ b/opendevin/events/event.py
@@ -1,20 +1,24 @@
-from dataclasses import asdict, dataclass
+from typing import Any
+
+from pydantic import BaseModel, PrivateAttr
 
 
-@dataclass
-class Event:
+class Event(BaseModel):
+    _message: str = PrivateAttr(default=None)
+    _source: str = PrivateAttr(default=None)
+
     def to_memory(self):
-        return asdict(self)
+        return super().model_dump()
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         d = self.to_memory()
         d['message'] = self.message
         return d
 
     @property
     def message(self) -> str:
-        return self._message  # type: ignore [attr-defined]
+        return self._message
 
     @property
     def source(self) -> str:
-        return self._source  # type: ignore [attr-defined]
+        return self._source

--- a/opendevin/events/observation/agent.py
+++ b/opendevin/events/observation/agent.py
@@ -1,18 +1,17 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class AgentStateChangedObservation(Observation):
     """
     This data class represents the result from delegating to another agent
     """
 
     agent_state: str
-    observation: str = ObservationType.AGENT_STATE_CHANGED
+    observation: ClassVar[str] = ObservationType.AGENT_STATE_CHANGED
 
     @property
     def message(self) -> str:

--- a/opendevin/events/observation/browse.py
+++ b/opendevin/events/observation/browse.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass, field
+from typing import ClassVar
+
+from pydantic import Field
 
 from opendevin.core.schema import ObservationType
 from opendevin.events.utils import remove_fields
@@ -6,22 +8,21 @@ from opendevin.events.utils import remove_fields
 from .observation import Observation
 
 
-@dataclass
 class BrowserOutputObservation(Observation):
     """
     This data class represents the output of a browser.
     """
 
     url: str
-    screenshot: str = field(repr=False)  # don't show in repr
+    screenshot: str = Field(repr=False)  # don't show in repr
     status_code: int = 200
     error: bool = False
-    observation: str = ObservationType.BROWSE
+    observation: ClassVar[str] = ObservationType.BROWSE
     # do not include in the memory
-    open_pages_urls: list = field(default_factory=list)
+    open_pages_urls: list = Field(default_factory=list)
     active_page_index: int = -1
-    dom_object: dict = field(default_factory=dict, repr=False)  # don't show in repr
-    axtree_object: dict = field(default_factory=dict, repr=False)  # don't show in repr
+    dom_object: dict = Field(default_factory=dict, repr=False)  # don't show in repr
+    axtree_object: dict = Field(default_factory=dict, repr=False)  # don't show in repr
     last_browser_action: str = ''
     focused_element_bid: str = ''
 

--- a/opendevin/events/observation/commands.py
+++ b/opendevin/events/observation/commands.py
@@ -1,11 +1,10 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class CmdOutputObservation(Observation):
     """
     This data class represents the output of a command.
@@ -14,7 +13,7 @@ class CmdOutputObservation(Observation):
     command_id: int
     command: str
     exit_code: int = 0
-    observation: str = ObservationType.RUN
+    observation: ClassVar[str] = ObservationType.RUN
 
     @property
     def error(self) -> bool:
@@ -25,14 +24,13 @@ class CmdOutputObservation(Observation):
         return f'Command `{self.command}` executed with exit code {self.exit_code}.'
 
 
-@dataclass
 class IPythonRunCellObservation(Observation):
     """
     This data class represents the output of a IPythonRunCellAction.
     """
 
     code: str
-    observation: str = ObservationType.RUN_IPYTHON
+    observation: ClassVar[str] = ObservationType.RUN_IPYTHON
 
     @property
     def error(self) -> bool:

--- a/opendevin/events/observation/delegate.py
+++ b/opendevin/events/observation/delegate.py
@@ -1,18 +1,17 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class AgentDelegateObservation(Observation):
     """
     This data class represents the result from delegating to another agent
     """
 
     outputs: dict
-    observation: str = ObservationType.DELEGATE
+    observation: ClassVar[str] = ObservationType.DELEGATE
 
     @property
     def message(self) -> str:

--- a/opendevin/events/observation/empty.py
+++ b/opendevin/events/observation/empty.py
@@ -1,18 +1,17 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class NullObservation(Observation):
     """
     This data class represents a null observation.
     This is used when the produced action is NOT executable.
     """
 
-    observation: str = ObservationType.NULL
+    observation: ClassVar[str] = ObservationType.NULL
 
     @property
     def message(self) -> str:

--- a/opendevin/events/observation/error.py
+++ b/opendevin/events/observation/error.py
@@ -1,17 +1,16 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class ErrorObservation(Observation):
     """
     This data class represents an error encountered by the agent.
     """
 
-    observation: str = ObservationType.ERROR
+    observation: ClassVar[str] = ObservationType.ERROR
 
     @property
     def message(self) -> str:

--- a/opendevin/events/observation/files.py
+++ b/opendevin/events/observation/files.py
@@ -1,32 +1,30 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class FileReadObservation(Observation):
     """
     This data class represents the content of a file.
     """
 
     path: str
-    observation: str = ObservationType.READ
+    observation: ClassVar[str] = ObservationType.READ
 
     @property
     def message(self) -> str:
         return f'I read the file {self.path}.'
 
 
-@dataclass
 class FileWriteObservation(Observation):
     """
     This data class represents a file write operation
     """
 
     path: str
-    observation: str = ObservationType.WRITE
+    observation: ClassVar[str] = ObservationType.WRITE
 
     @property
     def message(self) -> str:

--- a/opendevin/events/observation/observation.py
+++ b/opendevin/events/observation/observation.py
@@ -1,9 +1,6 @@
-from dataclasses import dataclass
-
 from opendevin.events.event import Event
 
 
-@dataclass
 class Observation(Event):
     content: str
 

--- a/opendevin/events/observation/recall.py
+++ b/opendevin/events/observation/recall.py
@@ -1,12 +1,10 @@
-from dataclasses import dataclass
-from typing import List
+from typing import ClassVar, List
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class AgentRecallObservation(Observation):
     """
     This data class represents a list of memories recalled by the agent.
@@ -14,7 +12,7 @@ class AgentRecallObservation(Observation):
 
     memories: List[str]
     role: str = 'assistant'
-    observation: str = ObservationType.RECALL
+    observation: ClassVar[str] = ObservationType.RECALL
 
     @property
     def message(self) -> str:

--- a/opendevin/events/observation/success.py
+++ b/opendevin/events/observation/success.py
@@ -1,17 +1,16 @@
-from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ObservationType
 
 from .observation import Observation
 
 
-@dataclass
 class SuccessObservation(Observation):
     """
     This data class represents the result of a successful action.
     """
 
-    observation: str = ObservationType.SUCCESS
+    observation: ClassVar[str] = ObservationType.SUCCESS
 
     @property
     def message(self) -> str:

--- a/opendevin/events/stream.py
+++ b/opendevin/events/stream.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Callable, Dict, List
 
 from opendevin.core.logger import opendevin_logger as logger
@@ -8,14 +8,14 @@ from opendevin.core.logger import opendevin_logger as logger
 from .event import Event
 
 
-class EventStreamSubscriber(str, Enum):
+class EventStreamSubscriber(StrEnum):
     AGENT_CONTROLLER = 'agent_controller'
     SERVER = 'server'
     RUNTIME = 'runtime'
     MAIN = 'main'
 
 
-class EventSource(str, Enum):
+class EventSource(StrEnum):
     AGENT = 'agent'
     USER = 'user'
 


### PR DESCRIPTION
close #1634 

**TODO**

- [ ] Modify tests in `tests/unit/test_action_serialization.py` to make sure use the correct type like uses str type for id.
- [ ] Add more tests in `tests/unit/test_observation_serialization.py` 


I think that existing tests lacked full coverage compared to `tests/unit/test_observation_serialization.py` so i expanded the refactor to include the entire `events` folder.

Further more, would it be beneficial to replace all usage of `dataclass` with Pydantic `BaseModel` classes to ensure consistent data validation and type checking across the project?