### PR TITLE
Save CI cycles for backend tests

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -10,9 +10,15 @@ on:
       - main
     paths-ignore:
       - '**/*.md'
+      - 'frontend/**'
+      - 'docs/**'
+      - 'evaluation/**'
   pull_request:
     paths-ignore:
       - '**/*.md'
+      - 'frontend/**'
+      - 'docs/**'
+      - 'evaluation/**'
 
 jobs:
   integration-tests-on-linux:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -9,10 +9,16 @@ on:
     branches:
       - main
     paths-ignore:
-      - "**/*.md"
+      - '**/*.md'
+      - 'frontend/**'
+      - 'docs/**'
+      - 'evaluation/**'
   pull_request:
     paths-ignore:
-      - "**/*.md"
+      - '**/*.md'
+      - 'frontend/**'
+      - 'docs/**'
+      - 'evaluation/**'
 
 jobs:
   test-on-macos:


### PR DESCRIPTION
There's no need to run backend unit tests and integration tests for changes in frontend, docs, or evaluation. 