### PR TITLE
Fix: Correct `--add-host` Flag Format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docker run \
     -v $WORKSPACE_BASE:/opt/workspace_base \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -p 3000:3000 \
-    --add-host host.docker.internal=host-gateway \
+    --add-host host.docker.internal:host-gateway \
     ghcr.io/opendevin/opendevin:0.5
 ```
 


### PR DESCRIPTION
This PR updates the README to correct the format of the `--add-host` flag used in the Docker run command in the README. 

The previous format `host.docker.internal=host-gateway` was incorrect and resulted in the following error: 
> invalid argument "host.docker.internal=host-gateway" for "--add-host" flag: bad format for add-host: "host.docker.internal=host-gateway" Use code with caution.

This PR fixes the issue by updating the flag to the correct format: `--add-host host-gateway:host.docker.internal`. This ensures that the Docker container can correctly resolve the host.docker.internal hostname to the host machine's gateway IP address.