### PR TITLE
Makefile setup-config to store the persist_sandbox boolean value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ setup-config-prompts:
 	 if [ "$$persist_sandbox" = "true" ]; then \
 		 read -p "Enter a password for the sandbox container: " ssh_password; \
 		 echo "ssh_password=\"$$ssh_password\"" >> $(CONFIG_FILE).tmp; \
+		 echo "persist_sandbox=$$persist_sandbox" >> $(CONFIG_FILE).tmp; \
 	 else \
 		echo "persist_sandbox=$$persist_sandbox" >> $(CONFIG_FILE).tmp; \
 	 fi


### PR DESCRIPTION
To make the sandbox persistant, we need to have persist_sandbox=true
 in config.toml 
 
 However, in current Makefile setup-config, it does not store this value.  