### PR TITLE
Support specify timeout for long running tasks

### DIFF
--- a/opendevin/runtime/docker/exec_box.py
+++ b/opendevin/runtime/docker/exec_box.py
@@ -106,7 +106,9 @@ class DockerExecBox(Sandbox):
         bg_cmd = self.background_commands[id]
         return bg_cmd.read_logs()
 
-    def execute(self, cmd: str) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+        timeout = timeout if timeout is not None else self.timeout
+
         # TODO: each execute is not stateful! We need to keep track of the current working directory
         def run_command(container, command):
             return container.exec_run(
@@ -119,7 +121,7 @@ class DockerExecBox(Sandbox):
                 run_command, self.container, self.get_exec_cmd(cmd)
             )
             try:
-                exit_code, logs = future.result(timeout=self.timeout)
+                exit_code, logs = future.result(timeout=timeout)
             except concurrent.futures.TimeoutError:
                 logger.exception(
                     'Command timed out, killing process...', exc_info=False

--- a/opendevin/runtime/docker/exec_box.py
+++ b/opendevin/runtime/docker/exec_box.py
@@ -106,7 +106,7 @@ class DockerExecBox(Sandbox):
         bg_cmd = self.background_commands[id]
         return bg_cmd.read_logs()
 
-    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: int | None = None) -> tuple[int, str]:
         timeout = timeout if timeout is not None else self.timeout
 
         # TODO: each execute is not stateful! We need to keep track of the current working directory

--- a/opendevin/runtime/docker/local_box.py
+++ b/opendevin/runtime/docker/local_box.py
@@ -33,14 +33,15 @@ class LocalBox(Sandbox):
         atexit.register(self.cleanup)
         super().__init__()
 
-    def execute(self, cmd: str) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+        timeout = timeout if timeout is not None else self.timeout
         try:
             completed_process = subprocess.run(
                 cmd,
                 shell=True,
                 text=True,
                 capture_output=True,
-                timeout=self.timeout,
+                timeout=timeout,
                 cwd=config.workspace_base,
                 env=self._env,
             )

--- a/opendevin/runtime/docker/local_box.py
+++ b/opendevin/runtime/docker/local_box.py
@@ -33,7 +33,7 @@ class LocalBox(Sandbox):
         atexit.register(self.cleanup)
         super().__init__()
 
-    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: int | None = None) -> tuple[int, str]:
         timeout = timeout if timeout is not None else self.timeout
         try:
             completed_process = subprocess.run(

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -343,7 +343,9 @@ class DockerSSHBox(Sandbox):
             f'Command: "{cmd}" timed out. Sending SIGINT to the process: {command_output}',
         )
 
-    def execute(self, cmd: str) -> Tuple[int, str]:
+    def execute(self, cmd: str, timeout: float | None = None) -> Tuple[int, str]:
+        timeout = timeout if timeout is not None else self.timeout
+
         commands = split_bash_commands(cmd)
         if len(commands) > 1:
             all_output = ''
@@ -356,7 +358,7 @@ class DockerSSHBox(Sandbox):
                     return exit_code, all_output
             return 0, all_output
         self.ssh.sendline(cmd)
-        success = self.ssh.prompt(timeout=self.timeout)
+        success = self.ssh.prompt(timeout=timeout)
         if not success:
             logger.exception('Command timed out, killing process...', exc_info=False)
             return self._send_interrupt(cmd)
@@ -389,7 +391,7 @@ class DockerSSHBox(Sandbox):
             self.ssh.prompt()
             exit_code_str = self.ssh.before.decode('utf-8')
             logger.debug(f'WAITING FOR exit code: {exit_code_str}')
-            if time.time() - _start_time > self.timeout:
+            if time.time() - _start_time > timeout:
                 return self._send_interrupt(
                     cmd, command_output, ignore_last_output=True
                 )

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -342,7 +342,7 @@ class DockerSSHBox(Sandbox):
             f'Command: "{cmd}" timed out. Sending SIGINT to the process: {command_output}',
         )
 
-    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: int | None = None) -> tuple[int, str]:
         timeout = timeout if timeout is not None else self.timeout
 
         commands = split_bash_commands(cmd)

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -8,7 +8,6 @@ import time
 import uuid
 from collections import namedtuple
 from glob import glob
-from typing import Tuple
 
 import docker
 from pexpect import pxssh
@@ -343,7 +342,7 @@ class DockerSSHBox(Sandbox):
             f'Command: "{cmd}" timed out. Sending SIGINT to the process: {command_output}',
         )
 
-    def execute(self, cmd: str, timeout: float | None = None) -> Tuple[int, str]:
+    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
         timeout = timeout if timeout is not None else self.timeout
 
         commands = split_bash_commands(cmd)

--- a/opendevin/runtime/e2b/sandbox.py
+++ b/opendevin/runtime/e2b/sandbox.py
@@ -72,7 +72,7 @@ class E2BBox(Sandbox):
         assert isinstance(proc, E2BProcess)
         return '\n'.join([m.line for m in proc.output_messages])
 
-    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: int | None = None) -> tuple[int, str]:
         timeout = timeout if timeout is not None else self.timeout
         process = self.sandbox.process.start(cmd, env_vars=self._env)
         try:

--- a/opendevin/runtime/e2b/sandbox.py
+++ b/opendevin/runtime/e2b/sandbox.py
@@ -72,10 +72,11 @@ class E2BBox(Sandbox):
         assert isinstance(proc, E2BProcess)
         return '\n'.join([m.line for m in proc.output_messages])
 
-    def execute(self, cmd: str) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+        timeout = timeout if timeout is not None else self.timeout
         process = self.sandbox.process.start(cmd, env_vars=self._env)
         try:
-            process_output = process.wait(timeout=self.timeout)
+            process_output = process.wait(timeout=timeout)
         except TimeoutException:
             logger.info('Command timed out, killing process...')
             process.kill()

--- a/opendevin/runtime/sandbox.py
+++ b/opendevin/runtime/sandbox.py
@@ -19,7 +19,7 @@ class Sandbox(ABC, PluginMixin):
         self._env[key] = value
 
     @abstractmethod
-    def execute(self, cmd: str) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
         pass
 
     @abstractmethod

--- a/opendevin/runtime/sandbox.py
+++ b/opendevin/runtime/sandbox.py
@@ -19,7 +19,7 @@ class Sandbox(ABC, PluginMixin):
         self._env[key] = value
 
     @abstractmethod
-    def execute(self, cmd: str, timeout: float | None = None) -> tuple[int, str]:
+    def execute(self, cmd: str, timeout: int | None = None) -> tuple[int, str]:
         pass
 
     @abstractmethod


### PR DESCRIPTION
This is part of the modification in https://github.com/OpenDevin/OpenDevin/pull/1468.

This PR allows `.execute` of all sandbox to accept an additional argument (`timeout`) which can override the default `self.timeout` specified at the initialization time of the sandbox.

It is required when setting up the evaluation environment: for some repo like `sympy`, the initialization takes several minutes for python setup and compilation, making it necessary to support manually set a longer timeout for such initialization command.