### PR TITLE
Runnable action

### DIFF
--- a/opendevin/events/action/action.py
+++ b/opendevin/events/action/action.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.events.event import Event
 
 
 @dataclass
 class Action(Event):
-    @property
-    def runnable(self):
-        return False
+    runnable: ClassVar[bool] = False
 
     def to_memory(self):
         d = super().to_memory()

--- a/opendevin/events/action/agent.py
+++ b/opendevin/events/action/agent.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import ClassVar, Dict
 
 from opendevin.core.schema import ActionType
 
@@ -24,10 +24,7 @@ class AgentRecallAction(Action):
     query: str
     thought: str = ''
     action: str = ActionType.RECALL
-
-    @property
-    def runnable(self) -> bool:
-        return True
+    runnable: ClassVar[bool] = True
 
     @property
     def message(self) -> str:

--- a/opendevin/events/action/browse.py
+++ b/opendevin/events/action/browse.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ActionType
 
@@ -10,10 +11,7 @@ class BrowseURLAction(Action):
     url: str
     thought: str = ''
     action: str = ActionType.BROWSE
-
-    @property
-    def runnable(self) -> bool:
-        return True
+    runnable: ClassVar[bool] = True
 
     @property
     def message(self) -> str:

--- a/opendevin/events/action/commands.py
+++ b/opendevin/events/action/commands.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ActionType
 
@@ -11,9 +12,7 @@ class CmdRunAction(Action):
     background: bool = False
     thought: str = ''
     action: str = ActionType.RUN
-
-    def runnable(self) -> bool:
-        return True
+    runnable: ClassVar[bool] = True
 
     @property
     def message(self) -> str:
@@ -32,9 +31,7 @@ class CmdKillAction(Action):
     id: int
     thought: str = ''
     action: str = ActionType.KILL
-
-    def runnable(self) -> bool:
-        return True
+    runnable: ClassVar[bool] = True
 
     @property
     def message(self) -> str:
@@ -49,9 +46,7 @@ class IPythonRunCellAction(Action):
     code: str
     thought: str = ''
     action: str = ActionType.RUN_IPYTHON
-
-    def runnable(self) -> bool:
-        return True
+    runnable: ClassVar[bool] = True
 
     def __str__(self) -> str:
         ret = '**IPythonRunCellAction**\n'

--- a/opendevin/events/action/files.py
+++ b/opendevin/events/action/files.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import ClassVar
 
 from opendevin.core.schema import ActionType
 
@@ -18,10 +19,7 @@ class FileReadAction(Action):
     end: int = -1
     thought: str = ''
     action: str = ActionType.READ
-
-    @property
-    def runnable(self) -> bool:
-        return True
+    runnable: ClassVar[bool] = True
 
     @property
     def message(self) -> str:
@@ -36,10 +34,7 @@ class FileWriteAction(Action):
     end: int = -1
     thought: str = ''
     action: str = ActionType.WRITE
-
-    @property
-    def runnable(self) -> bool:
-        return True
+    runnable: ClassVar[bool] = True
 
     @property
     def message(self) -> str:


### PR DESCRIPTION
This PR proposes to use ClassVar[bool] instead of the runnable property. Despite being in theory a static type hint, ClassVar is read by `@dataclass` and it does a couple of things at runtime:
- doesn't add it to `fields`, which are "true" instance vars
- doesn't add it to `__init__` and other methods that would lead to mypy upset about order of args with default values and without
- doesn't add it in `asdict()` or similar, although it can be accessed with `get_type_hints` (and it will say ClassVar)

All of those were true with it as property, and expected as a class var ("true class var"). It will be inherited as a class var, and it will be accessible for reading via an instance, so `action.runnable` works as it did.

Mypy will be upset now if we ever try `action.runnable = True`, via an instance, but we don't... and shouldn't?
@Umpire2018 @rbren 

Example for FileReadAction:
```
FileReadAction(path='twelve_queens_problem.txt', start=0, end=-1, thought='', action='read')
asdict: {'path': 'twelve_queens_problem.txt', 'start': 0, 'end': -1, 'thought': '', 'action': 'read'}
Classvars:  {'runnable': typing.ClassVar[bool]}
```
(the last one is from `get_type_hints()`)

Example for MessageAction:
```
MessageAction(content='I should start by researching existing solutions to the twelve queens problem in Python.', wait_for_response=False, action='message')
runnable: False
```