### PR TITLE
feat: use sphinx to build our API document

### DIFF
--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/sphinx/make.bat
+++ b/sphinx/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -1,0 +1,32 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../../opendevin'))
+sys.path.insert(0, os.path.abspath('../../'))
+
+
+project = 'opendevin'
+copyright = '2024, opendevin'
+author = 'opendevin'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['sphinx.ext.autodoc']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -1,0 +1,20 @@
+.. opendevin documentation master file, created by
+   sphinx-quickstart on Sun May 12 21:53:48 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to opendevin's documentation!
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules.rst
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/sphinx/source/modules.rst
+++ b/sphinx/source/modules.rst
@@ -1,0 +1,7 @@
+opendevin
+=========
+
+.. toctree::
+   :maxdepth: 4
+
+   opendevin

--- a/sphinx/source/opendevin.controller.rst
+++ b/sphinx/source/opendevin.controller.rst
@@ -1,0 +1,29 @@
+opendevin.controller package
+============================
+
+Submodules
+----------
+
+opendevin.controller.agent module
+---------------------------------
+
+.. automodule:: opendevin.controller.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.controller.agent\_controller module
+---------------------------------------------
+
+.. automodule:: opendevin.controller.agent_controller
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.controller
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.events.action.rst
+++ b/sphinx/source/opendevin.events.action.rst
@@ -1,0 +1,77 @@
+opendevin.events.action package
+===============================
+
+Submodules
+----------
+
+opendevin.events.action.action module
+-------------------------------------
+
+.. automodule:: opendevin.events.action.action
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.action.agent module
+------------------------------------
+
+.. automodule:: opendevin.events.action.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.action.browse module
+-------------------------------------
+
+.. automodule:: opendevin.events.action.browse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.action.commands module
+---------------------------------------
+
+.. automodule:: opendevin.events.action.commands
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.action.empty module
+------------------------------------
+
+.. automodule:: opendevin.events.action.empty
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.action.files module
+------------------------------------
+
+.. automodule:: opendevin.events.action.files
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.action.message module
+--------------------------------------
+
+.. automodule:: opendevin.events.action.message
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.action.tasks module
+------------------------------------
+
+.. automodule:: opendevin.events.action.tasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.events.action
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.events.observation.rst
+++ b/sphinx/source/opendevin.events.observation.rst
@@ -1,0 +1,93 @@
+opendevin.events.observation package
+====================================
+
+Submodules
+----------
+
+opendevin.events.observation.agent module
+-----------------------------------------
+
+.. automodule:: opendevin.events.observation.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.browse module
+------------------------------------------
+
+.. automodule:: opendevin.events.observation.browse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.commands module
+--------------------------------------------
+
+.. automodule:: opendevin.events.observation.commands
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.delegate module
+--------------------------------------------
+
+.. automodule:: opendevin.events.observation.delegate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.empty module
+-----------------------------------------
+
+.. automodule:: opendevin.events.observation.empty
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.error module
+-----------------------------------------
+
+.. automodule:: opendevin.events.observation.error
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.files module
+-----------------------------------------
+
+.. automodule:: opendevin.events.observation.files
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.observation module
+-----------------------------------------------
+
+.. automodule:: opendevin.events.observation.observation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.recall module
+------------------------------------------
+
+.. automodule:: opendevin.events.observation.recall
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.observation.success module
+-------------------------------------------
+
+.. automodule:: opendevin.events.observation.success
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.events.observation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.events.rst
+++ b/sphinx/source/opendevin.events.rst
@@ -1,0 +1,46 @@
+opendevin.events package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   opendevin.events.action
+   opendevin.events.observation
+
+Submodules
+----------
+
+opendevin.events.event module
+-----------------------------
+
+.. automodule:: opendevin.events.event
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.stream module
+------------------------------
+
+.. automodule:: opendevin.events.stream
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.events.utils module
+-----------------------------
+
+.. automodule:: opendevin.events.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.events
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.memory.rst
+++ b/sphinx/source/opendevin.memory.rst
@@ -1,0 +1,37 @@
+opendevin.memory package
+========================
+
+Submodules
+----------
+
+opendevin.memory.condenser module
+---------------------------------
+
+.. automodule:: opendevin.memory.condenser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.memory.history module
+-------------------------------
+
+.. automodule:: opendevin.memory.history
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.memory.memory module
+------------------------------
+
+.. automodule:: opendevin.memory.memory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.memory
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.rst
+++ b/sphinx/source/opendevin.rst
@@ -1,0 +1,22 @@
+opendevin package
+=================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   opendevin.controller
+   opendevin.events
+   opendevin.memory
+   opendevin.runtime
+   opendevin.server
+
+Module contents
+---------------
+
+.. automodule:: opendevin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.runtime.browser.rst
+++ b/sphinx/source/opendevin.runtime.browser.rst
@@ -1,0 +1,21 @@
+opendevin.runtime.browser package
+=================================
+
+Submodules
+----------
+
+opendevin.runtime.browser.browser\_env module
+---------------------------------------------
+
+.. automodule:: opendevin.runtime.browser.browser_env
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.runtime.browser
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.runtime.docker.rst
+++ b/sphinx/source/opendevin.runtime.docker.rst
@@ -1,0 +1,45 @@
+opendevin.runtime.docker package
+================================
+
+Submodules
+----------
+
+opendevin.runtime.docker.exec\_box module
+-----------------------------------------
+
+.. automodule:: opendevin.runtime.docker.exec_box
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.docker.local\_box module
+------------------------------------------
+
+.. automodule:: opendevin.runtime.docker.local_box
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.docker.process module
+---------------------------------------
+
+.. automodule:: opendevin.runtime.docker.process
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.docker.ssh\_box module
+----------------------------------------
+
+.. automodule:: opendevin.runtime.docker.ssh_box
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.runtime.docker
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.runtime.plugins.jupyter.rst
+++ b/sphinx/source/opendevin.runtime.plugins.jupyter.rst
@@ -1,0 +1,10 @@
+opendevin.runtime.plugins.jupyter package
+=========================================
+
+Module contents
+---------------
+
+.. automodule:: opendevin.runtime.plugins.jupyter
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.runtime.plugins.rst
+++ b/sphinx/source/opendevin.runtime.plugins.rst
@@ -1,0 +1,38 @@
+opendevin.runtime.plugins package
+=================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   opendevin.runtime.plugins.jupyter
+   opendevin.runtime.plugins.swe_agent_commands
+
+Submodules
+----------
+
+opendevin.runtime.plugins.mixin module
+--------------------------------------
+
+.. automodule:: opendevin.runtime.plugins.mixin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.plugins.requirement module
+--------------------------------------------
+
+.. automodule:: opendevin.runtime.plugins.requirement
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.runtime.plugins
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.runtime.plugins.swe_agent_commands.rst
+++ b/sphinx/source/opendevin.runtime.plugins.swe_agent_commands.rst
@@ -1,0 +1,21 @@
+opendevin.runtime.plugins.swe\_agent\_commands package
+======================================================
+
+Submodules
+----------
+
+opendevin.runtime.plugins.swe\_agent\_commands.parse\_commands module
+---------------------------------------------------------------------
+
+.. automodule:: opendevin.runtime.plugins.swe_agent_commands.parse_commands
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.runtime.plugins.swe_agent_commands
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.runtime.rst
+++ b/sphinx/source/opendevin.runtime.rst
@@ -1,0 +1,56 @@
+opendevin.runtime package
+=========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   opendevin.runtime.browser
+   opendevin.runtime.docker
+   opendevin.runtime.plugins
+   opendevin.runtime.utils
+
+Submodules
+----------
+
+opendevin.runtime.files module
+------------------------------
+
+.. automodule:: opendevin.runtime.files
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.process module
+--------------------------------
+
+.. automodule:: opendevin.runtime.process
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.runtime module
+--------------------------------
+
+.. automodule:: opendevin.runtime.runtime
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.sandbox module
+--------------------------------
+
+.. automodule:: opendevin.runtime.sandbox
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.runtime
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.runtime.utils.rst
+++ b/sphinx/source/opendevin.runtime.utils.rst
@@ -1,0 +1,29 @@
+opendevin.runtime.utils package
+===============================
+
+Submodules
+----------
+
+opendevin.runtime.utils.singleton module
+----------------------------------------
+
+.. automodule:: opendevin.runtime.utils.singleton
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.runtime.utils.system module
+-------------------------------------
+
+.. automodule:: opendevin.runtime.utils.system
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.runtime.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.server.agent.rst
+++ b/sphinx/source/opendevin.server.agent.rst
@@ -1,0 +1,29 @@
+opendevin.server.agent package
+==============================
+
+Submodules
+----------
+
+opendevin.server.agent.agent module
+-----------------------------------
+
+.. automodule:: opendevin.server.agent.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.server.agent.manager module
+-------------------------------------
+
+.. automodule:: opendevin.server.agent.manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.server.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.server.auth.rst
+++ b/sphinx/source/opendevin.server.auth.rst
@@ -1,0 +1,21 @@
+opendevin.server.auth package
+=============================
+
+Submodules
+----------
+
+opendevin.server.auth.auth module
+---------------------------------
+
+.. automodule:: opendevin.server.auth.auth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.server.auth
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.server.rst
+++ b/sphinx/source/opendevin.server.rst
@@ -1,0 +1,31 @@
+opendevin.server package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   opendevin.server.agent
+   opendevin.server.auth
+   opendevin.server.session
+
+Submodules
+----------
+
+opendevin.server.listen module
+------------------------------
+
+.. automodule:: opendevin.server.listen
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.server
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sphinx/source/opendevin.server.session.rst
+++ b/sphinx/source/opendevin.server.session.rst
@@ -1,0 +1,37 @@
+opendevin.server.session package
+================================
+
+Submodules
+----------
+
+opendevin.server.session.manager module
+---------------------------------------
+
+.. automodule:: opendevin.server.session.manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.server.session.msg\_stack module
+------------------------------------------
+
+.. automodule:: opendevin.server.session.msg_stack
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+opendevin.server.session.session module
+---------------------------------------
+
+.. automodule:: opendevin.server.session.session
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: opendevin.server.session
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Because our codebase become larger and larger. I find it is inefficiency to see every line code to catch up our latest progress. I prefer to build a API doc for us to do quick browser.

Solution for building API doc:
1. Pydocs
It is build-in module in python. But find it canot satisfied my requirement, and operation is tedious, I even need to manually  generate every sub module by myself.
2. Sphinx (Prefer)
Sphinx [[github](https://github.com/sphinx-doc/sphinx)] [[doc](https://www.sphinx-doc.org/en/master/)] is a popular open source project to create intelligent and beautiful documentation. After some investigation, I think the final website is better than pydocs. So I choose it.
3. Others
Not sure whether there exist better open source solution. Sphinx already solve my problem. But welcome any other suggestions.

What this PR do:

1. It will show all modules and their sub module architecture.
5. It will show the function signature and class defnition.
6. You can search function/class in website.

I only add the source directory, and ignore the build directory. In this way, we can keep commit clear and small. But when your want to browser the doc, you need to build it manually. I will add some cmd for building in the future PR. 

How to run:
Go to `sphinx` directory run `make clean & make html`, then html file will generate in `sphinx/build` directory. Open index.html in your browser.

How to update:
Go to `sphinx` directory, run `sphinx-apidoc -o source ../opendevin -f `, then do `make clean & make html`. 

Website example:

<img width="300" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33971064/96473c5a-0c0a-41a5-b65e-f9fbebc76364">

<img width="300" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33971064/d57e091c-384c-4802-b699-bbab89ef0670">

<img width="300" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33971064/ebf9f031-c042-4d4c-807f-6efefbd8ebdb">
