### PR TITLE
fix(swe_bench_eval): Mkdir `infer_logs` instead of `logs`

### DIFF
--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -399,7 +399,7 @@ if __name__ == '__main__':
     )
 
     pathlib.Path(eval_output_dir).mkdir(parents=True, exist_ok=True)
-    pathlib.Path(os.path.join(eval_output_dir, 'logs')).mkdir(
+    pathlib.Path(os.path.join(eval_output_dir, 'infer_logs')).mkdir(
         parents=True, exist_ok=True
     )
     logger.info(f'Using evaluation output directory: {eval_output_dir}')


### PR DESCRIPTION
Quick fix of a bug introduced in https://github.com/OpenDevin/OpenDevin/pull/2381