### PR TITLE
Encapsulate sandbox vars in sandbox config

### DIFF
--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -207,7 +207,7 @@ def get_request_action_prompt(
         'hint': hint,
         'user': user,
         'timeout': config.sandbox_timeout,
-        'WORKSPACE_MOUNT_PATH_IN_SANDBOX': config.workspace_mount_path_in_sandbox,
+        'WORKSPACE_MOUNT_PATH_IN_SANDBOX': config.sandbox.workspace_mount_path_in_sandbox,
     }
 
 

--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -196,7 +196,7 @@ def get_request_action_prompt(
             )
         bg_commands_message += '\nYou can end any process by sending a `kill` action with the numerical `command_id` above.'
 
-    user = 'opendevin' if config.run_as_devin else 'root'
+    user = 'opendevin' if config.sandbox.run_as_devin else 'root'
 
     monologue = thoughts + recent_events
 
@@ -206,7 +206,7 @@ def get_request_action_prompt(
         'background_commands': bg_commands_message,
         'hint': hint,
         'user': user,
-        'timeout': config.sandbox_timeout,
+        'timeout': config.sandbox.sandbox_timeout,
         'WORKSPACE_MOUNT_PATH_IN_SANDBOX': config.sandbox.workspace_mount_path_in_sandbox,
     }
 

--- a/evaluation/EDA/run_infer.py
+++ b/evaluation/EDA/run_infer.py
@@ -187,8 +187,8 @@ if __name__ == '__main__':
     )
     args, _ = parser.parse_known_args()
     if args.directory:
-        config.workspace_base = os.path.abspath(args.directory)
-        print(f'Setting workspace base to {config.workspace_base}')
+        config.sandbox.workspace_base = os.path.abspath(args.directory)
+        print(f'Setting workspace base to {config.sandbox.workspace_base}')
     # NOTE: It is preferable to load datasets from huggingface datasets and perform post-processing
     # so we don't need to manage file uploading to OpenDevin's repo
     eda_dataset = load_dataset(

--- a/evaluation/TUTORIAL.md
+++ b/evaluation/TUTORIAL.md
@@ -31,16 +31,19 @@ workspace_base = "/path/to/your/workspace"
 workspace_mount_path = "/path/to/your/workspace"
 # ==========================
 
-sandbox_container_image = "ghcr.io/opendevin/sandbox:latest"
-sandbox_type = "ssh"
-sandbox_timeout = 120
+# linting python after editing helps LLM fix indentations
+enable_auto_lint = true
+
+[sandbox]
+container_image = "ghcr.io/opendevin/sandbox:latest"
+type = "ssh"
+timeout = 120
 ssh_hostname = "localhost"
 
 # SWEBench eval specific - but you can tweak it to your needs
 use_host_network = false
 run_as_devin = false
-# linting python after editing helps LLM fix indentations
-enable_auto_lint = true
+
 
 [llm]
 # IMPORTANT: add your API key here, and set the model to the one you want to evaluate

--- a/evaluation/agent_bench/README.md
+++ b/evaluation/agent_bench/README.md
@@ -18,15 +18,18 @@ cache_dir = "/path/to/cache"
 workspace_base = "/path/to/workspace"
 workspace_mount_path = "/path/to/workspace"
 
-sandbox_container_image = "ghcr.io/opendevin/sandbox:latest"
-sandbox_type = "ssh"
-sandbox_timeout = 120
+enable_auto_lint = true
+
+[sandbox]
+container_image = "ghcr.io/opendevin/sandbox:latest"
+type = "ssh"
+timeout = 120
 ssh_hostname = "localhost"
 
 use_host_network = false
 # AgentBench specific
 run_as_devin = true
-enable_auto_lint = true
+
 
 [eval_gpt35_turbo]
 model = "gpt-3.5-turbo"

--- a/evaluation/agent_bench/run_infer.py
+++ b/evaluation/agent_bench/run_infer.py
@@ -93,7 +93,7 @@ def process_instance(
     # create a directory for the instance's workspace
     instance_workspace = str(os.path.join(config.sandbox.workspace_base, inst_id))
     container_inst_workspace = str(
-        os.path.join(config.workspace_mount_path_in_sandbox, inst_id)
+        os.path.join(config.sandbox.workspace_mount_path_in_sandbox, inst_id)
     )
     if os.path.exists(instance_workspace):
         shutil.rmtree(instance_workspace)

--- a/evaluation/agent_bench/run_infer.py
+++ b/evaluation/agent_bench/run_infer.py
@@ -91,7 +91,7 @@ def process_instance(
     inst_id = instance.instance_id
     question = instance.description
     # create a directory for the instance's workspace
-    instance_workspace = str(os.path.join(config.workspace_base, inst_id))
+    instance_workspace = str(os.path.join(config.sandbox.workspace_base, inst_id))
     container_inst_workspace = str(
         os.path.join(config.workspace_mount_path_in_sandbox, inst_id)
     )

--- a/evaluation/bird/run_infer.py
+++ b/evaluation/bird/run_infer.py
@@ -143,7 +143,9 @@ def process_instance(
 
     # Copy the database to the workspace
     db_root = os.path.join(
-        config.workspace_base, 'evaluation_bird/dev/dev_databases', instance.db_id
+        config.sandbox.workspace_base,
+        'evaluation_bird/dev/dev_databases',
+        instance.db_id,
     )
     target_path = os.path.join(workspace_mount_path, f'{instance.db_id}')
     if not os.path.exists(target_path):
@@ -262,7 +264,7 @@ def download_bird():
     """
     Downloads and extracts the bird dataset from a specified URL into a local directory.
     """
-    dataset_path = os.path.join(config.workspace_base, 'evaluation_bird')
+    dataset_path = os.path.join(config.sandbox.workspace_base, 'evaluation_bird')
     devset_path = os.path.join(dataset_path, 'dev')
     if not os.path.exists(dataset_path):
         logger.info(

--- a/evaluation/bird/run_infer.py
+++ b/evaluation/bird/run_infer.py
@@ -129,7 +129,7 @@ def process_instance(
     instance, agent_class, metadata, skip_workspace_mount, reset_logger: bool = True
 ):
     workspace_mount_path = os.path.join(
-        config.workspace_mount_path, 'bird_eval_workspace'
+        config.sandbox.workspace_mount_path, 'bird_eval_workspace'
     )
     # create process-specific workspace dir
     # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
@@ -139,7 +139,7 @@ def process_instance(
         pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
 
     # reset workspace to config
-    config.workspace_mount_path = workspace_mount_path
+    config.sandbox.workspace_mount_path = workspace_mount_path
 
     # Copy the database to the workspace
     db_root = os.path.join(
@@ -201,7 +201,7 @@ def process_instance(
         print(result)
     """
     path = os.path.join(
-        config.workspace_mount_path, f'{instance.task_id.replace("/", "__")}.py'
+        config.sandbox.workspace_mount_path, f'{instance.task_id.replace("/", "__")}.py'
     )
     instruction = (
         f'You are a SQL expert and need to complete the following text-to-SQL tasks.'

--- a/evaluation/gaia/run_infer.py
+++ b/evaluation/gaia/run_infer.py
@@ -76,15 +76,15 @@ def process_instance(instance, agent_class, metadata, reset_logger: bool = True)
     # create process-specific workspace dir
     # we will create a workspace directory for EACH process
     # so that different agent don't interfere with each other.
-    old_workspace_mount_path = config.workspace_mount_path
+    old_workspace_mount_path = config.sandbox.workspace_mount_path
 
     try:
         workspace_mount_path = os.path.join(
-            config.workspace_mount_path, '_eval_workspace'
+            config.sandbox.workspace_mount_path, '_eval_workspace'
         )
         workspace_mount_path = os.path.join(workspace_mount_path, str(os.getpid()))
         pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
-        config.workspace_mount_path = workspace_mount_path
+        config.sandbox.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallelize the evaluation
         eval_output_dir = metadata['eval_output_dir']
@@ -203,7 +203,7 @@ def process_instance(instance, agent_class, metadata, reset_logger: bool = True)
         logger.error('Process instance failed')
         raise
     finally:
-        config.workspace_mount_path = old_workspace_mount_path
+        config.sandbox.workspace_mount_path = old_workspace_mount_path
     return output
 
 

--- a/evaluation/gaia/run_infer.py
+++ b/evaluation/gaia/run_infer.py
@@ -221,8 +221,8 @@ if __name__ == '__main__':
     )
     args, _ = parser.parse_known_args()
     if args.directory:
-        config.workspace_base = os.path.abspath(args.directory)
-        logger.info(f'Setting workspace base to {config.workspace_base}')
+        config.sandbox.workspace_base = os.path.abspath(args.directory)
+        logger.info(f'Setting workspace base to {config.sandbox.workspace_base}')
     # NOTE: It is preferable to load datasets from huggingface datasets and perform post-processing
     # so we don't need to manage file uploading to OpenDevin's repo
     level = args.level

--- a/evaluation/gorilla/run_infer.py
+++ b/evaluation/gorilla/run_infer.py
@@ -69,14 +69,14 @@ def process_instance(
     # create process-specific workspace dir
     # we will create a workspace directory for EACH process
     # so that different agent don't interfere with each other.
-    old_workspace_mount_path = config.workspace_mount_path
+    old_workspace_mount_path = config.sandbox.workspace_mount_path
     try:
         workspace_mount_path = os.path.join(
-            config.workspace_mount_path, '_eval_workspace'
+            config.sandbox.workspace_mount_path, '_eval_workspace'
         )
         workspace_mount_path = os.path.join(workspace_mount_path, str(os.getpid()))
         pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
-        config.workspace_mount_path = workspace_mount_path
+        config.sandbox.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallize the evaluation
         eval_output_dir = metadata['eval_output_dir']
@@ -158,7 +158,7 @@ def process_instance(
         logger.error('Process instance failed')
         raise
     finally:
-        config.workspace_mount_path = old_workspace_mount_path
+        config.sandbox.workspace_mount_path = old_workspace_mount_path
     return output
 
 

--- a/evaluation/gorilla/run_infer.py
+++ b/evaluation/gorilla/run_infer.py
@@ -172,8 +172,8 @@ if __name__ == '__main__':
     )
     args, _ = parser.parse_known_args()
     if args.directory:
-        config.workspace_base = os.path.abspath(args.directory)
-        print(f'Setting workspace base to {config.workspace_base}')
+        config.sandbox.workspace_base = os.path.abspath(args.directory)
+        print(f'Setting workspace base to {config.sandbox.workspace_base}')
 
     # Check https://github.com/OpenDevin/OpenDevin/blob/main/evaluation/swe_bench/README.md#configure-opendevin-and-your-llm
     # for details of how to set `llm_config`

--- a/evaluation/gpqa/run_infer.py
+++ b/evaluation/gpqa/run_infer.py
@@ -165,7 +165,7 @@ def process_instance(
     Process a single instance from the dataset
     """
     old_workspace_mount_path = config.workspace_mount_path
-    old_workspace_base = config.workspace_base
+    old_workspace_base = config.sandbox.workspace_base
     try:
         workspace_mount_path = os.path.join(
             config.workspace_mount_path, '_eval_workspace'
@@ -179,7 +179,7 @@ def process_instance(
             pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
 
         # reset workspace to config
-        config.workspace_base = workspace_mount_path
+        config.sandbox.workspace_base = workspace_mount_path
         config.workspace_mount_path = workspace_mount_path
 
         # workspace_mount_path = os.path.join(config.workspace_mount_path, '_eval_workspace')
@@ -296,7 +296,7 @@ def process_instance(
         raise
     finally:
         config.workspace_mount_path = old_workspace_mount_path
-        config.workspace_base = old_workspace_base
+        config.sandbox.workspace_base = old_workspace_base
     return output
 
 

--- a/evaluation/gpqa/run_infer.py
+++ b/evaluation/gpqa/run_infer.py
@@ -164,11 +164,11 @@ def process_instance(
     """
     Process a single instance from the dataset
     """
-    old_workspace_mount_path = config.workspace_mount_path
+    old_workspace_mount_path = config.sandbox.workspace_mount_path
     old_workspace_base = config.sandbox.workspace_base
     try:
         workspace_mount_path = os.path.join(
-            config.workspace_mount_path, '_eval_workspace'
+            config.sandbox.workspace_mount_path, '_eval_workspace'
         )
         # create process-specific workspace dir
         # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
@@ -180,9 +180,9 @@ def process_instance(
 
         # reset workspace to config
         config.sandbox.workspace_base = workspace_mount_path
-        config.workspace_mount_path = workspace_mount_path
+        config.sandbox.workspace_mount_path = workspace_mount_path
 
-        # workspace_mount_path = os.path.join(config.workspace_mount_path, '_eval_workspace')
+        # workspace_mount_path = os.path.join(config.sandbox.workspace_mount_path, '_eval_workspace')
         # workspace_mount_path = os.path.abspath(workspace_mount_path)
         # # create process-specific workspace dir
         # # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
@@ -295,7 +295,7 @@ def process_instance(
         logger.error('Process instance failed')
         raise
     finally:
-        config.workspace_mount_path = old_workspace_mount_path
+        config.sandbox.workspace_mount_path = old_workspace_mount_path
         config.sandbox.workspace_base = old_workspace_base
     return output
 

--- a/evaluation/humanevalfix/run_infer.py
+++ b/evaluation/humanevalfix/run_infer.py
@@ -138,12 +138,12 @@ def get_test_result(instance, path, language='python', timeout=10):
 def process_instance(
     instance, agent_class, metadata, skip_workspace_mount, reset_logger: bool = True
 ):
-    old_workspace_mount_path = config.workspace_mount_path
+    old_workspace_mount_path = config.sandbox.workspace_mount_path
     old_workspace_base = config.sandbox.workspace_base
 
     try:
         workspace_mount_path = os.path.join(
-            config.workspace_mount_path, '_eval_workspace'
+            config.sandbox.workspace_mount_path, '_eval_workspace'
         )
         # create process-specific workspace dir
         # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
@@ -154,7 +154,7 @@ def process_instance(
 
         # reset workspace to config
         config.sandbox.workspace_base = workspace_mount_path
-        config.workspace_mount_path = workspace_mount_path
+        config.sandbox.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallelize the evaluation
         if reset_logger:
@@ -246,7 +246,7 @@ def process_instance(
         logger.error('Process instance failed')
         raise
     finally:
-        config.workspace_mount_path = old_workspace_mount_path
+        config.sandbox.workspace_mount_path = old_workspace_mount_path
         config.sandbox.workspace_base = old_workspace_base
     return output
 

--- a/evaluation/humanevalfix/run_infer.py
+++ b/evaluation/humanevalfix/run_infer.py
@@ -139,7 +139,7 @@ def process_instance(
     instance, agent_class, metadata, skip_workspace_mount, reset_logger: bool = True
 ):
     old_workspace_mount_path = config.workspace_mount_path
-    old_workspace_base = config.workspace_base
+    old_workspace_base = config.sandbox.workspace_base
 
     try:
         workspace_mount_path = os.path.join(
@@ -153,7 +153,7 @@ def process_instance(
             pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
 
         # reset workspace to config
-        config.workspace_base = workspace_mount_path
+        config.sandbox.workspace_base = workspace_mount_path
         config.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallelize the evaluation
@@ -247,7 +247,7 @@ def process_instance(
         raise
     finally:
         config.workspace_mount_path = old_workspace_mount_path
-        config.workspace_base = old_workspace_base
+        config.sandbox.workspace_base = old_workspace_base
     return output
 
 

--- a/evaluation/logic_reasoning/run_infer.py
+++ b/evaluation/logic_reasoning/run_infer.py
@@ -136,12 +136,12 @@ def process_instance(
     eval_output_dir,
     reset_logger: bool = True,
 ):
-    old_workspace_mount_path = config.workspace_mount_path
+    old_workspace_mount_path = config.sandbox.workspace_mount_path
     old_workspace_base = config.sandbox.workspace_base
 
     try:
         workspace_mount_path = os.path.join(
-            config.workspace_mount_path, '_eval_workspace'
+            config.sandbox.workspace_mount_path, '_eval_workspace'
         )
         # create process-specific workspace dir
         # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
@@ -152,7 +152,7 @@ def process_instance(
 
         # reset workspace to config
         config.sandbox.workspace_base = workspace_mount_path
-        config.workspace_mount_path = workspace_mount_path
+        config.sandbox.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallelize the evaluation
         if reset_logger:
@@ -267,7 +267,7 @@ def process_instance(
         logger.error('Process instance failed')
         raise
     finally:
-        config.workspace_mount_path = old_workspace_mount_path
+        config.sandbox.workspace_mount_path = old_workspace_mount_path
         config.sandbox.workspace_base = old_workspace_base
 
     # Close the sandbox

--- a/evaluation/logic_reasoning/run_infer.py
+++ b/evaluation/logic_reasoning/run_infer.py
@@ -137,7 +137,7 @@ def process_instance(
     reset_logger: bool = True,
 ):
     old_workspace_mount_path = config.workspace_mount_path
-    old_workspace_base = config.workspace_base
+    old_workspace_base = config.sandbox.workspace_base
 
     try:
         workspace_mount_path = os.path.join(
@@ -151,7 +151,7 @@ def process_instance(
             pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
 
         # reset workspace to config
-        config.workspace_base = workspace_mount_path
+        config.sandbox.workspace_base = workspace_mount_path
         config.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallelize the evaluation
@@ -268,7 +268,7 @@ def process_instance(
         raise
     finally:
         config.workspace_mount_path = old_workspace_mount_path
-        config.workspace_base = old_workspace_base
+        config.sandbox.workspace_base = old_workspace_base
 
     # Close the sandbox
     sandbox.close()
@@ -293,8 +293,8 @@ if __name__ == '__main__':
 
     args, _ = parser.parse_known_args()
     if args.directory:
-        config.workspace_base = os.path.abspath(args.directory)
-        print(f'Setting workspace base to {config.workspace_base}')
+        config.sandbox.workspace_base = os.path.abspath(args.directory)
+        print(f'Setting workspace base to {config.sandbox.workspace_base}')
     # NOTE: It is preferable to load datasets from huggingface datasets and perform post-processing
     # so we don't need to manage file uploading to OpenDevin's repo
 

--- a/evaluation/miniwob/README.md
+++ b/evaluation/miniwob/README.md
@@ -16,10 +16,12 @@ Add the following configurations:
 [core]
 max_iterations = 100
 cache_dir = "/tmp/cache"
-sandbox_container_image = "ghcr.io/opendevin/sandbox:latest"
-sandbox_type = "ssh"
+
+[sandbox]
+container_image = "ghcr.io/opendevin/sandbox:latest"
+type = "ssh"
 ssh_hostname = "localhost"
-sandbox_timeout = 120
+timeout = 120
 
 # TODO: Change these to the model you want to evaluate
 [eval_gpt4_1106_preview]

--- a/evaluation/mint/run_infer.py
+++ b/evaluation/mint/run_infer.py
@@ -82,7 +82,9 @@ def process_instance(
     eval_output_dir,
     reset_logger: bool = True,
 ):
-    workspace_mount_path = os.path.join(config.workspace_mount_path, '_eval_workspace')
+    workspace_mount_path = os.path.join(
+        config.sandbox.workspace_mount_path, '_eval_workspace'
+    )
     # create process-specific workspace dir
     # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
     # so that different agent don't interfere with each other.

--- a/evaluation/ml_bench/README.md
+++ b/evaluation/ml_bench/README.md
@@ -24,10 +24,12 @@ Add the following configurations:
 [core]
 max_iterations = 100
 cache_dir = "/tmp/cache"
-ssh_hostname = "localhost"
 enable_auto_lint = true
+
+[sandbox]
+ssh_hostname = "localhost"
 run_as_devin = false
-sandbox_container_image = "public.ecr.aws/i5g0m1f6/ml-bench" # Use the latest image from the ML-Bench repository
+container_image = "public.ecr.aws/i5g0m1f6/ml-bench" # Use the latest image from the ML-Bench repository
 
 # TODO: Change these to the model you want to evaluate
 [eval_gpt4_1106_preview]

--- a/evaluation/ml_bench/run_infer.py
+++ b/evaluation/ml_bench/run_infer.py
@@ -102,7 +102,7 @@ def process_instance(
     instance, agent_class, metadata, eval_output_dir, reset_logger: bool = True
 ):
     old_workspace_mount_path = config.workspace_mount_path
-    old_workspace_base = config.workspace_base
+    old_workspace_base = config.sandbox.workspace_base
     try:
         workspace_mount_path = os.path.join(
             config.workspace_mount_path, '_eval_workspace'
@@ -113,7 +113,7 @@ def process_instance(
         pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
 
         # reset workspace to config
-        config.workspace_base = workspace_mount_path
+        config.sandbox.workspace_base = workspace_mount_path
         config.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallize the evaluation
@@ -242,7 +242,7 @@ def process_instance(
         raise
     finally:
         config.workspace_mount_path = old_workspace_mount_path
-        config.workspace_base = old_workspace_base
+        config.sandbox.workspace_base = old_workspace_base
 
     # Shutdown the sandbox
     sandbox.close()

--- a/evaluation/ml_bench/run_infer.py
+++ b/evaluation/ml_bench/run_infer.py
@@ -101,11 +101,11 @@ ID2CONDA = {
 def process_instance(
     instance, agent_class, metadata, eval_output_dir, reset_logger: bool = True
 ):
-    old_workspace_mount_path = config.workspace_mount_path
+    old_workspace_mount_path = config.sandbox.workspace_mount_path
     old_workspace_base = config.sandbox.workspace_base
     try:
         workspace_mount_path = os.path.join(
-            config.workspace_mount_path, '_eval_workspace'
+            config.sandbox.workspace_mount_path, '_eval_workspace'
         )
         # create process-specific workspace dir
         # so that different agent don't interfere with each other.
@@ -114,7 +114,7 @@ def process_instance(
 
         # reset workspace to config
         config.sandbox.workspace_base = workspace_mount_path
-        config.workspace_mount_path = workspace_mount_path
+        config.sandbox.workspace_mount_path = workspace_mount_path
 
         # Setup the logger properly, so you can run multi-processing to parallize the evaluation
         if reset_logger:
@@ -241,7 +241,7 @@ def process_instance(
         logger.error(f'Error processing instance {instance["id"]}: {e}')
         raise
     finally:
-        config.workspace_mount_path = old_workspace_mount_path
+        config.sandbox.workspace_mount_path = old_workspace_mount_path
         config.sandbox.workspace_base = old_workspace_base
 
     # Shutdown the sandbox

--- a/evaluation/swe_bench/README.md
+++ b/evaluation/swe_bench/README.md
@@ -42,15 +42,17 @@ Add the following configurations:
 [core]
 max_iterations = 100
 cache_dir = "/tmp/cache"
-sandbox_container_image = "ghcr.io/opendevin/sandbox:latest"
-sandbox_type = "ssh"
+enable_auto_lint = true
+
+[sandbox]
+container_image = "ghcr.io/opendevin/sandbox:latest"
+type = "ssh"
 ssh_hostname = "localhost"
-sandbox_timeout = 120
+timeout = 120
 
 # SWEBench eval specific
 use_host_network = false
 run_as_devin = false
-enable_auto_lint = true
 
 # TODO: Change these to the model you want to evaluate
 [eval_gpt4_1106_preview]

--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -197,7 +197,9 @@ def process_instance(
     eval_output_dir: str,
     reset_logger: bool = True,
 ):
-    workspace_mount_path = os.path.join(config.workspace_mount_path, '_eval_workspace')
+    workspace_mount_path = os.path.join(
+        config.sandbox.workspace_mount_path, '_eval_workspace'
+    )
     # create process-specific workspace dir
     # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
     # so that different agent don't interfere with each other.

--- a/evaluation/swe_bench/swe_env_box.py
+++ b/evaluation/swe_bench/swe_env_box.py
@@ -84,11 +84,11 @@ class SWEBenchSSHBox(DockerSSHBox):
                 '/', '__'
             )
         old_workspace_base = config.sandbox.workspace_base
-        old_workspace_mount_path = config.workspace_mount_path
+        old_workspace_mount_path = config.sandbox.workspace_mount_path
 
         try:
             config.sandbox.workspace_base = workspace_mount_path
-            config.workspace_mount_path = workspace_mount_path
+            config.sandbox.workspace_mount_path = workspace_mount_path
 
             # linting python after editing helps LLM fix indentations
             config.enable_auto_lint = True
@@ -127,7 +127,7 @@ class SWEBenchSSHBox(DockerSSHBox):
         finally:
             # restore workspace_base and workspace_mount_path
             config.sandbox.workspace_base = old_workspace_base
-            config.workspace_mount_path = old_workspace_mount_path
+            config.sandbox.workspace_mount_path = old_workspace_mount_path
         return sandbox
 
     def get_diff_patch(self):

--- a/evaluation/swe_bench/swe_env_box.py
+++ b/evaluation/swe_bench/swe_env_box.py
@@ -83,11 +83,11 @@ class SWEBenchSSHBox(DockerSSHBox):
             workspace_dir_name = f"{instance['repo']}__{instance['version']}".replace(
                 '/', '__'
             )
-        old_workspace_base = config.workspace_base
+        old_workspace_base = config.sandbox.workspace_base
         old_workspace_mount_path = config.workspace_mount_path
 
         try:
-            config.workspace_base = workspace_mount_path
+            config.sandbox.workspace_base = workspace_mount_path
             config.workspace_mount_path = workspace_mount_path
 
             # linting python after editing helps LLM fix indentations
@@ -126,7 +126,7 @@ class SWEBenchSSHBox(DockerSSHBox):
             raise
         finally:
             # restore workspace_base and workspace_mount_path
-            config.workspace_base = old_workspace_base
+            config.sandbox.workspace_base = old_workspace_base
             config.workspace_mount_path = old_workspace_mount_path
         return sandbox
 

--- a/evaluation/toolqa/run_infer.py
+++ b/evaluation/toolqa/run_infer.py
@@ -67,7 +67,7 @@ def process_instance(task, agent_class, metadata, reset_logger: bool = True):
     # create process-specific workspace dir
     # we will create a workspace directory for EACH process
     # so that different agent don't interfere with each other.
-    workspace_mount_path = config.workspace_mount_path
+    workspace_mount_path = config.sandbox.workspace_mount_path
     pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
 
     # Setup the logger properly, so you can run multi-processing to parallize the evaluation
@@ -222,8 +222,8 @@ if __name__ == '__main__':
         raise ValueError('Please choose from easy and hard for hardness.')
 
     logger.info(f'Evaluating ToolQA {dataset} {hardness} test')
-    # workspace_mount_path = os.path.join(config.workspace_mount_path, '_eval_workspace')
-    workspace_mount_path = config.workspace_mount_path
+    # workspace_mount_path = os.path.join(config.sandbox.workspace_mount_path, '_eval_workspace')
+    workspace_mount_path = config.sandbox.workspace_mount_path
     pathlib.Path(workspace_mount_path).mkdir(parents=True, exist_ok=True)
     toolqa_test = get_data(dataset, hardness)
     toolqa_data_path = download_data(workspace_mount_path)

--- a/evaluation/toolqa/run_infer.py
+++ b/evaluation/toolqa/run_infer.py
@@ -165,8 +165,8 @@ if __name__ == '__main__':
     )
     args, _ = parser.parse_known_args()
     if args.directory:
-        config.workspace_base = os.path.abspath(args.directory)
-        print(f'Setting workspace base to {config.workspace_base}')
+        config.sandbox.workspace_base = os.path.abspath(args.directory)
+        print(f'Setting workspace base to {config.sandbox.workspace_base}')
     # Check https://github.com/OpenDevin/OpenDevin/blob/main/evaluation/swe_bench/README.md#configure-opendevin-and-your-llm
     # for details of how to set `llm_config`
     if args.llm_config:

--- a/evaluation/webarena/README.md
+++ b/evaluation/webarena/README.md
@@ -16,10 +16,12 @@ Add the following configurations:
 [core]
 max_iterations = 100
 cache_dir = "/tmp/cache"
-sandbox_container_image = "ghcr.io/opendevin/sandbox:latest"
-sandbox_type = "ssh"
+
+[sandbox]
+container_image = "ghcr.io/opendevin/sandbox:latest"
+type = "ssh"
 ssh_hostname = "localhost"
-sandbox_timeout = 120
+timeout = 120
 
 # TODO: Change these to the model you want to evaluate
 [eval_gpt4_1106_preview]

--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -128,8 +128,8 @@ class SandboxConfig(metaclass=Singleton):
     Configuration for the sandbox.
 
     Attributes:
-        sandbox_container_image: The container image to use for the sandbox.
-        sandbox_type: The type of sandbox to use. Options are: ssh, exec, e2b, local.
+        container_image: The container image to use for the sandbox.
+        type: The type of sandbox to use. Options are: ssh, exec, e2b, local.
         workspace_base: The base path for the workspace. Defaults to ./workspace as an absolute path.
         workspace_mount_path: The path to mount the workspace. This is set to the workspace base by default.
         workspace_mount_path_in_sandbox: The path to mount the workspace in the sandbox. Defaults to /workspace.
@@ -146,12 +146,12 @@ class SandboxConfig(metaclass=Singleton):
 
     """
 
-    sandbox_container_image: str = 'ghcr.io/opendevin/sandbox' + (
+    container_image: str = 'ghcr.io/opendevin/sandbox' + (
         f':{os.getenv("OPEN_DEVIN_BUILD_VERSION")}'
         if os.getenv('OPEN_DEVIN_BUILD_VERSION')
         else ':main'
     )
-    sandbox_type: str = 'ssh'  # Can be 'ssh', 'exec', or 'e2b'
+    type: str = 'ssh'  # Can be 'ssh', 'exec', or 'e2b'
     workspace_base: str = os.path.join(os.getcwd(), 'workspace')
     workspace_mount_path: str | None = None
     workspace_mount_path_in_sandbox: str = '/workspace'
@@ -409,7 +409,7 @@ def finalize_config(config: AppConfig):
     config.sandbox.workspace_base = os.path.abspath(config.sandbox.workspace_base)
 
     # In local there is no sandbox, the workspace will have the same pwd as the host
-    if config.sandbox.sandbox_type == 'local':
+    if config.sandbox.type == 'local':
         config.sandbox.workspace_mount_path_in_sandbox = (
             config.sandbox.workspace_mount_path
         )

--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -414,7 +414,7 @@ def finalize_config(config: AppConfig):
             config.sandbox.workspace_mount_path
         )
 
-    if config.workspace_mount_rewrite:  # and not config.workspace_mount_path:
+    if config.workspace_mount_rewrite:  # and not config.sandbox.workspace_mount_path:
         # TODO why do we need to check if workspace_mount_path is None?
         base = config.sandbox.workspace_base or os.getcwd()
         parts = config.workspace_mount_rewrite.split(':')

--- a/opendevin/runtime/docker/exec_box.py
+++ b/opendevin/runtime/docker/exec_box.py
@@ -107,7 +107,7 @@ class DockerExecBox(Sandbox):
     def __init__(
         self,
         container_image: str | None = None,
-        timeout: int = config.sandbox_timeout,
+        timeout: int = config.sandbox.sandbox_timeout,
         sid: str | None = None,
     ):
         # Initialize docker client. Throws an exception if Docker is not reachable.
@@ -360,13 +360,13 @@ class DockerExecBox(Sandbox):
 
     @property
     def user_id(self):
-        return config.sandbox_user_id
+        return config.sandbox.sandbox_user_id
 
     @property
     def run_as_devin(self):
         # FIXME: On some containers, the devin user doesn't have enough permission, e.g. to install packages
         # How do we make this more flexible?
-        return config.run_as_devin
+        return config.sandbox.run_as_devin
 
     @property
     def sandbox_workspace_dir(self):

--- a/opendevin/runtime/docker/exec_box.py
+++ b/opendevin/runtime/docker/exec_box.py
@@ -130,7 +130,7 @@ class DockerExecBox(Sandbox):
         # if it is too long, the user may have to wait for a unnecessary long time
         self.timeout = timeout
         self.container_image = (
-            config.sandbox_container_image
+            config.sandbox.sandbox_container_image
             if container_image is None
             else container_image
         )
@@ -313,7 +313,7 @@ class DockerExecBox(Sandbox):
 
         try:
             # start the container
-            mount_dir = config.workspace_mount_path
+            mount_dir = config.sandbox.workspace_mount_path
             self.container = self.docker_client.containers.run(
                 self.container_image,
                 command='tail -f /dev/null',
@@ -370,7 +370,7 @@ class DockerExecBox(Sandbox):
 
     @property
     def sandbox_workspace_dir(self):
-        return config.workspace_mount_path_in_sandbox
+        return config.sandbox.workspace_mount_path_in_sandbox
 
 
 if __name__ == '__main__':

--- a/opendevin/runtime/docker/exec_box.py
+++ b/opendevin/runtime/docker/exec_box.py
@@ -130,7 +130,7 @@ class DockerExecBox(Sandbox):
         # if it is too long, the user may have to wait for a unnecessary long time
         self.timeout = timeout
         self.container_image = (
-            config.sandbox.sandbox_container_image
+            config.sandbox.container_image
             if container_image is None
             else container_image
         )

--- a/opendevin/runtime/docker/local_box.py
+++ b/opendevin/runtime/docker/local_box.py
@@ -27,7 +27,7 @@ from opendevin.runtime.sandbox import Sandbox
 
 class LocalBox(Sandbox):
     def __init__(self, timeout: int = config.sandbox_timeout):
-        os.makedirs(config.workspace_base, exist_ok=True)
+        os.makedirs(config.sandbox.workspace_base, exist_ok=True)
         self.timeout = timeout
         self.background_commands: dict[int, Process] = {}
         self.cur_background_id = 0
@@ -45,7 +45,7 @@ class LocalBox(Sandbox):
                 text=True,
                 capture_output=True,
                 timeout=timeout,
-                cwd=config.workspace_base,
+                cwd=config.sandbox.workspace_base,
                 env=self._env,
             )
             return completed_process.returncode, completed_process.stdout.strip()
@@ -58,7 +58,7 @@ class LocalBox(Sandbox):
             f'mkdir -p {sandbox_dest}',
             shell=True,
             text=True,
-            cwd=config.workspace_base,
+            cwd=config.sandbox.workspace_base,
             env=self._env,
         )
         if res.returncode != 0:
@@ -69,7 +69,7 @@ class LocalBox(Sandbox):
                 f'cp -r {host_src} {sandbox_dest}',
                 shell=True,
                 text=True,
-                cwd=config.workspace_base,
+                cwd=config.sandbox.workspace_base,
                 env=self._env,
             )
             if res.returncode != 0:
@@ -81,7 +81,7 @@ class LocalBox(Sandbox):
                 f'cp {host_src} {sandbox_dest}',
                 shell=True,
                 text=True,
-                cwd=config.workspace_base,
+                cwd=config.sandbox.workspace_base,
                 env=self._env,
             )
             if res.returncode != 0:
@@ -96,7 +96,7 @@ class LocalBox(Sandbox):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
-            cwd=config.workspace_base,
+            cwd=config.sandbox.workspace_base,
         )
         bg_cmd = DockerProcess(
             id=self.cur_background_id, command=cmd, result=process, pid=process.pid
@@ -130,7 +130,7 @@ class LocalBox(Sandbox):
         self.close()
 
     def get_working_directory(self):
-        return config.workspace_base
+        return config.sandbox.workspace_base
 
 
 if __name__ == '__main__':

--- a/opendevin/runtime/docker/local_box.py
+++ b/opendevin/runtime/docker/local_box.py
@@ -26,7 +26,7 @@ from opendevin.runtime.sandbox import Sandbox
 
 
 class LocalBox(Sandbox):
-    def __init__(self, timeout: int = config.sandbox_timeout):
+    def __init__(self, timeout: int = config.sandbox.sandbox_timeout):
         os.makedirs(config.sandbox.workspace_base, exist_ok=True)
         self.timeout = timeout
         self.background_commands: dict[int, Process] = {}

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -226,7 +226,7 @@ class DockerSSHBox(Sandbox):
             self.instance_id = (sid or '') + str(uuid.uuid4())
 
         self.timeout = timeout
-        self.container_image = container_image or config.sandbox_container_image
+        self.container_image = container_image or config.sandbox.sandbox_container_image
         self.container_name = self.container_name_prefix + self.instance_id
 
         # set up random user password
@@ -648,7 +648,7 @@ class DockerSSHBox(Sandbox):
 
     @property
     def sandbox_workspace_dir(self):
-        return config.workspace_mount_path_in_sandbox
+        return config.sandbox.workspace_mount_path_in_sandbox
 
     @property
     def ssh_hostname(self):
@@ -670,7 +670,7 @@ class DockerSSHBox(Sandbox):
 
     @property
     def volumes(self):
-        mount_dir = config.workspace_mount_path
+        mount_dir = config.sandbox.workspace_mount_path
         logger.info(f'Mounting workspace directory: {mount_dir}')
         return {
             mount_dir: {'bind': self.sandbox_workspace_dir, 'mode': 'rw'},

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -200,7 +200,7 @@ class DockerSSHBox(Sandbox):
     def __init__(
         self,
         container_image: str | None = None,
-        timeout: int = config.sandbox_timeout,
+        timeout: int = config.sandbox.sandbox_timeout,
         sid: str | None = None,
     ):
         logger.info(
@@ -216,7 +216,7 @@ class DockerSSHBox(Sandbox):
             )
             raise ex
 
-        if config.persist_sandbox:
+        if config.sandbox.persist_sandbox:
             if not self.run_as_devin:
                 raise Exception(
                     'Persistent sandbox is currently designed for opendevin user only. Please set run_as_devin=True in your config.toml'
@@ -230,13 +230,13 @@ class DockerSSHBox(Sandbox):
         self.container_name = self.container_name_prefix + self.instance_id
 
         # set up random user password
-        if config.persist_sandbox:
-            if not config.ssh_password:
+        if config.sandbox.persist_sandbox:
+            if not config.sandbox.ssh_password:
                 raise Exception(
                     'Please add ssh_password to your config.toml or add -e SSH_PASSWORD to your docker run command'
                 )
-            self._ssh_password = config.ssh_password
-            self._ssh_port = config.ssh_port
+            self._ssh_password = config.sandbox.ssh_password
+            self._ssh_port = config.sandbox.ssh_port
         else:
             self._ssh_password = str(uuid.uuid4())
             self._ssh_port = find_available_tcp_port()
@@ -246,7 +246,7 @@ class DockerSSHBox(Sandbox):
         except docker.errors.NotFound:
             self.is_initial_session = True
             logger.info('Detected initial session.')
-        if not config.persist_sandbox or self.is_initial_session:
+        if not config.sandbox.persist_sandbox or self.is_initial_session:
             logger.info('Creating new Docker container')
             n_tries = 5
             while n_tries > 0:
@@ -388,7 +388,7 @@ class DockerSSHBox(Sandbox):
             )
             hostname = self.ssh_hostname
             username = 'opendevin' if self.run_as_devin else 'root'
-            if config.persist_sandbox:
+            if config.sandbox.persist_sandbox:
                 password_msg = 'using your SSH password'
             else:
                 password_msg = f"using the password '{self._ssh_password}'"
@@ -636,15 +636,15 @@ class DockerSSHBox(Sandbox):
 
     @property
     def user_id(self):
-        return config.sandbox_user_id
+        return config.sandbox.sandbox_user_id
 
     @property
     def sandbox_user_id(self):
-        return config.sandbox_user_id
+        return config.sandbox.sandbox_user_id
 
     @property
     def run_as_devin(self):
-        return config.run_as_devin
+        return config.sandbox.run_as_devin
 
     @property
     def sandbox_workspace_dir(self):
@@ -652,11 +652,11 @@ class DockerSSHBox(Sandbox):
 
     @property
     def ssh_hostname(self):
-        return config.ssh_hostname
+        return config.sandbox.ssh_hostname
 
     @property
     def use_host_network(self):
-        return config.use_host_network
+        return config.sandbox.use_host_network
 
     def is_container_running(self):
         try:
@@ -748,7 +748,7 @@ class DockerSSHBox(Sandbox):
             try:
                 if (
                     container.name.startswith(self.container_name)
-                    and not config.persist_sandbox
+                    and not config.sandbox.persist_sandbox
                 ):
                     # only remove the container we created
                     # otherwise all other containers with the same prefix will be removed

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -226,7 +226,7 @@ class DockerSSHBox(Sandbox):
             self.instance_id = (sid or '') + str(uuid.uuid4())
 
         self.timeout = timeout
-        self.container_image = container_image or config.sandbox.sandbox_container_image
+        self.container_image = container_image or config.sandbox.container_image
         self.container_name = self.container_name_prefix + self.instance_id
 
         # set up random user password

--- a/opendevin/runtime/e2b/sandbox.py
+++ b/opendevin/runtime/e2b/sandbox.py
@@ -24,10 +24,10 @@ class E2BBox(Sandbox):
     def __init__(
         self,
         template: str = 'open-devin',
-        timeout: int = config.sandbox_timeout,
+        timeout: int = config.sandbox.sandbox_timeout,
     ):
         self.sandbox = E2BSandbox(
-            api_key=config.e2b_api_key,
+            api_key=config.sandbox.e2b_api_key,
             template=template,
             # It's possible to stream stdout and stderr from sandbox and from each process
             on_stderr=lambda x: logger.info(f'E2B sandbox stderr: {x}'),

--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -70,7 +70,7 @@ class Runtime:
     ):
         self.sid = sid
         if sandbox is None:
-            self.sandbox = create_sandbox(sid, config.sandbox_type)
+            self.sandbox = create_sandbox(sid, config.sandbox.sandbox_type)
             self._is_external_sandbox = False
         else:
             self.sandbox = sandbox

--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -70,7 +70,7 @@ class Runtime:
     ):
         self.sid = sid
         if sandbox is None:
-            self.sandbox = create_sandbox(sid, config.sandbox.sandbox_type)
+            self.sandbox = create_sandbox(sid, config.sandbox.type)
             self._is_external_sandbox = False
         else:
             self.sandbox = sandbox

--- a/opendevin/runtime/sandbox.py
+++ b/opendevin/runtime/sandbox.py
@@ -20,7 +20,7 @@ class Sandbox(ABC, PluginMixin):
                 self.add_to_env(sandbox_key, os.environ[key])
         if config.enable_auto_lint:
             self.add_to_env('ENABLE_AUTO_LINT', 'true')
-        self.initialize_plugins: bool = config.initialize_plugins
+        self.initialize_plugins: bool = config.sandbox.initialize_plugins
 
     def add_to_env(self, key: str, value: str):
         self._env[key] = value

--- a/opendevin/runtime/server/files.py
+++ b/opendevin/runtime/server/files.py
@@ -22,16 +22,18 @@ def resolve_path(file_path, working_directory):
     abs_path_in_sandbox = path_in_sandbox.resolve()
 
     # If the path is outside the workspace, deny it
-    if not abs_path_in_sandbox.is_relative_to(config.workspace_mount_path_in_sandbox):
+    if not abs_path_in_sandbox.is_relative_to(
+        config.sandbox.workspace_mount_path_in_sandbox
+    ):
         raise PermissionError(f'File access not permitted: {file_path}')
 
     # Get path relative to the root of the workspace inside the sandbox
     path_in_workspace = abs_path_in_sandbox.relative_to(
-        Path(config.workspace_mount_path_in_sandbox)
+        Path(config.sandbox.workspace_mount_path_in_sandbox)
     )
 
     # Get path relative to host
-    path_in_host_workspace = Path(config.workspace_base) / path_in_workspace
+    path_in_host_workspace = Path(config.sandbox.workspace_base) / path_in_workspace
 
     return path_in_host_workspace
 

--- a/opendevin/runtime/server/runtime.py
+++ b/opendevin/runtime/server/runtime.py
@@ -33,7 +33,7 @@ class ServerRuntime(Runtime):
         sandbox: Sandbox | None = None,
     ):
         super().__init__(event_stream, sid, sandbox)
-        self.file_store = LocalFileStore(config.workspace_base)
+        self.file_store = LocalFileStore(config.sandbox.workspace_base)
 
     async def run(self, action: CmdRunAction) -> Observation:
         return self._run_command(action.command, background=action.background)

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -11,27 +11,27 @@ SANDBOX_PATH_PREFIX = '/workspace'
 def test_resolve_path():
     assert (
         files.resolve_path('test.txt', '/workspace')
-        == Path(config.workspace_base) / 'test.txt'
+        == Path(config.sandbox.workspace_base) / 'test.txt'
     )
     assert (
         files.resolve_path('subdir/test.txt', '/workspace')
-        == Path(config.workspace_base) / 'subdir' / 'test.txt'
+        == Path(config.sandbox.workspace_base) / 'subdir' / 'test.txt'
     )
     assert (
         files.resolve_path(Path(SANDBOX_PATH_PREFIX) / 'test.txt', '/workspace')
-        == Path(config.workspace_base) / 'test.txt'
+        == Path(config.sandbox.workspace_base) / 'test.txt'
     )
     assert (
         files.resolve_path(
             Path(SANDBOX_PATH_PREFIX) / 'subdir' / 'test.txt', '/workspace'
         )
-        == Path(config.workspace_base) / 'subdir' / 'test.txt'
+        == Path(config.sandbox.workspace_base) / 'subdir' / 'test.txt'
     )
     assert (
         files.resolve_path(
             Path(SANDBOX_PATH_PREFIX) / 'subdir' / '..' / 'test.txt', '/workspace'
         )
-        == Path(config.workspace_base) / 'test.txt'
+        == Path(config.sandbox.workspace_base) / 'test.txt'
     )
     with pytest.raises(PermissionError):
         files.resolve_path(Path(SANDBOX_PATH_PREFIX) / '..' / 'test.txt', '/workspace')
@@ -41,5 +41,5 @@ def test_resolve_path():
         files.resolve_path(Path('/') / 'test.txt', '/workspace')
     assert (
         files.resolve_path('test.txt', '/workspace/test')
-        == Path(config.workspace_base) / 'test' / 'test.txt'
+        == Path(config.sandbox.workspace_base) / 'test' / 'test.txt'
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -54,7 +54,7 @@ def test_compat_env_to_config(monkeypatch, setup_env):
     config = AppConfig()
     load_from_env(config, os.environ)
 
-    assert config.workspace_base == '/repos/opendevin/workspace'
+    assert config.sandbox.workspace_base == '/repos/opendevin/workspace'
     assert isinstance(config.llm, LLMConfig)
     assert config.llm.api_key == 'sk-proj-rgMV0...'
     assert config.llm.model == 'gpt-4o'
@@ -75,7 +75,7 @@ def test_load_from_old_style_env(monkeypatch, default_config):
     assert default_config.llm.api_key == 'test-api-key'
     assert default_config.agent.memory_enabled is True
     assert default_config.agent.name == 'PlannerAgent'
-    assert default_config.workspace_base == '/opt/files/workspace'
+    assert default_config.sandbox.workspace_base == '/opt/files/workspace'
 
 
 def test_load_from_new_style_toml(default_config, temp_toml_file):
@@ -100,7 +100,7 @@ workspace_base = "/opt/files2/workspace"
     assert default_config.llm.api_key == 'toml-api-key'
     assert default_config.agent.name == 'TestAgent'
     assert default_config.agent.memory_enabled is True
-    assert default_config.workspace_base == '/opt/files2/workspace'
+    assert default_config.sandbox.workspace_base == '/opt/files2/workspace'
 
 
 def test_env_overrides_toml(monkeypatch, default_config, temp_toml_file):
@@ -127,7 +127,7 @@ disable_color = true
     assert os.environ.get('LLM_MODEL') is None
     assert default_config.llm.model == 'test-model'
     assert default_config.llm.api_key == 'env-api-key'
-    assert default_config.workspace_base == '/opt/files4/workspace'
+    assert default_config.sandbox.workspace_base == '/opt/files4/workspace'
     assert default_config.sandbox_type == 'ssh'
     assert default_config.disable_color is True
 
@@ -182,7 +182,7 @@ def test_workspace_mount_path_default(default_config):
     assert default_config.workspace_mount_path is None
     finalize_config(default_config)
     assert default_config.workspace_mount_path == os.path.abspath(
-        default_config.workspace_base
+        default_config.sandbox.workspace_base
     )
 
 
@@ -197,7 +197,7 @@ def test_workspace_mount_path_in_sandbox_local(default_config):
 
 
 def test_workspace_mount_rewrite(default_config, monkeypatch):
-    default_config.workspace_base = '/home/user/project'
+    default_config.sandbox.workspace_base = '/home/user/project'
     default_config.workspace_mount_rewrite = '/home/user:/sandbox'
     monkeypatch.setattr('os.getcwd', lambda: '/current/working/directory')
     finalize_config(default_config)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -113,8 +113,10 @@ api_key = "toml-api-key"
 
 [core]
 workspace_base = "/opt/files3/workspace"
-sandbox_type = "local"
 disable_color = true
+
+[sandbox]
+type = "local"
 """)
 
     monkeypatch.setenv('LLM_API_KEY', 'env-api-key')
@@ -128,7 +130,7 @@ disable_color = true
     assert default_config.llm.model == 'test-model'
     assert default_config.llm.api_key == 'env-api-key'
     assert default_config.sandbox.workspace_base == '/opt/files4/workspace'
-    assert default_config.sandbox_type == 'ssh'
+    assert default_config.sandbox.type == 'ssh'
     assert default_config.disable_color is True
 
 
@@ -168,7 +170,7 @@ def test_invalid_toml_format(monkeypatch, temp_toml_file, default_config):
 
 def test_finalize_config(default_config):
     # Test finalize config
-    default_config.sandbox_type = 'local'
+    default_config.sandbox.type = 'local'
     finalize_config(default_config)
 
     assert (
@@ -188,7 +190,7 @@ def test_workspace_mount_path_default(default_config):
 
 def test_workspace_mount_path_in_sandbox_local(default_config):
     assert default_config.workspace_mount_path_in_sandbox == '/workspace'
-    default_config.sandbox_type = 'local'
+    default_config.sandbox.type = 'local'
     finalize_config(default_config)
     assert (
         default_config.workspace_mount_path_in_sandbox

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -174,27 +174,27 @@ def test_finalize_config(default_config):
     finalize_config(default_config)
 
     assert (
-        default_config.workspace_mount_path_in_sandbox
-        == default_config.workspace_mount_path
+        default_config.sandbox.workspace_mount_path_in_sandbox
+        == default_config.sandbox.workspace_mount_path
     )
 
 
 # tests for workspace, mount path, path in sandbox, cache dir
 def test_workspace_mount_path_default(default_config):
-    assert default_config.workspace_mount_path is None
+    assert default_config.sandbox.workspace_mount_path is None
     finalize_config(default_config)
-    assert default_config.workspace_mount_path == os.path.abspath(
+    assert default_config.sandbox.workspace_mount_path == os.path.abspath(
         default_config.sandbox.workspace_base
     )
 
 
 def test_workspace_mount_path_in_sandbox_local(default_config):
-    assert default_config.workspace_mount_path_in_sandbox == '/workspace'
+    assert default_config.sandbox.workspace_mount_path_in_sandbox == '/workspace'
     default_config.sandbox.type = 'local'
     finalize_config(default_config)
     assert (
-        default_config.workspace_mount_path_in_sandbox
-        == default_config.workspace_mount_path
+        default_config.sandbox.workspace_mount_path_in_sandbox
+        == default_config.sandbox.workspace_mount_path
     )
 
 
@@ -203,7 +203,7 @@ def test_workspace_mount_rewrite(default_config, monkeypatch):
     default_config.workspace_mount_rewrite = '/home/user:/sandbox'
     monkeypatch.setattr('os.getcwd', lambda: '/current/working/directory')
     finalize_config(default_config)
-    assert default_config.workspace_mount_path == '/sandbox/project'
+    assert default_config.sandbox.workspace_mount_path == '/sandbox/project'
 
 
 def test_embedding_base_url_default(default_config):

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -90,10 +90,10 @@ EOF
 
 def test_ssh_box_run_as_devin(temp_dir):
     # get a temporary directory
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [
             DockerSSHBox()
@@ -132,10 +132,10 @@ def test_ssh_box_run_as_devin(temp_dir):
 
 def test_ssh_box_multi_line_cmd_run_as_devin(temp_dir):
     # get a temporary directory
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('pwd && ls -l')
@@ -153,10 +153,10 @@ def test_ssh_box_multi_line_cmd_run_as_devin(temp_dir):
 
 def test_ssh_box_stateful_cmd_run_as_devin(temp_dir):
     # get a temporary directory
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [
             DockerSSHBox()
@@ -185,10 +185,10 @@ def test_ssh_box_stateful_cmd_run_as_devin(temp_dir):
 
 def test_ssh_box_failed_cmd_run_as_devin(temp_dir):
     # get a temporary directory
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('non_existing_command')
@@ -200,10 +200,10 @@ def test_ssh_box_failed_cmd_run_as_devin(temp_dir):
 
 
 def test_single_multiline_command(temp_dir):
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('echo \\\n -e "foo"')
@@ -225,10 +225,10 @@ def test_single_multiline_command(temp_dir):
 
 
 def test_multiline_echo(temp_dir):
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('echo -e "hello\nworld"')
@@ -251,10 +251,10 @@ def test_multiline_echo(temp_dir):
 
 def test_sandbox_whitespace(temp_dir):
     # get a temporary directory
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('echo -e "\\n\\n\\n"')
@@ -276,10 +276,10 @@ def test_sandbox_whitespace(temp_dir):
 
 def test_sandbox_jupyter_plugin(temp_dir):
     # get a temporary directory
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [DockerSSHBox()]:
             box.init_plugins([JupyterRequirement])
@@ -297,10 +297,10 @@ def test_sandbox_jupyter_plugin(temp_dir):
 
 def test_sandbox_jupyter_agentskills_fileop_pwd(temp_dir):
     # get a temporary directory
-    with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
-        config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'config.sandbox.type', new='ssh'
+    with patch.object(config.sandbox, 'workspace_base', new=temp_dir), patch.object(
+        config.sandbox, 'workspace_mount_path', new=temp_dir
+    ), patch.object(config.sandbox, 'run_as_devin', new='true'), patch.object(
+        config.sandbox, 'type', new='ssh'
     ):
         for box in [DockerSSHBox()]:
             box.init_plugins([AgentSkillsRequirement, JupyterRequirement])

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -93,7 +93,7 @@ def test_ssh_box_run_as_devin(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [
             DockerSSHBox()
@@ -135,7 +135,7 @@ def test_ssh_box_multi_line_cmd_run_as_devin(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('pwd && ls -l')
@@ -156,7 +156,7 @@ def test_ssh_box_stateful_cmd_run_as_devin(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [
             DockerSSHBox()
@@ -188,7 +188,7 @@ def test_ssh_box_failed_cmd_run_as_devin(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('non_existing_command')
@@ -203,7 +203,7 @@ def test_single_multiline_command(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('echo \\\n -e "foo"')
@@ -228,7 +228,7 @@ def test_multiline_echo(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('echo -e "hello\nworld"')
@@ -254,7 +254,7 @@ def test_sandbox_whitespace(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [DockerSSHBox(), DockerExecBox()]:
             exit_code, output = box.execute('echo -e "\\n\\n\\n"')
@@ -279,7 +279,7 @@ def test_sandbox_jupyter_plugin(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [DockerSSHBox()]:
             box.init_plugins([JupyterRequirement])
@@ -300,7 +300,7 @@ def test_sandbox_jupyter_agentskills_fileop_pwd(temp_dir):
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
     ), patch.object(config, 'run_as_devin', new='true'), patch.object(
-        config, 'sandbox_type', new='ssh'
+        config, 'config.sandbox.type', new='ssh'
     ):
         for box in [DockerSSHBox()]:
             box.init_plugins([AgentSkillsRequirement, JupyterRequirement])

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -104,7 +104,7 @@ def test_ssh_box_run_as_devin(temp_dir):
             )
             assert output.strip() == 'total 0'
 
-            assert config.workspace_base == temp_dir
+            assert config.sandbox.workspace_base == temp_dir
             exit_code, output = box.execute('ls -l')
             assert exit_code == 0, 'The exit code should be 0.'
             assert output.strip() == 'total 0'


### PR DESCRIPTION
This PR is proposing to simplify the config.toml file by adding a section specifically for sandbox config vars. It should make the rest more readable. It practically splits AppConfig in half, the sandbox-specific vars have become really that many.

It is a goal to also preserve compatibility with the corresponding env vars.

New toml should look like:
```
[core]
max_iterations=500
max_chars=50000000
debug=true
file_store="local"
file_store_path="/somewhere/repos/opendevin/cache"

[sandbox]
type="ssh"
timeout=10
persist_sandbox=true
workspace_base="/somewhere/repos/workspace"
workspace_mount_path="/somewhere/repos/workspace"
workspace_mount_path_in_sandbox="/workspace"
...
```