### PR TITLE
feat: replace `dataclass` with `Pydantic dataclass` in `action` for type validation

### DIFF
--- a/dev_config/python/.pre-commit-config.yaml
+++ b/dev_config/python/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          [types-requests, types-setuptools, types-pyyaml, types-toml]
+          [types-requests, types-setuptools, types-pyyaml, types-toml, pydantic>=2]
         entry: mypy --config-file dev_config/python/mypy.ini opendevin/ agenthub/
         always_run: true
         pass_filenames: false

--- a/dev_config/python/mypy.ini
+++ b/dev_config/python/mypy.ini
@@ -9,3 +9,5 @@ no_implicit_optional = True
 strict_optional = True
 
 exclude = agenthub/monologue_agent/regression
+
+plugins = pydantic.mypy

--- a/opendevin/events/action/action.py
+++ b/opendevin/events/action/action.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
 from typing import ClassVar
+
+from pydantic.dataclasses import dataclass
 
 from opendevin.events.event import Event
 

--- a/opendevin/events/action/agent.py
+++ b/opendevin/events/action/agent.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
 from typing import ClassVar
+
+from pydantic.dataclasses import Field, dataclass
 
 from opendevin.core.schema import ActionType
 
@@ -43,7 +44,7 @@ class AgentSummarizeAction(Action):
 
 @dataclass
 class AgentFinishAction(Action):
-    outputs: dict = field(default_factory=dict)
+    outputs: dict = Field(default_factory=dict)
     thought: str = ''
     action: str = ActionType.FINISH
 
@@ -54,7 +55,7 @@ class AgentFinishAction(Action):
 
 @dataclass
 class AgentRejectAction(Action):
-    outputs: dict = field(default_factory=dict)
+    outputs: dict = Field(default_factory=dict)
     thought: str = ''
     action: str = ActionType.REJECT
 

--- a/opendevin/events/action/browse.py
+++ b/opendevin/events/action/browse.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
 from typing import ClassVar
+
+from pydantic.dataclasses import dataclass
 
 from opendevin.core.schema import ActionType
 

--- a/opendevin/events/action/commands.py
+++ b/opendevin/events/action/commands.py
@@ -1,5 +1,7 @@
-from dataclasses import dataclass
 from typing import ClassVar
+
+from pydantic import StrictInt
+from pydantic.dataclasses import dataclass
 
 from opendevin.core.schema import ActionType
 
@@ -28,7 +30,7 @@ class CmdRunAction(Action):
 
 @dataclass
 class CmdKillAction(Action):
-    id: int
+    id: StrictInt
     thought: str = ''
     action: str = ActionType.KILL
     runnable: ClassVar[bool] = True

--- a/opendevin/events/action/empty.py
+++ b/opendevin/events/action/empty.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 
 from opendevin.core.schema import ActionType
 

--- a/opendevin/events/action/files.py
+++ b/opendevin/events/action/files.py
@@ -1,5 +1,7 @@
-from dataclasses import dataclass
 from typing import ClassVar
+
+from pydantic import StrictInt
+from pydantic.dataclasses import dataclass
 
 from opendevin.core.schema import ActionType
 
@@ -15,8 +17,8 @@ class FileReadAction(Action):
     """
 
     path: str
-    start: int = 0
-    end: int = -1
+    start: StrictInt = 0
+    end: StrictInt = -1
     thought: str = ''
     action: str = ActionType.READ
     runnable: ClassVar[bool] = True
@@ -30,8 +32,8 @@ class FileReadAction(Action):
 class FileWriteAction(Action):
     path: str
     content: str
-    start: int = 0
-    end: int = -1
+    start: StrictInt = 0
+    end: StrictInt = -1
     thought: str = ''
     action: str = ActionType.WRITE
     runnable: ClassVar[bool] = True

--- a/opendevin/events/action/message.py
+++ b/opendevin/events/action/message.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 
 from opendevin.core.schema import ActionType
 

--- a/opendevin/events/action/tasks.py
+++ b/opendevin/events/action/tasks.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from pydantic.dataclasses import Field, dataclass
 
 from opendevin.core.schema import ActionType
 
@@ -9,7 +9,7 @@ from .action import Action
 class AddTaskAction(Action):
     parent: str
     goal: str
-    subtasks: list = field(default_factory=list)
+    subtasks: list = Field(default_factory=list)
     thought: str = ''
     action: str = ActionType.ADD_TASK
 

--- a/opendevin/events/event.py
+++ b/opendevin/events/event.py
@@ -1,4 +1,6 @@
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
+
+from pydantic.dataclasses import dataclass
 
 
 @dataclass


### PR DESCRIPTION
close #1634 

- Introduce Pydantic's Strict Types such as `StrictInt`
- Update test cases to reflect `ValidationError`

cc @li-boxuan @enyst 