### PR TITLE
Add documentation regarding how to fix github issues with OpenDevin

### DIFF
--- a/docs/src/pages/faq.tsx
+++ b/docs/src/pages/faq.tsx
@@ -49,7 +49,7 @@ export default function FAQ() {
           , we aim to tackle the challenges faced by Code LLMs in practical
           scenarios, producing works that significantly contribute to the
           community and pave the way for future advancements.
-        <h2 style={{ fontSize: "2rem" }}>Fixing GitHub Issues</h2>
+        </p>
         <h3>How to fix an issue on OpenDevin?</h3>
         <p>
           To fix an issue on GitHub using OpenDevin, send a prompt to OpenDevin asking it to follow these steps:

--- a/docs/src/pages/faq.tsx
+++ b/docs/src/pages/faq.tsx
@@ -51,8 +51,9 @@ export default function FAQ() {
           community and pave the way for future advancements.
         <h2 style={{ fontSize: "2rem" }}>Fixing GitHub Issues</h2>
         <h3>How to fix an issue on OpenDevin?</h3>
+        <h3>How to fix an issue on OpenDevin?</h3>
         <p>
-          To fix an issue on OpenDevin, follow these steps:
+          To fix an issue on GitHub using OpenDevin, send a prompt to OpenDevin asking it to follow these steps:
           <ol>
             <li>Read the issue on <a href="https://github.com/OpenDevin/OpenDevin/issues/1611">GitHub</a></li>
             <li>Clone the repository and check out a new branch</li>

--- a/docs/src/pages/faq.tsx
+++ b/docs/src/pages/faq.tsx
@@ -49,6 +49,26 @@ export default function FAQ() {
           , we aim to tackle the challenges faced by Code LLMs in practical
           scenarios, producing works that significantly contribute to the
           community and pave the way for future advancements.
+        <h2 style={{ fontSize: "2rem" }}>Fixing GitHub Issues</h2>
+        <h3>How to fix an issue on OpenDevin?</h3>
+        <p>
+          To fix an issue on OpenDevin, follow these steps:
+          <ol>
+            <li>Read the issue on <a href="https://github.com/OpenDevin/OpenDevin/issues/1611">GitHub</a></li>
+            <li>Clone the repository and check out a new branch</li>
+            <li>Based on the instructions in the issue description, modify files to fix the issue</li>
+            <li>Push the resulting output to GitHub using the GITHUB_TOKEN environment variable</li>
+            <li>Tell me the link that I need to go to to send a pull request</li>
+          </ol>
+          Before you run OpenDevin, you can do:
+          <pre>
+            export SANDBOX_ENV_GITHUB_TOKEN=XXX
+          </pre>
+          where XXX is a GitHub token that you created that has permissions to push to the OpenDevin repo. If you don’t have write permission to the OpenDevin repo, you might need to change that to:
+          <pre>
+            4. Push the resulting output to my fork at https://github.com/USERNAME/OpenDevin/ using the GITHUB_TOKEN environment variable
+          </pre>
+          where USERNAME is your GitHub username.
         </p>
       </div>
     </Layout>

--- a/docs/src/pages/faq.tsx
+++ b/docs/src/pages/faq.tsx
@@ -51,7 +51,6 @@ export default function FAQ() {
           community and pave the way for future advancements.
         <h2 style={{ fontSize: "2rem" }}>Fixing GitHub Issues</h2>
         <h3>How to fix an issue on OpenDevin?</h3>
-        <h3>How to fix an issue on OpenDevin?</h3>
         <p>
           To fix an issue on GitHub using OpenDevin, send a prompt to OpenDevin asking it to follow these steps:
           <ol>


### PR DESCRIPTION
Fixes #1828

------

This PR was entirely written by OpenDevin using GPT-4o. I had to send three corrections (in English) to fix mistakes, which you can see in the commits. Here were my prompts:

prompt 1
```
Please fix a github issue according to the following procedure:

Read the issue on https://github.com/OpenDevin/OpenDevin/issues/1828

Clone the repository and check out a new branch

Based on the instructions in the issue description, modify files to fix the issue

Push the resulting output to github using the GITHUB_TOKEN environment variable for authentication

Tell me the link that I need to go to to send a pull request
```

prompt 2
```
Thanks, this is a great start! But note that the user of OpenDevin does not need to perform these steps themselves, but rather needs to send a prompt to OpenDevin that describes these steps. Could you modify the documentation so that it says "To fix an issue GitHub using OpenDevin, send a prompt to OpenDevin asking it to follow these steps:"
```

prompt 3
```
It seems the now there are two lines "<h3>How to fix an issue on OpenDevin?</h3>", could you remove one?
```

prompt4
```
I'm getting an error about a missing close paragraph tag, can you fix it?
```