### PR TITLE
fix: need to run as root to use SWEBench container

### DIFF
--- a/evaluation/swe_bench/swe_env_box.py
+++ b/evaluation/swe_bench/swe_env_box.py
@@ -86,7 +86,8 @@ class SWEBenchSSHBox(DockerSSHBox):
 
         # linting python after editing helps LLM fix indentations
         config.enable_auto_lint = True
-
+        # Need to run as root to use SWEBench container
+        config.run_as_devin = False
         sandbox = cls(
             container_image=SWE_BENCH_CONTAINER_IMAGE,
             swe_instance_id=instance['instance_id'],


### PR DESCRIPTION
When I run ```poetry run python evaluation/swe_bench/swe_env_box.py```, it failed to execute ```source /swe_util/swe_entry.sh``` in the SWEBench container, to ```source /swe_util/swe_entry.sh``` correctly need to run as root, but it connect the container through ssh as devin by defult, so we need to connect the container as root.  
 
The default config.run_as_devin is true, but when we use SWEBench container, we need to run as root to use it.