### PR TITLE
Docker Post Installation

### DIFF
--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -34,7 +34,8 @@ mv /home/opendevin/.cache/ms-playwright/ /home/enduser/.cache/
 # get the user group of /var/run/docker.sock and set opendevin to that group
 DOCKER_SOCKET_GID=$(stat -c '%g' /var/run/docker.sock)
 echo "Docker socket group id: $DOCKER_SOCKET_GID"
-usermod -aG $DOCKER_SOCKET_GID enduser
+groupadd -g $DOCKER_SOCKET_GID docker
+usermod -aG docker enduser
 
 # switch to the user and start the server
 su enduser -c "cd /app && uvicorn opendevin.server.listen:app --host 0.0.0.0 --port 3000"


### PR DESCRIPTION
Solves #1657 

In this issue, seems the group associated with the group ID is deleted.

[docs.docker.com/engine/install/linux-postinstall](https://docs.docker.com/engine/install/linux-postinstall/)