### PR TITLE
feat: add metrics related to cost for better observability

### DIFF
--- a/agenthub/SWE_agent/agent.py
+++ b/agenthub/SWE_agent/agent.py
@@ -42,7 +42,7 @@ class SWEAgent(Agent):
         self.running_memory.append(memory)
 
     def _think_act(self, messages: list[dict]) -> tuple[Action, str]:
-        resp = self.llm.completion(
+        resp = self.llm.do_completion(
             messages=messages,
             temperature=0.05,
         )

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -9,7 +9,6 @@ from agenthub.codeact_agent.prompt import (
 )
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
-from opendevin.core.logger import opendevin_logger as logger
 from opendevin.events.action import (
     Action,
     AgentFinishAction,

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -214,7 +214,7 @@ class CodeActAgent(Agent):
                 f'\n\nENVIRONMENT REMINDER: You have {state.max_iterations - state.iteration} turns left to complete the task.'
             )
 
-        response = self.llm.completion(
+        response = self.llm.do_completion(
             messages=messages,
             stop=[
                 '</execute_ipython>',
@@ -223,8 +223,6 @@ class CodeActAgent(Agent):
             ],
             temperature=0.0,
         )
-
-        self.log_cost(response)
 
         action_str: str = parse_response(response)
         state.num_of_chars += sum(
@@ -268,14 +266,3 @@ class CodeActAgent(Agent):
 
     def search_memory(self, query: str) -> list[str]:
         raise NotImplementedError('Implement this abstract method')
-
-    def log_cost(self, response):
-        try:
-            cur_cost = self.llm.completion_cost(response)
-        except Exception:
-            cur_cost = 0
-        logger.info(
-            'Cost: %.2f USD | Accumulated Cost: %.2f USD',
-            cur_cost,
-            self.llm.metrics.total_cost,
-        )

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -10,7 +10,6 @@ from agenthub.codeact_agent.prompt import (
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
 from opendevin.core.logger import opendevin_logger as logger
-from opendevin.core.metrics import opendevin_metrics as metrics
 from opendevin.events.action import (
     Action,
     AgentFinishAction,
@@ -275,9 +274,8 @@ class CodeActAgent(Agent):
             cur_cost = self.llm.completion_cost(response)
         except Exception:
             cur_cost = 0
-        metrics.add_cost(cur_cost)
         logger.info(
             'Cost: %.2f USD | Accumulated Cost: %.2f USD',
             cur_cost,
-            metrics.total_cost,
+            self.llm.metrics.total_cost,
         )

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -10,6 +10,7 @@ from agenthub.codeact_agent.prompt import (
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
 from opendevin.core.logger import opendevin_logger as logger
+from opendevin.core.metrics import opendevin_metrics as metrics
 from opendevin.events.action import (
     Action,
     AgentFinishAction,
@@ -173,7 +174,6 @@ class CodeActAgent(Agent):
         Resets the CodeAct Agent.
         """
         super().reset()
-        self.cost_accumulator = 0
 
     def step(self, state: State) -> Action:
         """
@@ -275,9 +275,9 @@ class CodeActAgent(Agent):
             cur_cost = self.llm.completion_cost(response)
         except Exception:
             cur_cost = 0
-        self.cost_accumulator += cur_cost
+        metrics.add_cost(cur_cost)
         logger.info(
             'Cost: %.2f USD | Accumulated Cost: %.2f USD',
             cur_cost,
-            self.cost_accumulator,
+            metrics.total_cost,
         )

--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -65,7 +65,7 @@ class MicroAgent(Agent):
             latest_user_message=latest_user_message,
         )
         messages = [{'content': prompt, 'role': 'user'}]
-        resp = self.llm.completion(messages=messages)
+        resp = self.llm.do_completion(messages=messages)
         action_resp = resp['choices'][0]['message']['content']
         state.num_of_chars += len(prompt) + len(action_resp)
         action = parse_response(action_resp)

--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -242,7 +242,7 @@ class MonologueAgent(Agent):
             state.background_commands_obs,
         )
         messages = [{'content': prompt, 'role': 'user'}]
-        resp = self.llm.completion(messages=messages)
+        resp = self.llm.do_completion(messages=messages)
         action_resp = resp['choices'][0]['message']['content']
         state.num_of_chars += len(prompt) + len(action_resp)
         action = prompts.parse_action_response(action_resp)

--- a/agenthub/planner_agent/agent.py
+++ b/agenthub/planner_agent/agent.py
@@ -43,7 +43,7 @@ class PlannerAgent(Agent):
             return AgentFinishAction()
         prompt = get_prompt(state)
         messages = [{'content': prompt, 'role': 'user'}]
-        resp = self.llm.completion(messages=messages)
+        resp = self.llm.do_completion(messages=messages)
         action_resp = resp['choices'][0]['message']['content']
         state.num_of_chars += len(prompt) + len(action_resp)
         action = parse_response(action_resp)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -89,6 +89,8 @@ class AgentController:
 
     def update_state_after_step(self):
         self.state.updated_info = []
+        # update metrics especially for cost
+        self.state.metrics = self.agent.llm.metrics
 
     async def report_error(self, message: str, exception: Exception | None = None):
         self.state.error = message

--- a/opendevin/controller/state/state.py
+++ b/opendevin/controller/state/state.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 
 from opendevin.controller.state.task import RootTask
 from opendevin.core.logger import opendevin_logger as logger
+from opendevin.core.metrics import Metrics
 from opendevin.core.schema import AgentState
 from opendevin.events.action import (
     Action,
@@ -30,6 +31,7 @@ class State:
     outputs: dict = field(default_factory=dict)
     error: str | None = None
     agent_state: AgentState = AgentState.LOADING
+    metrics: Metrics = Metrics()
 
     def save_to_session(self, sid: str):
         fs = get_file_store()

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -6,23 +6,23 @@ class Metrics:
     """
 
     def __init__(self) -> None:
-        self._total_cost = 0.0
-        self._costs = []
+        self._total_cost: float = 0.0
+        self._costs: list[float] = []
         self.reset()
 
     @property
     def total_cost(self) -> float:
         return self._total_cost
 
-    @property
-    def costs(self) -> list:
-        return self._costs
-
     @total_cost.setter
     def total_cost(self, value: float) -> None:
         if value < 0:
             raise ValueError('Total cost cannot be negative.')
         self._total_cost = value
+
+    @property
+    def costs(self) -> list:
+        return self._costs
 
     def add_cost(self, value: float) -> None:
         if value < 0:
@@ -52,4 +52,3 @@ class Metrics:
         for key, value in metrics.items():
             logs += f'{key}: {value}\n'
         return logs
-

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -1,0 +1,50 @@
+
+class Metrics():
+    """
+    Metrics class can record various metrics during running and evaluation.
+    Currently we definte the following metrics:
+        total_cost: the total cost of the current LLM.
+    """
+    def __init__(self) -> None:
+        self._total_cost = 0
+        self.reset()
+
+    @property
+    def total_cost(self) -> float:
+        return self._total_cost
+
+    @total_cost.setter
+    def total_cost(self, value: float) -> None:
+        if value < 0:
+            raise ValueError("Total cost cannot be negative.")
+        self._total_cost = value
+    
+    def add_cost(self, value: float) -> None:
+        if value < 0:
+            raise ValueError("Added cost cannot be negative.")
+        self._total_cost += value
+    
+    def reset(self):
+        """
+        Reset all metrics to zero value.
+        """
+        self._total_cost = 0
+
+    def get(self):
+        """
+        Return the metrics in a dictionary.
+        """
+        return {
+            "total_cost": self._total_cost
+        }
+    
+    def log(self):
+        """
+        Log the metrics.
+        """
+        metrics = self.get()
+        logs = ""
+        for key, value in metrics.items():
+            logs += f"{key}: {value}\n"
+        return logs
+    

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -2,23 +2,22 @@ class Metrics:
     """
     Metrics class can record various metrics during running and evaluation.
     Currently we define the following metrics:
-        total_cost: the total cost of the current LLM.
+        accumulated_cost: the total cost (USD $) of the current LLM.
     """
 
     def __init__(self) -> None:
-        self._total_cost: float = 0.0
+        self._accumulated_cost: float = 0.0
         self._costs: list[float] = []
-        self.reset()
 
     @property
-    def total_cost(self) -> float:
-        return self._total_cost
+    def accumulated_cost(self) -> float:
+        return self._accumulated_cost
 
-    @total_cost.setter
-    def total_cost(self, value: float) -> None:
+    @accumulated_cost.setter
+    def accumulated_cost(self, value: float) -> None:
         if value < 0:
             raise ValueError('Total cost cannot be negative.')
-        self._total_cost = value
+        self._accumulated_cost = value
 
     @property
     def costs(self) -> list:
@@ -27,21 +26,14 @@ class Metrics:
     def add_cost(self, value: float) -> None:
         if value < 0:
             raise ValueError('Added cost cannot be negative.')
-        self._total_cost += value
+        self._accumulated_cost += value
         self._costs.append(value)
-
-    def reset(self):
-        """
-        Reset all metrics to zero value.
-        """
-        self._total_cost = 0
-        self._costs = []
 
     def get(self):
         """
         Return the metrics in a dictionary.
         """
-        return {'total_cost': self._total_cost, 'costs': self._costs}
+        return {'accumulated_cost': self._accumulated_cost, 'costs': self._costs}
 
     def log(self):
         """

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -1,7 +1,7 @@
 class Metrics:
     """
     Metrics class can record various metrics during running and evaluation.
-    Currently we definte the following metrics:
+    Currently we define the following metrics:
         total_cost: the total cost of the current LLM.
     """
 

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -7,11 +7,16 @@ class Metrics:
 
     def __init__(self) -> None:
         self._total_cost = 0.0
+        self._costs = []
         self.reset()
 
     @property
     def total_cost(self) -> float:
         return self._total_cost
+
+    @property
+    def costs(self) -> list:
+        return self._costs
 
     @total_cost.setter
     def total_cost(self, value: float) -> None:
@@ -23,18 +28,20 @@ class Metrics:
         if value < 0:
             raise ValueError('Added cost cannot be negative.')
         self._total_cost += value
+        self._costs.append(value)
 
     def reset(self):
         """
         Reset all metrics to zero value.
         """
         self._total_cost = 0
+        self._costs = []
 
     def get(self):
         """
         Return the metrics in a dictionary.
         """
-        return {'total_cost': self._total_cost}
+        return {'total_cost': self._total_cost, 'costs': self._costs}
 
     def log(self):
         """
@@ -46,4 +53,3 @@ class Metrics:
             logs += f'{key}: {value}\n'
         return logs
 
-opendevin_metrics = Metrics()

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -45,3 +45,5 @@ class Metrics:
         for key, value in metrics.items():
             logs += f'{key}: {value}\n'
         return logs
+
+opendevin_metrics = Metrics()

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -1,12 +1,12 @@
-
-class Metrics():
+class Metrics:
     """
     Metrics class can record various metrics during running and evaluation.
     Currently we definte the following metrics:
         total_cost: the total cost of the current LLM.
     """
+
     def __init__(self) -> None:
-        self._total_cost = 0
+        self._total_cost = 0.0
         self.reset()
 
     @property
@@ -16,14 +16,14 @@ class Metrics():
     @total_cost.setter
     def total_cost(self, value: float) -> None:
         if value < 0:
-            raise ValueError("Total cost cannot be negative.")
+            raise ValueError('Total cost cannot be negative.')
         self._total_cost = value
-    
+
     def add_cost(self, value: float) -> None:
         if value < 0:
-            raise ValueError("Added cost cannot be negative.")
+            raise ValueError('Added cost cannot be negative.')
         self._total_cost += value
-    
+
     def reset(self):
         """
         Reset all metrics to zero value.
@@ -34,17 +34,14 @@ class Metrics():
         """
         Return the metrics in a dictionary.
         """
-        return {
-            "total_cost": self._total_cost
-        }
-    
+        return {'total_cost': self._total_cost}
+
     def log(self):
         """
         Log the metrics.
         """
         metrics = self.get()
-        logs = ""
+        logs = ''
         for key, value in metrics.items():
-            logs += f"{key}: {value}\n"
+            logs += f'{key}: {value}\n'
         return logs
-    

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -207,6 +207,8 @@ class LLM:
     def do_completion(self, *args, **kwargs):
         """
         Wrapper for the litellm completion function.
+
+        Check the complete documentation at https://litellm.vercel.app/docs/completion
         """
         resp = self._completion(*args, **kwargs)
         self.post_completion(resp)

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -211,7 +211,7 @@ class LLM:
         resp = self._completion(*args, **kwargs)
         self.post_completion(resp)
         return resp
-    
+
     def post_completion(self, response: str) -> None:
         """
         Post-process the completion response.
@@ -225,7 +225,6 @@ class LLM:
             cur_cost,
             self.metrics.total_cost,
         )
-        
 
     def get_token_count(self, messages):
         """

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -204,6 +204,29 @@ class LLM:
         """
         return self._completion
 
+    def do_completion(self, *args, **kwargs):
+        """
+        Wrapper for the litellm completion function.
+        """
+        resp = self._completion(*args, **kwargs)
+        self.post_completion(resp)
+        return resp
+    
+    def post_completion(self, response: str) -> None:
+        """
+        Post-process the completion response.
+        """
+        try:
+            cur_cost = self.completion_cost(response)
+        except Exception:
+            cur_cost = 0
+        logger.info(
+            'Cost: %.2f USD | Accumulated Cost: %.2f USD',
+            cur_cost,
+            self.metrics.total_cost,
+        )
+        
+
     def get_token_count(self, messages):
         """
         Get the number of tokens in a list of messages.

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -225,7 +225,7 @@ class LLM:
         logger.info(
             'Cost: %.2f USD | Accumulated Cost: %.2f USD',
             cur_cost,
-            self.metrics.total_cost,
+            self.metrics.accumulated_cost,
         )
 
     def get_token_count(self, messages):

--- a/opendevin/memory/condenser.py
+++ b/opendevin/memory/condenser.py
@@ -16,7 +16,7 @@ class MemoryCondenser:
 
         try:
             messages = [{'content': summarize_prompt, 'role': 'user'}]
-            resp = llm.completion(messages=messages)
+            resp = llm.do_completion(messages=messages)
             summary_response = resp['choices'][0]['message']['content']
             return summary_response
         except Exception as e:

--- a/tests/unit/test_micro_agents.py
+++ b/tests/unit/test_micro_agents.py
@@ -31,7 +31,7 @@ def test_coder_agent_with_summary():
     """
     mock_llm = MagicMock()
     content = json.dumps({'action': 'finish', 'args': {}})
-    mock_llm.completion.return_value = {'choices': [{'message': {'content': content}}]}
+    mock_llm.do_completion.return_value = {'choices': [{'message': {'content': content}}]}
 
     coder_agent = Agent.get_cls('CoderAgent')(llm=mock_llm)
     assert coder_agent is not None
@@ -43,8 +43,8 @@ def test_coder_agent_with_summary():
     state = State(history=history, inputs={'summary': summary})
     coder_agent.step(state)
 
-    mock_llm.completion.assert_called_once()
-    _, kwargs = mock_llm.completion.call_args
+    mock_llm.do_completion.assert_called_once()
+    _, kwargs = mock_llm.do_completion.call_args
     prompt = kwargs['messages'][0]['content']
     assert task in prompt
     assert "Here's a summary of the codebase, as it relates to this task" in prompt
@@ -58,7 +58,7 @@ def test_coder_agent_without_summary():
     """
     mock_llm = MagicMock()
     content = json.dumps({'action': 'finish', 'args': {}})
-    mock_llm.completion.return_value = {'choices': [{'message': {'content': content}}]}
+    mock_llm.do_completion.return_value = {'choices': [{'message': {'content': content}}]}
 
     coder_agent = Agent.get_cls('CoderAgent')(llm=mock_llm)
     assert coder_agent is not None
@@ -69,8 +69,8 @@ def test_coder_agent_without_summary():
     state = State(history=history)
     coder_agent.step(state)
 
-    mock_llm.completion.assert_called_once()
-    _, kwargs = mock_llm.completion.call_args
+    mock_llm.do_completion.assert_called_once()
+    _, kwargs = mock_llm.do_completion.call_args
     prompt = kwargs['messages'][0]['content']
     assert task in prompt
     assert "Here's a summary of the codebase, as it relates to this task" not in prompt


### PR DESCRIPTION
As mentioned in #1913, we need find a better way to log the cost of LLM. 

1. I create a `Metrics` class. We have already have `logger` class in opendevin, but have no way to record the metrics.
2. I add `total_cost: float` `costs: list` vairable in `Metrics`. 
3. `Agent`-> `LLM` -> `Metrics`, then every agent will be recorded how much they spend.
4. `State` -> `Metrics`, then agent will update the latest metrics into state when `step`.
5. Do little refactor on `completion` function as `do_completion`, then when every agent call it in `step`, it will auto calculate the cost, accumulate cost, record cost, and log it out.

