### PR TITLE
fix: a critical bug of sharing _subscribers and _events between class…

### DIFF
--- a/opendevin/events/stream.py
+++ b/opendevin/events/stream.py
@@ -21,9 +21,10 @@ class EventSource(str, Enum):
 
 
 class EventStream:
-    _subscribers: dict[str, Callable] = {}
-    _events: list[Event] = []
-    _lock = asyncio.Lock()
+    def __init__(self):
+        self._subscribers: dict[str, Callable] = {}
+        self._events: list[Event] = []
+        self._lock = asyncio.Lock()
 
     def subscribe(self, id: EventStreamSubscriber, callback: Callable):
         if id in self._subscribers:
@@ -40,9 +41,9 @@ class EventStream:
     # TODO: make this not async
     async def add_event(self, event: Event, source: EventSource):
         async with self._lock:
-            event._id = len(self._events)  # type: ignore [attr-defined]
-            event._timestamp = datetime.now()  # type: ignore [attr-defined]
-            event._source = source  # type: ignore [attr-defined]
+            event._id = len(self._events)  # type: ignore[attr-defined]
+            event._timestamp = datetime.now()  # type: ignore[attr-defined]
+            event._source = source  # type: ignore[attr-defined]
             self._events.append(event)
         for key, fn in self._subscribers.items():
             await fn(event)


### PR DESCRIPTION
fix: a critical bug of sharing _subscribers and _events between class not obj instance, when multi agent running(several browsers opened at the same time), the state management will be messed up.

Open our page in another browser, the eventStream init process will logging this:
![image](https://github.com/OpenDevin/OpenDevin/assets/1708914/ba52ffa2-e850-48d5-a6fe-7f24675f2d02)


