### PR TITLE
fix: remove backtick escaping from run_ipython

### DIFF
--- a/opendevin/runtime/server/runtime.py
+++ b/opendevin/runtime/server/runtime.py
@@ -1,5 +1,3 @@
-import ast
-
 from opendevin.core.config import config
 from opendevin.events.action import (
     AgentRecallAction,
@@ -37,36 +35,6 @@ class ServerRuntime(Runtime):
         super().__init__(event_stream, sid, sandbox)
         self.file_store = LocalFileStore(config.workspace_base)
 
-    def _is_python_code(self, text):
-        """
-        Check if the given text is valid Python code.
-
-        Args:
-            text (str): The text to check.
-
-        Returns:
-            bool: True if the text is valid Python code, False otherwise.
-        """
-        try:
-            ast.parse(text)
-            return True
-        except SyntaxError:
-            return False
-
-    def _preprocess_text(self, text):
-        """
-        Preprocess the text to escape backticks if it's valid Python code.
-
-        Args:
-            text (str): The text to preprocess.
-
-        Returns:
-            str: The preprocessed or original text.
-        """
-        if self._is_python_code(text):
-            return text.replace('`', r'\`')
-        return text
-
     async def run(self, action: CmdRunAction) -> Observation:
         return self._run_command(action.command, background=action.background)
 
@@ -80,7 +48,6 @@ class ServerRuntime(Runtime):
         )
 
     async def run_ipython(self, action: IPythonRunCellAction) -> Observation:
-        action.code = self._preprocess_text(action.code)
         obs = self._run_command(
             ("cat > /tmp/opendevin_jupyter_temp.py <<'EOL'\n" f'{action.code}\n' 'EOL'),
             background=False,


### PR DESCRIPTION
Finally removing the escaping of backticks from `run_ipython` commands which causes syntax errors more often than not.

Related PR's:
https://github.com/OpenDevin/OpenDevin/pull/2321
https://github.com/OpenDevin/OpenDevin/pull/2117#discussion_r1617737723

Fixes: https://github.com/OpenDevin/OpenDevin/issues/2238