### PR TITLE
Support specifying custom cost per token

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -66,6 +66,8 @@ class LLMConfig(metaclass=Singleton):
     custom_llm_provider: str | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    input_cost_per_token: float | None = None
+    output_cost_per_token: float | None = None
 
     def defaults_to_dict(self) -> dict:
         """

--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -44,6 +44,8 @@ class LLMConfig(metaclass=Singleton):
         custom_llm_provider: The custom LLM provider to use. This is undocumented in opendevin, and normally not used. It is documented on the litellm side.
         max_input_tokens: The maximum number of input tokens. Note that this is currently unused, and the value at runtime is actually the total tokens in OpenAI (e.g. 128,000 tokens for GPT-4).
         max_output_tokens: The maximum number of output tokens. This is sent to the LLM.
+        input_cost_per_token: The cost per input token. This will available in logs for the user to check.
+        output_cost_per_token: The cost per output token. This will available in logs for the user to check.
     """
 
     model: str = 'gpt-3.5-turbo'

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -232,6 +232,8 @@ def test_api_keys_repr_str():
         'api_key',
         'aws_access_key_id',
         'aws_secret_access_key',
+        'input_cost_per_token',
+        'output_cost_per_token',
     ]
     for attr_name in dir(LLMConfig):
         if (


### PR DESCRIPTION
Support tracking costs for other model endpoints by setting in `config.toml` of llm:
```
input_cost_per_token = 0.00000014
output_cost_per_token = 0.00000028
```