### PR TITLE
feat: skip deploy-docs in folk repos.

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    if: github.repository == 'OpenDevin/OpenDevin'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,7 +43,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.repository == 'OpenDevin/OpenDevin'
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write # to deploy to Pages


### PR DESCRIPTION
In folk repos, there's no github actions enabled,  the deploy-decs [build] job will be runned(but not used...) and the [deploy] job will be failed:
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/44c102f2-5f88-4b04-a78e-be0f516ee773)
