### PR TITLE
Fix frontend browsing screenshot not showing bug, allow link following in markdown

### DIFF
--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -17,8 +17,8 @@ export function handleObservationMessage(message: ObservationMessage) {
       store.dispatch(appendJupyterOutput(message.content));
       break;
     case ObservationType.BROWSE:
-      if (message.screenshot) {
-        store.dispatch(setScreenshotSrc(message.screenshot));
+      if (message.extras?.screenshot) {
+        store.dispatch(setScreenshotSrc(message.extras?.screenshot));
       }
       if (message.extras?.url) {
         store.dispatch(setUrl(message.extras.url));

--- a/frontend/src/types/Message.tsx
+++ b/frontend/src/types/Message.tsx
@@ -21,7 +21,4 @@ export interface ObservationMessage {
 
   // A friendly message that can be put in the chat log
   message: string;
-
-  // optional screenshot
-  screenshot?: string;
 }

--- a/opendevin/runtime/browser/browser_env.py
+++ b/opendevin/runtime/browser/browser_env.py
@@ -23,7 +23,7 @@ class BrowserEnv:
     def __init__(self):
         self.html_text_converter = html2text.HTML2Text()
         # ignore links and images
-        self.html_text_converter.ignore_links = True
+        self.html_text_converter.ignore_links = False
         self.html_text_converter.ignore_images = True
         # use alt text for images
         self.html_text_converter.images_to_alt = True


### PR DESCRIPTION
Fixed the screenshot not showing up in frontend.
Allow browsing observations to contain links so that the agent could follow through URLs