### PR TITLE
feat(frontend): Add actions to send feedback to backend

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,19 @@
+export interface FeedbackData {
+  email: string;
+  token: string;
+  feedback: "positive" | "negative";
+  trajectory: unknown[];
+}
+
+export const sendFeedback = async (data: FeedbackData) =>
+  fetch(
+    "https://kttkfkoju5.execute-api.us-east-2.amazonaws.com/od-share-trajectory",
+    {
+      method: "POST",
+      mode: "no-cors",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    },
+  );

--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -24,6 +24,7 @@ interface ScrollButtonProps {
   onClick: () => void;
   icon: JSX.Element;
   label: string;
+  // eslint-disable-next-line react/require-default-props
   disabled?: boolean;
 }
 

--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -17,7 +17,7 @@ import { useScrollToBottom } from "#/hooks/useScrollToBottom";
 import Session from "#/services/session";
 import { getToken } from "#/services/auth";
 import toast from "#/utils/toast";
-import { FeedbackData } from "#/api";
+import { FeedbackData, sendFeedback } from "#/api";
 import { removeApiKey } from "#/utils/utils";
 
 interface ScrollButtonProps {
@@ -60,7 +60,7 @@ function ChatInterface() {
     };
 
     try {
-      // await sendFeedback(data);
+      await sendFeedback(data);
     } catch (e) {
       console.error(e);
       toast.error("share-error", "Failed to share, see console for details.");

--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -5,6 +5,7 @@ import { RiArrowRightDoubleLine } from "react-icons/ri";
 import { useTranslation } from "react-i18next";
 import { twMerge } from "tailwind-merge";
 import { VscArrowDown } from "react-icons/vsc";
+import { FaRegThumbsDown, FaRegThumbsUp } from "react-icons/fa";
 import ChatInput from "./ChatInput";
 import Chat from "./Chat";
 import { RootState } from "#/store";
@@ -13,6 +14,11 @@ import { sendChatMessage } from "#/services/chatService";
 import { addUserMessage, addAssistantMessage } from "#/state/chatSlice";
 import { I18nKey } from "#/i18n/declaration";
 import { useScrollToBottom } from "#/hooks/useScrollToBottom";
+import Session from "#/services/session";
+import { getToken } from "#/services/auth";
+import toast from "#/utils/toast";
+import { FeedbackData } from "#/api";
+import { removeApiKey } from "#/utils/utils";
 
 interface ScrollButtonProps {
   onClick: () => void;
@@ -42,6 +48,27 @@ function ChatInterface() {
   const dispatch = useDispatch();
   const { messages } = useSelector((state: RootState) => state.chat);
   const { curAgentState } = useSelector((state: RootState) => state.agent);
+
+  const [feedbackShared, setFeedbackShared] = React.useState(false);
+
+  const shareFeedback = async (feedback: "positive" | "negative") => {
+    const data: FeedbackData = {
+      email: "NOT_PROVIDED",
+      token: getToken(),
+      feedback,
+      trajectory: removeApiKey(Session._history),
+    };
+
+    try {
+      // await sendFeedback(data);
+    } catch (e) {
+      console.error(e);
+      toast.error("share-error", "Failed to share, see console for details.");
+    } finally {
+      toast.info("Feedback shared successfully.");
+      setFeedbackShared(true);
+    }
+  };
 
   const handleSendMessage = (content: string) => {
     dispatch(addUserMessage(content));
@@ -104,6 +131,21 @@ function ChatInterface() {
               label: t(I18nKey.CHAT_INTERFACE$INPUT_CONTINUE_MESSAGE),
             })}
         </div>
+
+        {!feedbackShared && messages.length > 3 && (
+          <div className="flex justify-start gap-2 p-2">
+            <ScrollButton
+              onClick={() => shareFeedback("positive")}
+              icon={<FaRegThumbsUp className="inline mr-2 w-3 h-3" />}
+              label=""
+            />
+            <ScrollButton
+              onClick={() => shareFeedback("negative")}
+              icon={<FaRegThumbsDown className="inline mr-2 w-3 h-3" />}
+              label=""
+            />
+          </div>
+        )}
       </div>
 
       <ChatInput

--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -24,18 +24,21 @@ interface ScrollButtonProps {
   onClick: () => void;
   icon: JSX.Element;
   label: string;
+  disabled?: boolean;
 }
 
 function ScrollButton({
   onClick,
   icon,
   label,
+  disabled = false,
 }: ScrollButtonProps): JSX.Element {
   return (
     <button
       type="button"
       className="relative border-1 text-xs rounded px-2 py-1 border-neutral-600 bg-neutral-700 cursor-pointer select-none"
       onClick={onClick}
+      disabled={disabled}
     >
       <div className="flex items-center">
         {icon} <span className="inline-block">{label}</span>
@@ -50,6 +53,7 @@ function ChatInterface() {
   const { curAgentState } = useSelector((state: RootState) => state.agent);
 
   const [feedbackShared, setFeedbackShared] = React.useState(false);
+  const [feedbackLoading, setFeedbackLoading] = React.useState(false);
 
   const shareFeedback = async (feedback: "positive" | "negative") => {
     const data: FeedbackData = {
@@ -60,13 +64,15 @@ function ChatInterface() {
     };
 
     try {
+      setFeedbackLoading(true);
       await sendFeedback(data);
+      toast.info("Feedback shared successfully.");
     } catch (e) {
       console.error(e);
       toast.error("share-error", "Failed to share, see console for details.");
     } finally {
-      toast.info("Feedback shared successfully.");
       setFeedbackShared(true);
+      setFeedbackLoading(false);
     }
   };
 
@@ -135,11 +141,13 @@ function ChatInterface() {
         {!feedbackShared && messages.length > 3 && (
           <div className="flex justify-start gap-2 p-2">
             <ScrollButton
+              disabled={feedbackLoading}
               onClick={() => shareFeedback("positive")}
               icon={<FaRegThumbsUp className="inline mr-2 w-3 h-3" />}
               label=""
             />
             <ScrollButton
+              disabled={feedbackLoading}
               onClick={() => shareFeedback("negative")}
               icon={<FaRegThumbsDown className="inline mr-2 w-3 h-3" />}
               label=""

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -9,6 +9,8 @@ class Session {
 
   private static _latest_event_id: number = -1;
 
+  public static _history: Record<string, unknown>[] = [];
+
   // callbacks contain a list of callable functions
   // event: function, like:
   // open: [function1, function2]
@@ -79,6 +81,7 @@ class Session {
       let data = null;
       try {
         data = JSON.parse(e.data);
+        Session._history.push(data);
       } catch (err) {
         // TODO: report the error
         console.error("Error parsing JSON data", err);
@@ -137,6 +140,7 @@ class Session {
 
     if (Session.isConnected()) {
       Session._socket?.send(message);
+      Session._history.push(JSON.parse(message));
     } else {
       const msg = "Connection failed. Retry...";
       toast.error("ws", msg);

--- a/frontend/src/utils/utils.test.ts
+++ b/frontend/src/utils/utils.test.ts
@@ -1,0 +1,6 @@
+import { removeApiKey } from "./utils";
+
+test("removeApiKey", () => {
+  const data = [{ args: { LLM_API_KEY: "key", LANGUAGE: "en" } }];
+  expect(removeApiKey(data)).toEqual([{ args: { LANGUAGE: "en" } }]);
+});

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -4,3 +4,28 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+interface EventActionHistory {
+  args?: {
+    LLM_API_KEY?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export const removeApiKey = (
+  data: EventActionHistory[],
+): EventActionHistory[] =>
+  data.map((item) => {
+    // Create a shallow copy of item
+    const newItem = { ...item };
+
+    // Check if LLM_API_KEY exists and delete it from a new args object
+    if (newItem.args?.LLM_API_KEY) {
+      const newArgs = { ...newItem.args };
+      delete newArgs.LLM_API_KEY;
+      newItem.args = newArgs;
+    }
+
+    return newItem;
+  });


### PR DESCRIPTION
Partially addresses #1802

## Summary
- Extends the `Session` class to store event history from both agent and user.
- Introduces two buttons (thumbs up and thumbs down) that sends back session history up to that point to backend created by @neubig 
- Conditionally renders these buttons when message length (agent + user) is > 3
- Hides buttons after clicking on either button
- Removes `LLM_API_KEY` before sending data

## Notes
The data that is sent is of type `Record<string, unknown>` (`Dict[str, Any]`) and includes an `email` key according to @neubig API request definition. We currently do not store any user email, therefore the value is hardcoded to `'NOT_PROVIDED'`

This was a quick PR, so the chat interface component tests were **not extended to reflect this feature**