### PR TITLE
fix: Fix husky install deprecated message (since v9 of husky) (#2190)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "prelint": "npm run make-i18n",
     "lint": "eslint src --ext .ts,.tsx,.js && prettier --check src/**/*.{ts,tsx}",
     "lint:fix": "eslint src --ext .ts,.tsx,.js --fix && prettier --write src/**/*.{ts,tsx}",
-    "prepare": "cd .. && husky install frontend/.husky"
+    "prepare": "cd .. && husky frontend/.husky"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Remove husky "install" parameter to avoid deprecated warning during make build.

Fixes https://github.com/OpenDevin/OpenDevin/issues/2190