### PR TITLE
ssh_box: Shutdown container when fail to start ssh session

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -253,7 +253,13 @@ class DockerSSHBox(Sandbox):
                     raise e
                 time.sleep(5)
         self.setup_user()
-        self.start_ssh_session()
+
+        try:
+            self.start_ssh_session()
+        except pxssh.ExceptionPxssh as e:
+            self.close()
+            raise e
+
         # make sure /tmp always exists
         self.execute('mkdir -p /tmp')
         # set git config


### PR DESCRIPTION
I have seen this many times, both locally and on CI. Although the chance is low (less than 10% for me), sometimes OpenDevin fails to start a ssh session, and exits without shutting down containers, leaving them as zombies. This PR makes sure the close method is called before it shuts down.


With this PR, when the program exits due to ssh connection error, the container correctly exits:
<img width="1320" alt="Screenshot 2024-05-18 at 12 54 57 AM" src="https://github.com/OpenDevin/OpenDevin/assets/25746010/5fff5f74-b9b0-4ae1-8215-3fa43a955beb">

Just to show you there's no running container now:
<img width="1185" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/25746010/dce93c5b-fe3d-4885-b83f-3437c2efa258">

