### PR TITLE
BrowserEnv: init exception handling

### DIFF
--- a/opendevin/core/exceptions.py
+++ b/opendevin/core/exceptions.py
@@ -58,6 +58,19 @@ class TaskInvalidStateError(Exception):
         super().__init__(message)
 
 
+class BrowserInitException(Exception):
+    def __init__(self, message='Failed to initialize browser environment'):
+        super().__init__(message)
+
+
+class BrowserUnavailableException(Exception):
+    def __init__(
+        self,
+        message='Browser environment is not available, please check if has been initialized',
+    ):
+        super().__init__(message)
+
+
 # These exceptions get sent back to the LLM
 class AgentMalformedActionError(Exception):
     def __init__(self, message='Malformed response'):

--- a/opendevin/runtime/browser/browser_env.py
+++ b/opendevin/runtime/browser/browser_env.py
@@ -12,11 +12,8 @@ import numpy as np
 from browsergym.utils.obs import flatten_dom_to_str
 from PIL import Image
 
+from opendevin.core.exceptions import BrowserInitException
 from opendevin.core.logger import opendevin_logger as logger
-
-
-class BrowserException(Exception):
-    pass
 
 
 class BrowserEnv:
@@ -38,7 +35,8 @@ class BrowserEnv:
         logger.info('Starting browser env...')
         self.process.start()
         if not self.check_alive():
-            raise BrowserException('Failed to start browser environment.')
+            self.close()
+            raise BrowserInitException('Failed to start browser environment.')
         atexit.register(self.close)
 
     def browser_process(self):
@@ -93,7 +91,7 @@ class BrowserEnv:
                 if response_id == unique_request_id:
                     return obs
 
-    def check_alive(self, timeout: float = 10):
+    def check_alive(self, timeout: float = 60):
         self.agent_side.send(('IS_ALIVE', None))
         if self.agent_side.poll(timeout=timeout):
             response_id, _ = self.agent_side.recv()

--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -2,6 +2,8 @@ import asyncio
 from abc import abstractmethod
 
 from opendevin.core.config import config
+from opendevin.core.exceptions import BrowserInitException
+from opendevin.core.logger import opendevin_logger as logger
 from opendevin.events import EventSource, EventStream, EventStreamSubscriber
 from opendevin.events.action import (
     Action,
@@ -38,11 +40,11 @@ def create_sandbox(sid: str = 'default', sandbox_type: str = 'exec') -> Sandbox:
     if sandbox_type == 'exec':
         return DockerExecBox(sid=sid)
     elif sandbox_type == 'local':
-        return LocalBox()
+        return LocalBox(timeout=config.sandbox_timeout)
     elif sandbox_type == 'ssh':
-        return DockerSSHBox(sid=sid)
+        return DockerSSHBox(sid=sid, timeout=config.sandbox_timeout)
     elif sandbox_type == 'e2b':
-        return E2BBox()
+        return E2BBox(timeout=config.sandbox_timeout)
     else:
         raise ValueError(f'Invalid sandbox type: {sandbox_type}')
 
@@ -71,7 +73,13 @@ class Runtime:
         else:
             self.sandbox = sandbox
             self._is_external_sandbox = True
-        self.browser = BrowserEnv()
+        self.browser: BrowserEnv | None = None
+        try:
+            self.browser = BrowserEnv()
+        except BrowserInitException:
+            logger.warn(
+                'Failed to start browser environment, web browsing functionality will not work'
+            )
         self.file_store = InMemoryFileStore()
         self.event_stream = event_stream
         self.event_stream.subscribe(EventStreamSubscriber.RUNTIME, self.on_event)
@@ -80,7 +88,8 @@ class Runtime:
     def close(self):
         if not self._is_external_sandbox:
             self.sandbox.close()
-        self.browser.close()
+        if self.browser is not None:
+            self.browser.close()
         self._bg_task.cancel()
 
     def init_sandbox_plugins(self, plugins: list[PluginRequirement]) -> None:

--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -40,11 +40,11 @@ def create_sandbox(sid: str = 'default', sandbox_type: str = 'exec') -> Sandbox:
     if sandbox_type == 'exec':
         return DockerExecBox(sid=sid)
     elif sandbox_type == 'local':
-        return LocalBox(timeout=config.sandbox_timeout)
+        return LocalBox()
     elif sandbox_type == 'ssh':
-        return DockerSSHBox(sid=sid, timeout=config.sandbox_timeout)
+        return DockerSSHBox(sid=sid)
     elif sandbox_type == 'e2b':
-        return E2BBox(timeout=config.sandbox_timeout)
+        return E2BBox()
     else:
         raise ValueError(f'Invalid sandbox type: {sandbox_type}')
 

--- a/opendevin/runtime/server/browse.py
+++ b/opendevin/runtime/server/browse.py
@@ -1,11 +1,14 @@
 import os
 
+from opendevin.core.exceptions import BrowserUnavailableException
 from opendevin.core.schema import ActionType
 from opendevin.events.observation import BrowserOutputObservation
 from opendevin.runtime.browser.browser_env import BrowserEnv
 
 
-async def browse(action, browser: BrowserEnv) -> BrowserOutputObservation:  # type: ignore
+async def browse(action, browser: BrowserEnv | None) -> BrowserOutputObservation:  # type: ignore
+    if browser is None:
+        raise BrowserUnavailableException()
     if action.action == ActionType.BROWSE:
         # legacy BrowseURLAction
         asked_url = action.url

--- a/opendevin/runtime/server/browse.py
+++ b/opendevin/runtime/server/browse.py
@@ -6,7 +6,7 @@ from opendevin.events.observation import BrowserOutputObservation
 from opendevin.runtime.browser.browser_env import BrowserEnv
 
 
-async def browse(action, browser: BrowserEnv | None) -> BrowserOutputObservation:  # type: ignore
+async def browse(action, browser: BrowserEnv | None) -> BrowserOutputObservation:
     if browser is None:
         raise BrowserUnavailableException()
     if action.action == ActionType.BROWSE:


### PR DESCRIPTION
I am a bit surprised that I seem to be the only one who hits this issue consistently... but anyways, here's a little improvement:

1. Increase BrowserEnv init timeout from 10 seconds to 60 seconds
2. If BrowserEnv fails to init, print a warning log and ignore the error until OpenDevin really needs to use it

Fixes #2049 

## Demo

### Normal flow:

You could see that it actually took me 11 seconds to start the browser environment.

COMMAND: `poetry run python ./opendevin/core/main.py -i 10 -t "tell me the usa's president using google search" -c BrowsingAgent -m gpt-4o-2024-05-13`

```
20:53:27 - opendevin:INFO: browser_env.py:35 - Starting browser env...
20:53:38 - opendevin:INFO: browser_env.py:51 - Browser env started.
20:53:38 - OBSERVATION
**MessageAction** (source=EventSource.USER)
CONTENT: tell me the usa's president using google search
20:53:38 - opendevin:INFO: agent_controller.py:160 - Setting agent(BrowsingAgent) state from AgentState.LOADING to AgentState.RUNNING
20:53:38 - opendevin:INFO: agent_controller.py:160 - Setting agent(BrowsingAgent) state from AgentState.RUNNING to AgentState.RUNNING


==============
STEP 0

20:53:39 - opendevin:INFO: browsing_agent.py:163 - Cost: 0.00 USD | Accumulated Cost: 0.00 USD
20:53:39 - opendevin:INFO: browsing_agent.py:149 - # Current Accessibility Tree:


# Previous Actions


Here is an example with chain of thought of a valid action when clicking on a button:
"
In order to accomplish my goal I need to click on the button with bid 12
```click("12")```
"
20:53:39 - opendevin:INFO: browsing_agent.py:150 - In order to accomplish my goal, I need to navigate to Google to perform a search for the current president of the USA.
```

### BrowserEnv unavailable, not using browser feature

The log is too long so I didn't include everything, but I can assure you that it finishes its job, since this task doesn't require browsing functionality

COMMAND: `poetry run python ./opendevin/core/main.py -i 10 -t "write a hello-world script" -c CodeActAgent`

```
21:01:03 - opendevin:INFO: browser_env.py:35 - Starting browser env...
21:01:09 - opendevin:ERROR: browser_env.py:109 - Browser process did not terminate, forcefully terminating...
21:01:09 - opendevin:WARNING: runtime.py:80 - Failed to start browser environment, web browsing functionality will not work
21:01:10 - opendevin:INFO: mixin.py:31 - Copied files from [/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/plugins/agent_skills] to [/opendevin/plugins/agent_skills] inside sandbox.
21:01:10 - opendevin:INFO: mixin.py:39 - Initializing plugin [agent_skills] by executing [/opendevin/plugins/agent_skills/setup.sh] in the sandbox.
21:01:10 - opendevin:INFO: mixin.py:53 - Plugin agent_skills initialized successfully
21:01:11 - opendevin:INFO: mixin.py:31 - Copied files from [/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/plugins/jupyter] to [/opendevin/plugins/jupyter] inside sandbox.
21:01:11 - opendevin:INFO: mixin.py:39 - Initializing plugin [jupyter] by executing [/opendevin/plugins/jupyter/setup.sh] in the sandbox.
21:01:13 - opendevin:INFO: mixin.py:53 - Plugin jupyter initialized successfully
21:01:13 - opendevin:INFO: mixin.py:67 - Sourced ~/.bashrc successfully
21:01:13 - OBSERVATION
**MessageAction** (source=EventSource.USER)
CONTENT: write a hello-world script
21:01:13 - opendevin:INFO: agent_controller.py:160 - Setting agent(CodeActAgent) state from AgentState.LOADING to AgentState.RUNNING
21:01:13 - opendevin:INFO: agent_controller.py:160 - Setting agent(CodeActAgent) state from AgentState.RUNNING to AgentState.RUNNING


==============
STEP 0

21:01:14 - opendevin:INFO: llm.py:225 - Cost: 0.01 USD | Accumulated Cost: 0.01 USD
21:01:14 - ACTION
**IPythonRunCellAction**
THOUGHT: Sure! Let's start by creating a new file for the hello-world script.
```

### BrowserEnv unavailable, using browser feature

Obviously, this would fail.

COMMAND: `poetry run python ./opendevin/core/main.py -i 10 -t "tell me the usa's president using google search" -c BrowsingAgent -m gpt-4o-2024-05-13`

```
20:52:20 - opendevin:INFO: browser_env.py:35 - Starting browser env...
20:52:26 - opendevin:ERROR: browser_env.py:109 - Browser process did not terminate, forcefully terminating...
20:52:26 - opendevin:WARNING: runtime.py:80 - Failed to start browser environment, web browsing functionality will not work
20:52:26 - OBSERVATION
**MessageAction** (source=EventSource.USER)
CONTENT: tell me the usa's president using google search
20:52:26 - opendevin:INFO: agent_controller.py:160 - Setting agent(BrowsingAgent) state from AgentState.LOADING to AgentState.RUNNING
20:52:26 - opendevin:INFO: agent_controller.py:160 - Setting agent(BrowsingAgent) state from AgentState.RUNNING to AgentState.RUNNING


==============
STEP 0

20:52:27 - opendevin:INFO: browsing_agent.py:163 - Cost: 0.00 USD | Accumulated Cost: 0.00 USD
20:52:27 - opendevin:INFO: browsing_agent.py:149 - # Current Accessibility Tree:


# Previous Actions


Here is an example with chain of thought of a valid action when clicking on a button:
"
In order to accomplish my goal I need to click on the button with bid 12
```click("12")```
"
20:52:27 - opendevin:INFO: browsing_agent.py:150 - In order to accomplish my goal, I need to navigate to Google and perform a search for the current president of the USA.

```goto('https://www.google.com')```
20:52:27 - ACTION
**BrowseInteractiveAction**
THOUGHT: In order to accomplish my goal, I need to navigate to Google and perform a search for the current president of the USA.
BROWSER_ACTIONS: goto('https://www.google.com')
Traceback (most recent call last):
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/controller/agent_controller.py", line 110, in _start_step_loop
    await self._step()
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/controller/agent_controller.py", line 244, in _step
    await self.event_stream.add_event(action, EventSource.AGENT)
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/events/stream.py", line 97, in add_event
    await fn(event)
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/runtime.py", line 98, in on_event
    observation = await self.run_action(event)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/runtime.py", line 118, in run_action
    observation = await getattr(self, action_type)(action)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/server/runtime.py", line 120, in browse_interactive
    return await browse(action, self.browser)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/server/browse.py", line 11, in browse
    raise BrowserUnavailableException()
opendevin.core.exceptions.BrowserUnavailableException: Browser environment is not available, please check if has been initialized
20:52:27 - opendevin:ERROR: agent_controller.py:116 - Error while running the agent: Browser environment is not available, please check if has been initialized
20:52:27 - opendevin:ERROR: agent_controller.py:117 - Traceback (most recent call last):
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/controller/agent_controller.py", line 110, in _start_step_loop
    await self._step()
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/controller/agent_controller.py", line 244, in _step
    await self.event_stream.add_event(action, EventSource.AGENT)
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/events/stream.py", line 97, in add_event
    await fn(event)
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/runtime.py", line 98, in on_event
    observation = await self.run_action(event)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/runtime.py", line 118, in run_action
    observation = await getattr(self, action_type)(action)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/server/runtime.py", line 120, in browse_interactive
    return await browse(action, self.browser)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/liboxuan/workspace/OpenDevin/opendevin/runtime/server/browse.py", line 11, in browse
    raise BrowserUnavailableException()
opendevin.core.exceptions.BrowserUnavailableException: Browser environment is not available, please check if has been initialized

20:52:27 - opendevin:INFO: agent_controller.py:160 - Setting agent(BrowsingAgent) state from AgentState.RUNNING to AgentState.ERROR
20:52:27 - opendevin:INFO: agent_controller.py:160 - Setting agent(BrowsingAgent) state from AgentState.ERROR to AgentState.STOPPED
```