### PR TITLE
[AgentBench evaluation] set run_as_devin to true

### DIFF
--- a/evaluation/agent_bench/README.md
+++ b/evaluation/agent_bench/README.md
@@ -24,7 +24,8 @@ sandbox_timeout = 120
 ssh_hostname = "localhost"
 
 use_host_network = false
-run_as_devin = false
+# AgentBench specific
+run_as_devin = true
 enable_auto_lint = true
 
 [eval_gpt35_turbo]


### PR DESCRIPTION
Some tasks empty the contents of the /etc/sudoers file before running OpenDevin. If we set run_as_devin to false, then installation of jupyter environment would timeout.