### PR TITLE
Fix persist_sandbox in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ setup-config-prompts:
 		 read -p "Enter a password for the sandbox container: " ssh_password; \
 		 echo "ssh_password=\"$$ssh_password\"" >> $(CONFIG_FILE).tmp; \
 	 else \
-		echo "persist_sandbox=\"$$persist_sandbox\"" >> $(CONFIG_FILE).tmp; \
+		echo "persist_sandbox=$$persist_sandbox" >> $(CONFIG_FILE).tmp; \
 	 fi
 
 	@echo "" >> $(CONFIG_FILE).tmp


### PR DESCRIPTION
#2139 introduces persist_sandbox as an option to `make setup-config`, but has a syntax error. #2168 fixes the syntax error, but there's still another bug: it writes string `"false"` to config file. The correct way of doing it is to write boolean `false` without quotes, otherwise config loader doesn't recognize it.