### PR TITLE
fix session file not existed exception when init EventStream with a new session.

### DIFF
--- a/opendevin/events/stream.py
+++ b/opendevin/events/stream.py
@@ -35,7 +35,11 @@ class EventStream:
         self._reinitialize_from_file_store()
 
     def _reinitialize_from_file_store(self):
-        events = self._file_store.list(f'sessions/{self.sid}/events')
+        try:
+            events = self._file_store.list(f'sessions/{self.sid}/events')
+        except FileNotFoundError:
+            logger.warning(f'No events found for session {self.sid}')
+            return
         for event_str in events:
             id = self._get_id_from_filename(event_str)
             if id >= self._cur_id:
@@ -48,7 +52,10 @@ class EventStream:
         return int(filename.split('/')[-1].split('.')[0])
 
     def get_events(self, start_id=0, end_id=None) -> Iterable[Event]:
-        events = self._file_store.list(f'sessions/{self.sid}/events')
+        try:
+            events = self._file_store.list(f'sessions/{self.sid}/events')
+        except FileNotFoundError:
+            return
         for event_str in events:
             id = self._get_id_from_filename(event_str)
             if start_id <= id and (end_id is None or id <= end_id):


### PR DESCRIPTION
After session persistently stored， it will try to _reinitialize_from_file_store, but for a fresh new session which means no Persistent storage files will throw exceptions when init EventStream, or Persistent storage files removed from s3, the EventStream init flow brokes.