### PR TITLE
Integration test: exit if no prompt match

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 import io
 import os
 import re
+import sys
 from functools import partial
 
 import pytest
@@ -79,9 +80,10 @@ def mock_completion(*args, test_name, **kwargs):
     for message in messages:
         message_str += message['content']
     mock_response = get_mock_response(test_name, message_str)
-    assert mock_response is not None, (
-        'Mock response for prompt is not found:\n\n' + message_str
-    )
+    if mock_response is None:
+        print('Mock response for prompt is not found:\n\n' + message_str)
+        print('Exiting...')
+        sys.exit(1)
     response = completion(**kwargs, mock_response=mock_response)
     return response
 


### PR DESCRIPTION
Sometimes the test would still pass even if the prompts don't match, either because OpenDevin actually has already finished the task before itself declares success, OR the test assertions are too loose.

We should exit early so that bugs (that cause prompt mismatch) can be uncovered earlier.