### PR TITLE
fix: hide special paths; sort models

### DIFF
--- a/opendevin/runtime/files.py
+++ b/opendevin/runtime/files.py
@@ -34,6 +34,31 @@ def get_folder_structure(workdir: Path) -> WorkspaceFile:
     root = WorkspaceFile(name=workdir.name, children=[])
     for item in workdir.iterdir():
         if item.is_dir():
+            # Ignore special folders
+            if item.parts[-1] in (
+                '.git',
+                '.DS_Store',
+                '.svn',
+                '.hg',
+                '.idea',
+                '.vscode',
+                '.settings',
+                '.pytest_cache',
+                '__pycache__',
+                'node_modules',
+                'vendor',
+                'build',
+                'dist',
+                'bin',
+                'logs',
+                'log',
+                'tmp',
+                'temp',
+                'coverage',
+                'venv',
+                'env',
+            ):
+                continue
             dir = get_folder_structure(item)
             if dir.children:
                 root.children.append(dir)

--- a/opendevin/runtime/server/files.py
+++ b/opendevin/runtime/server/files.py
@@ -33,6 +33,35 @@ def resolve_path(file_path, working_directory):
     # Get path relative to host
     path_in_host_workspace = Path(config.workspace_base) / path_in_workspace
 
+    # Prevent special folders
+    if path_in_host_workspace:
+        path_obj = Path(path_in_host_workspace)
+        if path_obj:
+            if path_obj.parts[-1] in (
+                '.git',
+                '.DS_Store',
+                '.svn',
+                '.hg',
+                '.idea',
+                '.vscode',
+                '.settings',
+                '.pytest_cache',
+                '__pycache__',
+                'node_modules',
+                'vendor',
+                'build',
+                'dist',
+                'bin',
+                'logs',
+                'log',
+                'tmp',
+                'temp',
+                'coverage',
+                'venv',
+                'env',
+            ):
+                raise PermissionError('Invalid path.')
+
     return path_in_host_workspace
 
 

--- a/opendevin/server/README.md
+++ b/opendevin/server/README.md
@@ -3,6 +3,7 @@
 This is a WebSocket server that executes tasks using an agent.
 
 ## Install
+
 Follow the instructions in the base README.md to install dependencies and set up.
 
 ## Start the Server
@@ -13,7 +14,7 @@ uvicorn opendevin.server.listen:app --reload --port 3000
 
 ## Test the Server
 
-You can use `websocat` to test the server: https://github.com/vi/websocat
+You can use [`websocat`](https://github.com/vi/websocat) to test the server.
 
 ```sh
 websocat ws://127.0.0.1:3000/ws
@@ -24,23 +25,28 @@ websocat ws://127.0.0.1:3000/ws
 
 ```sh
 LLM_API_KEY=sk-... # Your OpenAI API Key
-LLM_MODEL=gpt-4o # Default model for the agent to use
-WORKSPACE_BASE=/path/to/your/workspace # Default path to model's workspace
+LLM_MODEL=gpt-4o   # Default model for the agent to use
+WORKSPACE_BASE=/path/to/your/workspace # Default absolute path to workspace
 ```
 
 ## API Schema
+
 There are two types of messages that can be sent to, or received from, the server:
+
 * Actions
 * Observations
 
 ### Actions
+
 An action has three parts:
+
 * `action`: The action to be taken
 * `args`: The arguments for the action
 * `message`: A friendly message that can be put in the chat log
 
 There are several kinds of actions. Their arguments are listed below.
 This list may grow over time.
+
 * `initialize` - initializes the agent. Only sent by client.
   * `model` - the name of the model to use
   * `directory` - the path to the workspace
@@ -66,7 +72,9 @@ This list may grow over time.
 * `finish` - agent signals that the task is completed
 
 ### Observations
+
 An observation has four parts:
+
 * `observation`: The observation type
 * `content`: A string representing the observed data
 * `extras`: additional structured data
@@ -74,6 +82,7 @@ An observation has four parts:
 
 There are several kinds of observations. Their extras are listed below.
 This list may grow over time.
+
 * `read` - the content of a file
   * `path` - the path of the file read
 * `browse` - the HTML content of a url


### PR DESCRIPTION
A list of special folders is now being excluded from the workspace folder tree:
`'.git',
                '.DS_Store',
                '.svn',
                '.hg',
                '.idea',
                '.vscode',
                '.settings',
                '.pytest_cache',
                '__pycache__',
                'node_modules',
                'vendor',
                'build',
                'dist',
                'bin',
                'logs',
                'log',
                'tmp',
                'temp',
                'coverage',
                'venv',
                'env'
`

The Models and Agents lists in the Settings is now sorted by name.

Fixes https://github.com/OpenDevin/OpenDevin/issues/2056