### PR TITLE
fix: close runtime after main completion

### DIFF
--- a/opendevin/core/main.py
+++ b/opendevin/core/main.py
@@ -119,6 +119,7 @@ async def main(
         await asyncio.sleep(1)  # Give back control for a tick, so the agent can run
 
     await controller.close()
+    runtime.close()
     return controller.get_state()
 
 


### PR DESCRIPTION
In the evaluation, I found that the number of browser processes will increase as the evaluation progresses -- until it brings the system to OOM.

I think This PR might fixes this by properly clean-up runtime resource when `main` finishes.