### PR TITLE
chore: update CI workflows to integrate testing with environment setup

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,3 +1,4 @@
+# File: .github/workflows/run-unit-tests.yml
 name: Run Unit Tests
 
 concurrency:
@@ -12,116 +13,45 @@ on:
 
 jobs:
   test-on-macos:
-    name: Test on macOS
-    runs-on: macos-13
-    env:
-      INSTALL_DOCKER: '0'  # Set to '0' to skip Docker installation
-    strategy:
-      matrix:
-        python-version: ["3.11"]
+    name: Run Unit Tests on MacOS
+    uses: ./.github/workflows/setup-environment.yml
+    with:
+      operating-system: macos-13
+      install-docker: false
+      make-command: install-python-dependencies
+      pytest-args: "./tests/unit -k 'not test_sandbox'"
 
-    steps:
-      - uses: actions/checkout@v4
+  test-only-sandbox-on-macos:
+    name: Run Unit Tests on MacOS (Docker for Sandbox Only)
+    uses: ./.github/workflows/setup-environment.yml
+    with:
+      operating-system: macos-13
+      install-docker: true
+      make-command: install-python-dependencies
+      pytest-args: "-s ./tests/unit/test_sandbox.py"
 
-      - name: Install poetry via pipx
-        run: pipx install poetry
+  test-on-ubuntu:
+    name: Run Unit Tests on Ubuntu
+    uses: ./.github/workflows/setup-environment.yml
+    with:
+      operating-system: ubuntu-latest
+      install-docker: false
+      make-command: install-python-dependencies
+      pytest-args: "./tests/unit -k 'not test_sandbox'"
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
 
-      - name: Install Python dependencies using Poetry
-        run: poetry install
+  test-only-sandbox-on-ubuntu:
+    name: Run Unit Tests on Ubuntu (Docker for Sandbox Only)
+    uses: ./.github/workflows/setup-environment.yml
+    with:
+      operating-system: ubuntu-latest
+      install-docker: true
+      make-command: install-python-dependencies
+      pytest-args: "-s ./tests/unit/test_sandbox.py"
 
-      - name: Install & Start Docker
-        if: env.INSTALL_DOCKER == '1'
-        run: |
-          brew install colima docker
-          colima start
-
-          # For testcontainers to find the Colima socket
-          # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
-          sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
-
-      - name: Build Environment
-        run: make build
-
-      - name: Run Tests
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit -k "not test_sandbox"
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  test-on-linux:
-    name: Test on Linux
-    runs-on: ubuntu-latest
-    env:
-      INSTALL_DOCKER: '0'  # Set to '0' to skip Docker installation
-    strategy:
-      matrix:
-        python-version: ["3.11"]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install poetry via pipx
-        run: pipx install poetry
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
-
-      - name: Install Python dependencies using Poetry
-        run: poetry install --without evaluation
-
-      - name: Build Environment
-        run: make build
-
-      - name: Run Tests
-        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ./tests/unit -k "not test_sandbox"
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  test-for-sandbox:
-    name: Test for Sandbox
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install poetry via pipx
-        run: pipx install poetry
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
-
-      - name: Install Python dependencies using Poetry
-        run: poetry install
-
-      - name: Build Environment
-        run: make build
-
-      - name: Run Integration Test for Sandbox
-        run: |
-          poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml -s ./tests/unit/test_sandbox.py
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_matrix_success:
     name: All Mac/Linux Tests Passed
     runs-on: ubuntu-latest
-    needs: [test-on-macos, test-on-linux, test-for-sandbox]
+    needs: [test-on-macos, test-only-sandbox-on-macos, test-on-ubuntu, test-only-sandbox-on-ubuntu]
     steps:
     - run: echo Done!

--- a/.github/workflows/setup-environment.yml
+++ b/.github/workflows/setup-environment.yml
@@ -1,0 +1,89 @@
+# File: .github/workflows/setup-environment.yml
+name: Setup Development Environment For Test
+
+on:
+  workflow_call:
+    inputs:
+      operating-system:
+        type: string
+        required: true
+        description: 'Operating system to run the job on'
+        enum:
+          - ubuntu-latest
+          - macos-13
+      install-docker:
+        type: boolean
+        required: true
+        description: 'Whether to install Docker'
+      make-command:
+        type: string
+        required: true
+        description: 'Command to run with make'
+        enum:
+          - build
+          - install-python-dependencies
+      pytest-args:
+        type: string
+        required: true
+        description: 'Arguments to pass to pytest'
+
+jobs:
+  setup:
+    runs-on: ${{ inputs.operating-system }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install poetry via pipx
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'poetry'
+
+      - name: Setup INSTALL_DOCKER Environment Variable
+        run: |
+          if [ "${{ inputs.install-docker }}" == "false" ]; then
+            export INSTALL_DOCKER='1'
+          else
+            export INSTALL_DOCKER='0'
+          fi
+          echo "INSTALL_DOCKER is set to $INSTALL_DOCKER"
+
+      - name: Conditionally Install Docker
+        if: inputs.install-docker
+        run: |
+          if [ "${{ runner.os }}" == "Linux" ]; then
+            if command -v docker &> /dev/null; then
+              echo "Docker is already installed on Linux."
+            else
+              curl -fsSL https://get.docker.com -o get-docker.sh
+              sudo sh get-docker.sh
+            fi
+          elif [ "${{ runner.os }}" == "macOS" ]; then
+            brew install colima docker
+            colima start
+
+            # For testcontainers to find the Colima socket
+            # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running
+            sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+          fi
+
+      - name: Build Environment
+        run: make ${{ inputs.make-command }}
+
+      - name: Run Tests
+        run: poetry run pytest --cov=agenthub --cov=opendevin --cov-report=xml ${{ inputs.pytest-args }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          directory: ./coverage/reports/
+          fail_ci_if_error: true
+          files: ./coverage1.xml,./coverage2.xml,!./cache
+          flags: unittests
+          name: codecov-umbrella
+          verbose: true
+          env:
+            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Implement reusable workflow 'setup-environment.yml' to configure the test environment on both macOS and Ubuntu.
- Add back missing `test-only-sandbox-on-macos` in previous commit.