### PR TITLE
Add Support for Docker Links in Sandbox Container

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -139,6 +139,7 @@ class AppConfig(metaclass=Singleton):
         workspace_mount_rewrite: The path to rewrite the workspace mount path to.
         cache_dir: The path to the cache directory. Defaults to /tmp/cache.
         sandbox_container_image: The container image to use for the sandbox.
+        sandbox_container_docker_links: The Docker links to use for the sandbox.
         run_as_devin: Whether to run as devin.
         max_iterations: The maximum number of iterations.
         max_budget_per_task: The maximum budget allowed per task, beyond which the agent will stop.
@@ -169,6 +170,9 @@ class AppConfig(metaclass=Singleton):
         if os.getenv('OPEN_DEVIN_BUILD_VERSION')
         else ':main'
     )
+    # sandbox_container_docker_links: dict | None = None
+    sandbox_container_docker_links: dict = field(default_factory=dict)
+
     run_as_devin: bool = True
     max_iterations: int = 100
     max_budget_per_task: float | None = None

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -676,6 +676,10 @@ class DockerSSHBox(Sandbox):
                     )
                 )
 
+            # Add custom links if any
+            links = config.sandbox_container_docker_links
+            logger.info(f'Custom links: {links}')
+
             # start the container
             logger.info(f'Mounting volumes: {self.volumes}')
             self.container = self.docker_client.containers.run(
@@ -687,6 +691,7 @@ class DockerSSHBox(Sandbox):
                 name=self.container_name,
                 detach=True,
                 volumes=self.volumes,
+                links=links,
             )
             logger.info('Container started')
         except Exception as ex:


### PR DESCRIPTION
This PR introduces a new feature that allows linking the sandbox container to other running containers using Docker links. This enhancement is particularly useful for scenarios where the sandbox needs to interact with other services or containers running in the same environment.