### PR TITLE
Enable mac integration tests unless a special tag is present

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -59,7 +59,7 @@ jobs:
   integration-tests-on-mac:
     name: Integration Tests on MacOS
     runs-on: macos-13
-    if: contains(github.event.pull_request.title, 'mac') || contains(github.event.pull_request.title, 'Mac')
+    if: ${{ !contains(github.event.pull_request.title, 'skip-mac') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Unless `skip-mac` is present, mac integration tests would run.