### PR TITLE
logger.py: Fix resource leak

### DIFF
--- a/opendevin/core/logger.py
+++ b/opendevin/core/logger.py
@@ -216,7 +216,7 @@ class LlmFileHandler(logging.FileHandler):
         self.baseFilename = os.path.join(self.log_directory, filename)
         self.stream = self._open()
         super().emit(record)
-        self.stream.close
+        self.stream.close()
         opendevin_logger.debug('Logging to %s', self.baseFilename)
         self.message_counter += 1
 


### PR DESCRIPTION
After a few fixes to resource leak, the benchmarks can now run in a much more stable mode. That being said, occasionally, I still see `OSError: [Errno 24] Too many open files`. Hope this is the last one...