### PR TITLE
Fix browser_env hung bug

### DIFF
--- a/opendevin/runtime/browser/browser_env.py
+++ b/opendevin/runtime/browser/browser_env.py
@@ -91,13 +91,22 @@ class BrowserEnv:
                     return obs
 
     def close(self):
+        if not self.process.is_alive():
+            logger.info('BrowserEnv already closed, no need to close again')
+            return
         try:
             self.agent_side.send(('SHUTDOWN', None))
-            self.process.join()
+            self.process.join(5)  # Wait for the process to terminate
+            if self.process.is_alive():
+                logger.error(
+                    'Browser process did not terminate, forcefully terminating...'
+                )
+                self.process.terminate()
+                self.process.join(5)  # Wait for the process to terminate
             self.agent_side.close()
             self.browser_side.close()
         except Exception:
-            pass
+            logger.error('Encountered an error when closing browser env', exc_info=True)
 
     @staticmethod
     def image_to_png_base64_url(image: np.ndarray | Image.Image):


### PR DESCRIPTION
As reported by https://github.com/OpenDevin/OpenDevin/pull/1911, browser_env sometimes fails to exit. It doesn't reproduce every time - for me it's roughly 10% chance to reproduce the bug.

I cannot really tell the root cause, but I add a fix that should do the work regardless. It's a bit hard to add a test for this - we would need to somehow mock web pages and feed to browser env. Let's worry about that later, when browser feature becomes more important and popular in OpenDevin.