### PR TITLE
doc: changed the welcome logo from 60vh to auto

### DIFF
--- a/docs/src/css/welcome.css
+++ b/docs/src/css/welcome.css
@@ -33,7 +33,7 @@
   
   @media (min-width: 768px) {
     .welcome-logo {
-      height: 60vh;
+      height: auto;
       width: 350px;
     }
   }


### PR DESCRIPTION
Fixes the weird aspect ratio of the OpenDevin Logo: 
Before: 

![before](https://github.com/OpenDevin/OpenDevin/assets/96804013/87c603fb-6942-4ff1-88d4-80ce0272e871)


After:
![after](https://github.com/OpenDevin/OpenDevin/assets/96804013/abf682d5-ccd5-4b0f-ad37-ad594f06343b)
