### PR TITLE
remove codecov annotations

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -12,3 +12,5 @@ coverage:
         threshold: 5% # allow project coverage to drop at most 5%
 
 comment: false
+github_checks:
+    annotations: false


### PR DESCRIPTION
I find these make it harder to review code

<img width="734" alt="Screenshot 2024-05-18 at 11 28 29 AM" src="https://github.com/OpenDevin/OpenDevin/assets/7611973/90c5e502-1083-4b4b-8918-ccce6b43afcc">
