### PR TITLE
Re-enable docker installation to fix macos unit test

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test on macOS
     runs-on: macos-13
     env:
-      INSTALL_DOCKER: "0" # Set to '0' to skip Docker installation
+      INSTALL_DOCKER: "1" # Set to '0' to skip Docker installation
     strategy:
       matrix:
         python-version: ["3.11"]


### PR DESCRIPTION
This PR attempt to fix errors when running MacOS unit test due to uninstalled docker:
```
../../../Library/Caches/pypoetry/virtualenvs/opendevin-0JG2Ceig-py3.11/lib/python3.11/site-packages/docker/api/client.py:207: in __init__
    self._version = self._retrieve_server_version()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <docker.api.client.APIClient object at 0x1528d48d0>

    def _retrieve_server_version(self):
        try:
            return self.version(api_version=False)["ApiVersion"]
        except KeyError as ke:
            raise DockerException(
                'Invalid response from docker daemon: key "ApiVersion"'
                ' is missing.'
            ) from ke
        except Exception as e:
>           raise DockerException(
                f'Error while fetching server API version: {e}'
            ) from e
E           docker.errors.DockerException: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))

../../../Library/Caches/pypoetry/virtualenvs/opendevin-0JG2Ceig-py3.11/lib/python3.11/site-packages/docker/api/client.py:230: DockerException
```