### PR TITLE
Transition Share-OpenDevin to gcloud endpoint

### DIFF
--- a/opendevin/server/data_models/feedback.py
+++ b/opendevin/server/data_models/feedback.py
@@ -15,9 +15,7 @@ class FeedbackDataModel(BaseModel):
     trajectory: list[dict[str, Any]]
 
 
-FEEDBACK_URL = (
-    'https://kttkfkoju5.execute-api.us-east-2.amazonaws.com/od-share-trajectory'
-)
+FEEDBACK_URL = 'https://share-od-trajectory-3u9bw9tx.uc.gateway.dev/share_od_trajectory'
 
 
 def store_feedback(feedback: FeedbackDataModel):


### PR DESCRIPTION
Part of #1802 

We have implemented some functionality to (privately or publicly) share feedback about instances where OpenDevin is working or not: https://github.com/OpenDevin/OpenDevin/pull/2169

Previously I had started hosting of Share-OpenDevin on my own personal AWS account, but we transitioned this to a more permanent gcloud endpoint that will be financially supported by All Hands AI so it won't disappear. This PR just changes the URL to point to this new endpoint.