### PR TITLE
main.py: Fix redundant ChangeAgentStateAction

### DIFF
--- a/opendevin/core/main.py
+++ b/opendevin/core/main.py
@@ -10,7 +10,7 @@ from opendevin.core.config import args, get_llm_config_arg
 from opendevin.core.logger import opendevin_logger as logger
 from opendevin.core.schema import AgentState
 from opendevin.events import EventSource, EventStream, EventStreamSubscriber
-from opendevin.events.action import ChangeAgentStateAction, MessageAction
+from opendevin.events.action import MessageAction
 from opendevin.events.event import Event
 from opendevin.events.observation import AgentStateChangedObservation
 from opendevin.llm.llm import LLM
@@ -93,9 +93,6 @@ async def main(
     runtime.init_sandbox_plugins(controller.agent.sandbox_plugins)
 
     await event_stream.add_event(MessageAction(content=task), EventSource.USER)
-    await event_stream.add_event(
-        ChangeAgentStateAction(agent_state=AgentState.RUNNING), EventSource.USER
-    )
 
     async def on_event(event: Event):
         if isinstance(event, AgentStateChangedObservation):


### PR DESCRIPTION
This is a minor bug that seems to be benign - it doesn't do anything malicious except for a redundant operation.

Without this fix, run any task with any agent using `main.py`:

<img width="1066" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/25746010/ca3718ef-121b-4292-b3ea-2fe4b3da32dc">


With this fix:

<img width="1058" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/25746010/ce37d58e-eccd-4336-bea2-af1281bc3b62">
