### PR TITLE
docs: fixed typo in launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docker run \
     -v $WORKSPACE_BASE:/opt/workspace_base \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -p 3000:3000 \
-    --add-host host.docker.internal:host-gateway \
+    --add-host host.docker.internal=host-gateway \
     ghcr.io/opendevin/opendevin:0.5
 ```
 


### PR DESCRIPTION
The argument `--add-host host.docker.internal:host-gateway` should be `--add-host host.docker.internal=host-gateway` (with an `=` character).

Solves `Error creating controller: Could not establish connection to host` errors.