### PR TITLE
Improve action and observation logging for the CLI interface

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -128,10 +128,12 @@ class AgentController:
             await self.set_agent_state_to(event.agent_state)  # type: ignore
         elif isinstance(event, MessageAction):
             if event.source == EventSource.USER:
+                logger.info(event, extra={'msg_type': 'OBSERVATION'})
                 await self.add_history(event, NullObservation(''))
                 if self.get_agent_state() != AgentState.RUNNING:
                     await self.set_agent_state_to(AgentState.RUNNING)
             elif event.source == EventSource.AGENT and event.wait_for_response:
+                logger.info(event, extra={'msg_type': 'ACTION'})
                 await self.set_agent_state_to(AgentState.AWAITING_USER_INPUT)
         elif isinstance(event, AgentDelegateAction):
             await self.start_delegate(event)

--- a/opendevin/events/action/agent.py
+++ b/opendevin/events/action/agent.py
@@ -40,6 +40,11 @@ class AgentSummarizeAction(Action):
     def message(self) -> str:
         return self.summary
 
+    def __str__(self) -> str:
+        ret = '**AgentSummarizeAction**\n'
+        ret += f'SUMMARY:{self.summary}'
+        return ret
+
 
 @dataclass
 class AgentFinishAction(Action):

--- a/opendevin/events/action/agent.py
+++ b/opendevin/events/action/agent.py
@@ -42,7 +42,7 @@ class AgentSummarizeAction(Action):
 
     def __str__(self) -> str:
         ret = '**AgentSummarizeAction**\n'
-        ret += f'SUMMARY:{self.summary}'
+        ret += f'SUMMARY: {self.summary}'
         return ret
 
 

--- a/opendevin/events/action/browse.py
+++ b/opendevin/events/action/browse.py
@@ -20,8 +20,8 @@ class BrowseURLAction(Action):
     def __str__(self) -> str:
         ret = '**BrowseURLAction**\n'
         if self.thought:
-            ret += f'THOUGHT:{self.thought}\n'
-        ret += f'URL:{self.url}'
+            ret += f'THOUGHT: {self.thought}\n'
+        ret += f'URL: {self.url}'
         return ret
 
 
@@ -39,6 +39,6 @@ class BrowseInteractiveAction(Action):
     def __str__(self) -> str:
         ret = '**BrowseInteractiveAction**\n'
         if self.thought:
-            ret += f'THOUGHT:{self.thought}\n'
-        ret += f'BROWSER_ACTIONS:{self.browser_actions}'
+            ret += f'THOUGHT: {self.thought}\n'
+        ret += f'BROWSER_ACTIONS: {self.browser_actions}'
         return ret

--- a/opendevin/events/action/browse.py
+++ b/opendevin/events/action/browse.py
@@ -17,6 +17,13 @@ class BrowseURLAction(Action):
     def message(self) -> str:
         return f'Browsing URL: {self.url}'
 
+    def __str__(self) -> str:
+        ret = '**BrowseURLAction**\n'
+        if self.thought:
+            ret += f'THOUGHT:{self.thought}\n'
+        ret += f'URL:{self.url}'
+        return ret
+
 
 @dataclass
 class BrowseInteractiveAction(Action):
@@ -28,3 +35,10 @@ class BrowseInteractiveAction(Action):
     @property
     def message(self) -> str:
         return f'Executing browser actions: {self.browser_actions}'
+
+    def __str__(self) -> str:
+        ret = '**BrowseInteractiveAction**\n'
+        if self.thought:
+            ret += f'THOUGHT:{self.thought}\n'
+        ret += f'BROWSER_ACTIONS:{self.browser_actions}'
+        return ret

--- a/opendevin/events/action/commands.py
+++ b/opendevin/events/action/commands.py
@@ -21,7 +21,7 @@ class CmdRunAction(Action):
     def __str__(self) -> str:
         ret = '**CmdRunAction**\n'
         if self.thought:
-            ret += f'THOUGHT:{self.thought}\n'
+            ret += f'THOUGHT: {self.thought}\n'
         ret += f'COMMAND:\n{self.command}'
         return ret
 
@@ -52,7 +52,7 @@ class IPythonRunCellAction(Action):
     def __str__(self) -> str:
         ret = '**IPythonRunCellAction**\n'
         if self.thought:
-            ret += f'THOUGHT:{self.thought}\n'
+            ret += f'THOUGHT: {self.thought}\n'
         ret += f'CODE:\n{self.code}'
         return ret
 

--- a/opendevin/events/action/message.py
+++ b/opendevin/events/action/message.py
@@ -16,6 +16,6 @@ class MessageAction(Action):
         return self.content
 
     def __str__(self) -> str:
-        ret = f'**MessageAction** ({self.action})\n'
-        ret += f'CONTENT:{self.content}'
+        ret = f'**MessageAction** (source={self.source})\n'
+        ret += f'CONTENT: {self.content}'
         return ret

--- a/opendevin/events/action/message.py
+++ b/opendevin/events/action/message.py
@@ -14,3 +14,8 @@ class MessageAction(Action):
     @property
     def message(self) -> str:
         return self.content
+
+    def __str__(self) -> str:
+        ret = f'**MessageAction** ({self.action})\n'
+        ret += f'CONTENT:{self.content}'
+        return ret

--- a/opendevin/events/observation/browse.py
+++ b/opendevin/events/observation/browse.py
@@ -28,3 +28,17 @@ class BrowserOutputObservation(Observation):
     @property
     def message(self) -> str:
         return 'Visited ' + self.url
+
+    def __str__(self) -> str:
+        return (
+            '**BrowserOutputObservation**\n'
+            f'URL: {self.url}\n'
+            f'Status code: {self.status_code}\n'
+            f'Error: {self.error}\n'
+            f'Open pages: {self.open_pages_urls}\n'
+            f'Active page index: {self.active_page_index}\n'
+            f'Last browser action: {self.last_browser_action}\n'
+            f'Last browser action error: {self.last_browser_action_error}\n'
+            f'Focused element bid: {self.focused_element_bid}\n'
+            f'CONTENT: {self.content}\n'
+        )


### PR DESCRIPTION
This PR ensures that:
* We properly log user messages and print it to the terminal
* Format browser action/obs, `AgentSummarizeAction`, `MessageAction` appropriately for logging

Example screenshot of logged messages:

<img width="1271" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/38853559/c3139784-96d1-41a8-8895-839b4da3aebc">
