### PR TITLE
Allow code coverage to be zero for PRs

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        threshold: 10% # allow patch coverage to be lower than project coverage by at most 10%
+        threshold: 100% # allow patch coverage to be lower than project coverage by any amount
     project:
       default:
         threshold: 5% # allow project coverage to drop at most 5%


### PR DESCRIPTION
Currently, CodeCov rejects a PR if its coverage is more than 10% lower than project coverage. Sometimes a PR is either hard to test, or cannot be tested completely, especially for small PRs. Although codecov check doesn't block the PR and one can still merge it, it is truly annoying.

This PR allows the patch/PR coverage to be zero - effectively allowing any PR as long as it doesn't decrease the whole project's coverage by 5%.