### PR TITLE
Use custom JSON with repairs in monologue-like agents

### DIFF
--- a/agenthub/planner_agent/prompt.py
+++ b/agenthub/planner_agent/prompt.py
@@ -175,9 +175,12 @@ def parse_response(response: str) -> Action:
     Returns:
     - Action: A valid next action to perform from model output
     """
+    # attempt to load the JSON dict from the response
     action_dict = json.loads(response)
+
     if 'contents' in action_dict:
         # The LLM gets confused here. Might as well be robust
         action_dict['content'] = action_dict.pop('contents')
+
     action = action_from_dict(action_dict)
     return action

--- a/tests/unit/test_response_parsing.py
+++ b/tests/unit/test_response_parsing.py
@@ -1,13 +1,23 @@
 import pytest
 
-from agenthub.micro.agent import LLMOutputError, parse_response
+from agenthub.micro.agent import parse_response as parse_response_micro
+from agenthub.monologue_agent.utils.prompts import (
+    parse_action_response as parse_response_monologue,
+)
+from agenthub.planner_agent.prompt import parse_response as parse_response_planner
+from opendevin.core.exceptions import LLMOutputError
+from opendevin.core.utils.json import loads as custom_loads
 from opendevin.events.action import (
     FileWriteAction,
     MessageAction,
 )
 
 
-def test_parse_single_complete_json():
+@pytest.mark.parametrize(
+    'parse_response_module',
+    [parse_response_micro, parse_response_planner, parse_response_monologue],
+)
+def test_parse_single_complete_json(parse_response_module):
     input_response = """
     {
         "action": "message",
@@ -19,10 +29,15 @@ def test_parse_single_complete_json():
     expected = MessageAction(
         "The following typos were fixed:\n* 'futur' -> 'future'\n* 'imagin' -> 'imagine'\n* 'techological' -> 'technological'\n* 'responsability' -> 'responsibility'\nThe corrected file is ./short_essay.txt."
     )
-    assert parse_response(input_response) == expected
+    result = parse_response_module(input_response)
+    assert result == expected
 
 
-def test_parse_json_with_surrounding_text():
+@pytest.mark.parametrize(
+    'parse_response_module',
+    [parse_response_micro, parse_response_planner, parse_response_monologue],
+)
+def test_parse_json_with_surrounding_text(parse_response_module):
     input_response = """
     Some initial text that is not JSON formatted.
     {
@@ -37,10 +52,15 @@ def test_parse_json_with_surrounding_text():
     expected = FileWriteAction(
         path='./updated_file.txt', content='Updated text content here...'
     )
-    assert parse_response(input_response) == expected
+    result = parse_response_module(input_response)
+    assert result == expected
 
 
-def test_parse_first_of_multiple_jsons():
+@pytest.mark.parametrize(
+    'parse_response_module',
+    [parse_response_micro, parse_response_planner, parse_response_monologue],
+)
+def test_parse_first_of_multiple_jsons(parse_response_module):
     input_response = """
     I will firstly do
     {
@@ -59,10 +79,18 @@ def test_parse_first_of_multiple_jsons():
     }
     """
     expected = FileWriteAction(path='./short_essay.txt', content='Text content here...')
-    assert parse_response(input_response) == expected
+    result = parse_response_module(input_response)
+    assert result == expected
 
 
 def test_invalid_json_raises_error():
-    input_response = '{"action": "write", "args": { "path": "./short_essay.txt", "content": "Missing closing brace"'
+    # This should fail if repair_json is able to fix this faulty JSON
+    input_response = '{"action": "write", "args": { "path": "./short_essay.txt", "content": "Missing closing brace" }'
     with pytest.raises(LLMOutputError):
-        parse_response(input_response)
+        custom_loads(input_response)
+
+
+def test_no_json_found():
+    input_response = 'This is just a string with no JSON object.'
+    with pytest.raises(LLMOutputError):
+        custom_loads(input_response)


### PR DESCRIPTION
- move json utility additions to the custom json parsing
- apply it to the monologue-like agents, planner, monologue, micro
- for monologue, this replaces the attempt to use the lengthiest JSON string with an attempt to use the first JSON 
(CC: @isavita )
