### PR TITLE
fix: change auto generate logs file permission

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -55,7 +55,7 @@ WORKSPACE_BASE="/Users/admin/OpenDevin/workspace" WORKSPACE_MOUNT_PATH="/Users/a
 poetry run pytest -s ./tests/integration
 ```
 
-Note: in order to run integration tests correctly, please ensure your workspace is empty.
+Note: in order to run integration tests correctly, please ensure your workspace is empty. If you meet package miss problem, make sure running `make install` first to install the necessary packages.
 
 
 ## Regenerate Integration Tests

--- a/tests/integration/regenerate.sh
+++ b/tests/integration/regenerate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eo pipefail
+umask 022
 
 WORKSPACE_MOUNT_PATH=$(pwd)/_test_workspace
 WORKSPACE_BASE=$(pwd)/_test_workspace
@@ -31,6 +32,7 @@ for agent in "${agents[@]}"; do
     rm -rf tests/integration/mock/$agent/test_write_simple_script/*
     mkdir $WORKSPACE_BASE
     echo -e "/exit\n" | SANDBOX_TYPE=$SANDBOX_TYPE WORKSPACE_BASE=$WORKSPACE_BASE \
+      DEBUG=true \
       WORKSPACE_MOUNT_PATH=$WORKSPACE_MOUNT_PATH AGENT=$agent \
       poetry run python ./opendevin/core/main.py \
       -i 10 \

--- a/tests/integration/regenerate.sh
+++ b/tests/integration/regenerate.sh
@@ -32,7 +32,6 @@ for agent in "${agents[@]}"; do
     rm -rf tests/integration/mock/$agent/test_write_simple_script/*
     mkdir $WORKSPACE_BASE
     echo -e "/exit\n" | SANDBOX_TYPE=$SANDBOX_TYPE WORKSPACE_BASE=$WORKSPACE_BASE \
-      DEBUG=true \
       WORKSPACE_MOUNT_PATH=$WORKSPACE_MOUNT_PATH AGENT=$agent \
       poetry run python ./opendevin/core/main.py \
       -i 10 \


### PR DESCRIPTION
The permission of auto generate folder will be `drwxr-xr-x`, file permission will be `-rw-r--r--`. Then the scipt may throw permission error when delete the logs file. Add mask to specify the file permission to solve the problem shown below.

<img width="624" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33971064/f108a2b0-617d-426e-a820-ca90894aba83">
