### PR TITLE
Add retry logic to ssh login

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -387,6 +387,7 @@ class DockerSSHBox(Sandbox):
             f"If you started OpenDevin with `docker run`, you should try `ssh -v -p {self._ssh_port} {username}@localhost` with the password '{self._ssh_password} on the host machine (where you started the container)."
         )
 
+        # TODO there's a similar block nearby, replace with some retry decorator instead or something
         n_retries = 5
         while n_retries > 0:
             try:

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -386,7 +386,22 @@ class DockerSSHBox(Sandbox):
             f"If you encounter any issues, you can try `ssh -v -p {self._ssh_port} {username}@{hostname}` with the password '{self._ssh_password}' and report the issue on GitHub. "
             f"If you started OpenDevin with `docker run`, you should try `ssh -v -p {self._ssh_port} {username}@localhost` with the password '{self._ssh_password} on the host machine (where you started the container)."
         )
-        self.ssh.login(hostname, username, self._ssh_password, port=self._ssh_port)
+
+        n_retries = 5
+        while n_retries > 0:
+            try:
+                self.ssh.login(
+                    hostname, username, self._ssh_password, port=self._ssh_port
+                )
+                break
+            except pxssh.ExceptionPxssh as e:
+                logger.exception(
+                    'Failed to login to SSH session, retrying...', exc_info=False
+                )
+                n_retries -= 1
+                if n_retries == 0:
+                    raise e
+                time.sleep(5)
 
         # Fix: https://github.com/pexpect/pexpect/issues/669
         self.ssh.sendline("bind 'set enable-bracketed-paste off'")


### PR DESCRIPTION
Similar to https://github.com/OpenDevin/OpenDevin/pull/2023, this PR add retry logic to `ssh.login`. While the loop looks a bit ugly, especially when used extensively :( - maybe we can figure out a way to clean this with some sort of retry decorator?

Without this, the `ssh.login` can occasionally failed due to same reason as https://github.com/OpenDevin/OpenDevin/pull/2023 (sshd not initialized yet).