### PR TITLE
fix: keep colon part in model name for OpenRouter

### DIFF
--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -131,7 +131,10 @@ class LLM:
         # litellm actually uses base Exception here for unknown model
         self.model_info = None
         try:
-            self.model_info = litellm.get_model_info(self.model_name.split(':')[0])
+            if not self.model_name.startswith('openrouter'):
+                self.model_info = litellm.get_model_info(self.model_name.split(':')[0])
+            else:
+                self.model_info = litellm.get_model_info(self.model_name)
         # noinspection PyBroadException
         except Exception:
             logger.warning(f'Could not get model info for {self.model_name}')


### PR DESCRIPTION
With https://github.com/OpenDevin/OpenDevin/pull/2122 the model name got truncated if a colon ":" was part of the model name as "tag".
It was originally aimed at https://github.com/OpenDevin/OpenDevin/issues/2118 to fix an issue with Ollama.

However, this caused problem with OpenRouter, where model names are like "wizardlm-2-8x22b:nitro" and that is the full model name as-is and now got truncated.

For what I could research, Ollama is supposed to have/support these tags and I'm not sure why 2118 caused an issue.

With this PR I added an if to prevent the split for openrouter.