### PR TITLE
ssh_box: Fix Docker client descriptor leak

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -756,6 +756,7 @@ class DockerSSHBox(Sandbox):
                     container.remove(force=True)
             except docker.errors.NotFound:
                 pass
+        self.docker_client.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Similar to #2209, this might have contributed to `OSError: [Errno 24] Too many open files` too.

I haven't seen that error since the fix in this PR and #2209.