### PR TITLE
Fix workspace paths defaults

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -73,8 +73,8 @@ class AppConfig(metaclass=Singleton):
     runtime: str = 'server'
     file_store: str = 'memory'
     file_store_path: str = '/tmp/file_store'
-    workspace_base: str = os.getcwd()
-    workspace_mount_path: str = os.getcwd()
+    workspace_base: str = os.path.join(os.getcwd(), 'workspace')
+    workspace_mount_path: str | None = None
     workspace_mount_path_in_sandbox: str = '/workspace'
     workspace_mount_rewrite: str | None = None
     cache_dir: str = '/tmp/cache'
@@ -263,6 +263,10 @@ def finalize_config(config: AppConfig):
     """
     More tweaks to the config after it's been loaded.
     """
+
+    # Set workspace_mount_path if not set by the user
+    if config.workspace_mount_path is None:
+        config.workspace_mount_path = os.path.abspath(config.workspace_base)
 
     # In local there is no sandbox, the workspace will have the same pwd as the host
     if config.sandbox_type == 'local':

--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -267,6 +267,7 @@ def finalize_config(config: AppConfig):
     # Set workspace_mount_path if not set by the user
     if config.workspace_mount_path is None:
         config.workspace_mount_path = os.path.abspath(config.workspace_base)
+    config.workspace_base = os.path.abspath(config.workspace_base)
 
     # In local there is no sandbox, the workspace will have the same pwd as the host
     if config.sandbox_type == 'local':


### PR DESCRIPTION
Setting workspace_mount_path to workspace_base was lost in the recent refactoring, this PR restores it. Also default workspace_base to ./workspace.