### PR TITLE
ssh_box: Close containers before throwing exception

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -268,7 +268,7 @@ class DockerSSHBox(Sandbox):
             self.start_docker_container()
         try:
             self.start_ssh_session()
-        except pxssh.ExceptionPxssh as e:
+        except Exception as e:
             self.close()
             raise e
 


### PR DESCRIPTION
I noticed this many many times during evaluation: a lot of stale containers left running.

The bug comes from https://github.com/OpenDevin/OpenDevin/blob/4ece6fb3cc421e83106c79054dc257ef4596dec3/opendevin/runtime/docker/ssh_box.py#L269-L273

where we only close the containers if we catch `pxssh.ExceptionPxssh`. This used to work until we added `@retry` annotation to `__ssh_login` method. Now this throws retry exception rather than ExceptionPxssh. Thus, our try except clause doesn't correctly catch the exception, leaving stale containers running.

The fix is to always close containers no matter what exception we catch.