### PR TITLE
Add docs for sharing feedback

### DIFF
--- a/docs/modules/usage/about.md
+++ b/docs/modules/usage/about.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # 📚 Misc

--- a/docs/modules/usage/feedback.md
+++ b/docs/modules/usage/feedback.md
@@ -1,0 +1,18 @@
+---
+sidebar_position: 6
+---
+
+# ✅ Providing Feedback
+
+When using OpenDevin, you will undoubtably encounter cases where things work well, and others where they don't. We encourage you to provide feedback when you use OpenDevin to help give feedback to the development team, and perhaps more importantly, create an open corpus of coding agent training examples -- Share-OpenDevin!
+
+## 📝 How to Provide Feedback
+
+Providing feedback is easy! When you are using OpenDevin, you can press the thumbs-up or thumbs-down button at any point during your interaction with. You will be prompted to provide your email address (e.g. so we can contact you if we want to ask any follow-up questions), and you can choose whether you want to provide feedback publicly or privately.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/5rFx-StMVV0?si=svo7xzp6LhGK_GXr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+## 📜 Data License and Privacy
+
+* **Public** data will be distributed under the MIT License, like OpenDevin itself, and can be used by the community to train and test models. Obviously, feedback that you can make public will be more valuable for the community as a whole, so when you are not dealing with sensitive information, we would encourage you to choose this option!
+* **Private** data will only be shared with the OpenDevin team for the purpose of improving OpenDevin.


### PR DESCRIPTION
Fixes https://github.com/OpenDevin/OpenDevin/issues/2204

Provides documentation for how to share feedback and how it will be used.