### PR TITLE
Add version display to agent status bar

### DIFF
--- a/frontend/src/components/AgentStatusBar.tsx
+++ b/frontend/src/components/AgentStatusBar.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { I18nKey } from "#/i18n/declaration";
 import { RootState } from "#/store";
 import AgentState from "#/types/AgentState";
+import { getVersion } from "#/services/versionService";
 
 const AgentStatusMap: { [k: string]: { message: string; indicator: string } } =
   {
@@ -44,13 +45,23 @@ const AgentStatusMap: { [k: string]: { message: string; indicator: string } } =
 function AgentStatusBar() {
   const { t } = useTranslation();
   const { curAgentState } = useSelector((state: RootState) => state.agent);
+  const [beVersion, setBeVersion] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
-  // TODO: Extend the agent status, e.g.:
-  // - Agent is typing
-  // - Agent is initializing
-  // - Agent is thinking
-  // - Agent is ready
-  // - Agent is not available
+  useEffect(() => {
+    setLoading(true);
+    getVersion()
+      .then((version) => {
+        setBeVersion(version);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, []);
+
   return (
     <div className="flex items-center">
       {curAgentState !== AgentState.LOADING ? (
@@ -60,6 +71,9 @@ function AgentStatusBar() {
           />
           <span className="text-sm text-stone-400">
             {AgentStatusMap[curAgentState].message}
+          </span>
+          <span className="ml-4 text-sm text-stone-400">
+            FE Version: 0.1.0 | BE Version: {loading ? "Loading..." : error ? `Error: ${error}` : beVersion}
           </span>
         </>
       ) : (

--- a/frontend/src/services/versionService.ts
+++ b/frontend/src/services/versionService.ts
@@ -1,0 +1,18 @@
+/**
+ * Service to fetch the backend version from the API endpoint.
+ */
+const getBackendVersion = async (): Promise<string> => {
+  try {
+    const response = await fetch('/api/version');
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    const data = await response.json();
+    return data.version;
+  } catch (error) {
+    console.error('Error fetching backend version:', error);
+    throw error;
+  }
+};
+
+export { getBackendVersion };

--- a/opendevin/server/version/version.py
+++ b/opendevin/server/version/version.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/api/version")
+async def get_version():
+    return {"version": "1.0.0"}


### PR DESCRIPTION
This pull request introduces the display of both frontend (FE) and backend (BE) versions in the Agent Status Bar, along with the necessary backend support for this feature.

- **Agent Status Bar Update**: Modifies `frontend/src/components/AgentStatusBar.tsx` to fetch and display the BE version alongside the FE version. It uses a new service `getVersion` from `#/services/versionService` to fetch the BE version. The component now handles loading and error states for the BE version fetch.
- **Version Service**: Adds a new file `frontend/src/services/versionService.ts` that defines `getBackendVersion`, a function to fetch the BE version from the `/api/version` API endpoint.
- **Backend Version Endpoint**: Adds a new file `opendevin/server/version/version.py` that implements a FastAPI route `/api/version` to return the BE version as "1.0.0".


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OpenDevin/OpenDevin?shareId=5a1ff106-2857-4b94-a11c-e816b14abc8c).