### PR TITLE
fix: Handle invalid exit code conversion

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -1,4 +1,5 @@
 import asyncio
+import traceback
 from typing import Optional, Type
 
 from opendevin.controller.agent import Agent
@@ -109,6 +110,7 @@ class AgentController:
                 logger.info('AgentController task was cancelled')
                 break
             except Exception as e:
+                traceback.print_exc()
                 logger.error(f'Error while running the agent: {e}')
                 await self.report_error(
                     'There was an unexpected error while running the agent', exception=e

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -474,9 +474,15 @@ class DockerSSHBox(Sandbox):
                 return self._send_interrupt(
                     cmd, command_output, ignore_last_output=True
                 )
-        exit_code = int(
-            exit_code_str.replace('echo $?', '').replace('\r\n', '').strip()
-        )
+        cleaned_exit_code_str = exit_code_str.replace('echo $?', '').strip()
+
+        try:
+            exit_code = int(cleaned_exit_code_str)
+        except ValueError:
+            logger.error(f'Invalid exit code: {cleaned_exit_code_str}')
+            # Handle the invalid exit code appropriately (e.g., raise an exception or set a default value)
+            exit_code = -1  # or some other appropriate default value
+
         return exit_code, command_output
 
     def copy_to(self, host_src: str, sandbox_dest: str, recursive: bool = False):


### PR DESCRIPTION
Solves
```
18:17:31 - ACTION
**CmdRunAction**
COMMAND:
echo "#!/bin/bash
edit 1:1 <<EOF
Updated Storybook
EOF" > tmp_script.sh; bash ./tmp_script.sh
Traceback (most recent call last):
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/controller/agent_controller.py", line 105, in _start_step_loop
    await self._step()
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/controller/agent_controller.py", line 231, in _step 
    await self.event_stream.add_event(action, EventSource.AGENT)
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/events/stream.py", line 87, in add_event
    await fn(event)
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/runtime/runtime.py", line 88, in on_event
    observation = await self.run_action(event)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/runtime/runtime.py", line 108, in run_action        
    observation = await getattr(self, action_type)(action)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/runtime/server/runtime.py", line 26, in run
    return self._run_command(action.command, background=action.background)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/runtime/server/runtime.py", line 96, in _run_command
    return self._run_immediately(command)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/runtime/server/runtime.py", line 100, in _run_immediately
    exit_code, output = self.sandbox.execute(command)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/smart/Desktop/GD/OpenDevin/opendevin/runtime/docker/ssh_box.py", line 477, in execute    
    exit_code = int(
                ^^^^
ValueError: invalid literal for int() with base 10: '> > > > > >'
```