### PR TITLE
template: Update bug template to include os version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -28,8 +28,8 @@ body:
   - type: textarea
     id: current-version
     attributes:
-      label: Current Version
-      description: What version are you using? If you're running in docker, tell us the tag you're using (e.g. ghcr.io/opendevin/opendevin:0.3.1).
+      label: Current OpenDevin version
+      description: What version of OpenDevin are you using? If you're running in docker, tell us the tag you're using (e.g. ghcr.io/opendevin/opendevin:0.3.1).
       render: bash
     validations:
       required: true
@@ -51,6 +51,12 @@ body:
       placeholder: |
         - Model:
         - Agent:
+
+  - type: textarea
+    id: os-version
+    attributes:
+      label: Operating System
+      description: What Operating System are you using? Linux, Mac OS, WSL on Windows
 
   - type: textarea
     id: repro-steps


### PR DESCRIPTION
Creating a place for Operating System when opening a bug so it doesn't need to be asked.
Also makes figuring out which OS has the most issues.