### PR TITLE
Add back jupyter PWD env var for agentskills

### DIFF
--- a/opendevin/runtime/plugins/jupyter/execute_cli
+++ b/opendevin/runtime/plugins/jupyter/execute_cli
@@ -1,3 +1,4 @@
 #!/bin/bash
 # Run the Python script with the specified interpreter
+export JUPYTER_PWD=$(pwd)
 $OPENDEVIN_PYTHON_INTERPRETER /opendevin/plugins/jupyter/execute_cli.py


### PR DESCRIPTION
We introduce `JUPYTER_PWD` in https://github.com/OpenDevin/OpenDevin/pull/2105/files#diff-fbc8351b325a35a525f30e58eae651dbd50b3692963c81b989bee4dac617511c, so that every `create_file`, `open_file` command from `agentskills` is aware of the (bash's) current working directory.

It got accidentally removed in this commit: https://github.com/OpenDevin/OpenDevin/commit/78e003caf651d5031510cb9ed5e094f02d28eddc

Adding it back now.

Example, when `cd` into a folder `aaa`, the new `create_file` command should create file inside `aaa`, instead of `/workspace':
<img width="1026" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/38853559/5360bf6b-dbb9-43e7-a648-2a4fc24f449a">
