### PR TITLE
fix: there maybe unexpected files in event file list, not like 1.json…

### DIFF
--- a/opendevin/events/stream.py
+++ b/opendevin/events/stream.py
@@ -50,8 +50,12 @@ class EventStream:
     def _get_filename_for_id(self, id: int) -> str:
         return f'sessions/{self.sid}/events/{id}.json'
 
-    def _get_id_from_filename(self, filename: str) -> int:
-        return int(filename.split('/')[-1].split('.')[0])
+    @staticmethod
+    def _get_id_from_filename(filename: str) -> int:
+        try:
+            return int(filename.split('/')[-1].split('.')[0])
+        except ValueError:
+            return -1
 
     def get_events(self, start_id=0, end_id=None) -> Iterable[Event]:
         event_id = start_id


### PR DESCRIPTION
fix: there maybe unexpected files in event file list, not like 1.json, 2.json, but .DS_Store for macOS system.

so the `_reinitialize_from_file_store` will throw exception during init `EventStream` from existing event store.