### PR TITLE
Memory: add delegates summaries

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -23,6 +23,7 @@ from opendevin.events.observation import (
 )
 from opendevin.events.serialization.event import truncate_content
 from opendevin.llm.llm import LLM
+from opendevin.memory.history import ShortTermHistory
 from opendevin.runtime.plugins import (
     AgentSkillsRequirement,
     JupyterRequirement,
@@ -167,7 +168,7 @@ class CodeActAgent(Agent):
         """
         super().reset()
 
-    def step(self, state: State) -> Action:
+    def step(self, state: State, history: ShortTermHistory) -> Action:
         """
         Performs one step using the CodeAct Agent.
         This includes gathering info on previous steps and prompting the model to make a command to execute.
@@ -184,7 +185,7 @@ class CodeActAgent(Agent):
         """
 
         # if we're done, go back
-        latest_user_message = state.history.get_last_user_message()
+        latest_user_message = history.get_last_user_message()
         if latest_user_message and latest_user_message.strip() == '/exit':
             return AgentFinishAction()
 

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -73,9 +73,7 @@ def get_observation_message(obs) -> dict[str, str] | None:
         splitted = content.split('\n')
         for i, line in enumerate(splitted):
             if '![image](data:image/png;base64,' in line:
-                splitted[i] = (
                     '![image](data:image/png;base64, ...) already displayed to user'
-                )
         content = '\n'.join(splitted)
         content = truncate_content(content)
         return {'role': 'user', 'content': content}
@@ -168,7 +166,7 @@ class CodeActAgent(Agent):
         """
         super().reset()
 
-    def step(self, state: State, history: ShortTermHistory) -> Action:
+    def step(self, state: State) -> Action:
         """
         Performs one step using the CodeAct Agent.
         This includes gathering info on previous steps and prompting the model to make a command to execute.
@@ -185,7 +183,7 @@ class CodeActAgent(Agent):
         """
 
         # if we're done, go back
-        latest_user_message = history.get_last_user_message()
+        latest_user_message = self.history.get_last_user_message()
         if latest_user_message and latest_user_message.strip() == '/exit':
             return AgentFinishAction()
 
@@ -212,7 +210,7 @@ class CodeActAgent(Agent):
             {'role': 'user', 'content': self.in_context_example},
         ]
 
-        for event in state.history.get_events():
+        for event in self.history.get_events():
             # create a regular message from an event
             message = (
                 get_action_message(event)
@@ -226,6 +224,8 @@ class CodeActAgent(Agent):
 
         # the latest user message is important:
         # we want to remind the agent of the environment constraints
+
+
         latest_user_message = next(
             (m for m in reversed(messages) if m['role'] == 'user'), None
         )

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -79,7 +79,9 @@ def get_observation_message(obs) -> dict[str, str] | None:
         splitted = content.split('\n')
         for i, line in enumerate(splitted):
             if '![image](data:image/png;base64,' in line:
-                '![image](data:image/png;base64, ...) already displayed to user'
+                splitted[i] = (
+                    '![image](data:image/png;base64, ...) already displayed to user'
+                )
         content = '\n'.join(splitted)
         content = truncate_content(content)
         return {'role': 'user', 'content': content}

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -16,6 +16,7 @@ from opendevin.events.action import (
     IPythonRunCellAction,
     MessageAction,
 )
+from opendevin.events.action.agent import AgentDelegateSummaryAction
 from opendevin.events.observation import (
     AgentDelegateObservation,
     CmdOutputObservation,
@@ -42,6 +43,11 @@ def action_to_str(action: Action) -> str:
         return f'{action.thought}\n<execute_browse>\n{action.inputs["task"]}\n</execute_browse>'
     elif isinstance(action, MessageAction):
         return action.content
+    elif isinstance(action, AgentSummarizeAction):
+        return f'You made actions like {action.summarized_actions} with the result: {action.summary}'
+    elif isinstance(action, AgentDelegateSummaryAction):
+        relevant_info_str = '\n'.join(info for info in action.relevant_info)
+        return f'You delegated to {action.agent} for task: {action.task}. \nThe result was: {action.summary}. \n{relevant_info_str}'
     return ''
 
 
@@ -51,6 +57,7 @@ def get_action_message(action: Action) -> dict[str, str] | None:
         or isinstance(action, CmdRunAction)
         or isinstance(action, IPythonRunCellAction)
         or isinstance(action, MessageAction)
+        or isinstance(action, AgentDelegateSummaryAction)
     ):
         return {
             'role': 'user' if action.source == 'user' else 'assistant',

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -23,7 +23,6 @@ from opendevin.events.observation import (
 )
 from opendevin.events.serialization.event import truncate_content
 from opendevin.llm.llm import LLM
-from opendevin.memory.history import ShortTermHistory
 from opendevin.runtime.plugins import (
     AgentSkillsRequirement,
     JupyterRequirement,
@@ -183,7 +182,7 @@ class CodeActAgent(Agent):
         """
 
         # if we're done, go back
-        latest_user_message = self.history.get_last_user_message()
+        latest_user_message = state.history.get_last_user_message()
         if latest_user_message and latest_user_message.strip() == '/exit':
             return AgentFinishAction()
 

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -72,7 +72,7 @@ def get_observation_message(obs) -> dict[str, str] | None:
         splitted = content.split('\n')
         for i, line in enumerate(splitted):
             if '![image](data:image/png;base64,' in line:
-                    '![image](data:image/png;base64, ...) already displayed to user'
+                '![image](data:image/png;base64, ...) already displayed to user'
         content = '\n'.join(splitted)
         content = truncate_content(content)
         return {'role': 'user', 'content': content}

--- a/opendevin/controller/agent.py
+++ b/opendevin/controller/agent.py
@@ -11,7 +11,7 @@ from opendevin.core.exceptions import (
 from opendevin.llm.llm import LLM
 from opendevin.runtime.plugins import PluginRequirement
 from opendevin.runtime.tools import RuntimeTool
-
+from opendevin.memory.history import ShortTermHistory
 
 class Agent(ABC):
     DEPRECATED = False
@@ -29,9 +29,13 @@ class Agent(ABC):
     def __init__(
         self,
         llm: LLM,
+
     ):
         self.llm = llm
+        self.history = ShortTermHistory(llm)
         self._complete = False
+
+
 
     @property
     def complete(self) -> bool:

--- a/opendevin/controller/agent.py
+++ b/opendevin/controller/agent.py
@@ -11,7 +11,7 @@ from opendevin.core.exceptions import (
 from opendevin.llm.llm import LLM
 from opendevin.runtime.plugins import PluginRequirement
 from opendevin.runtime.tools import RuntimeTool
-from opendevin.memory.history import ShortTermHistory
+
 
 class Agent(ABC):
     DEPRECATED = False
@@ -29,13 +29,9 @@ class Agent(ABC):
     def __init__(
         self,
         llm: LLM,
-
     ):
         self.llm = llm
-        self.history = ShortTermHistory(llm)
         self._complete = False
-
-
 
     @property
     def complete(self) -> bool:

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -53,6 +53,7 @@ class AgentController:
     parent: 'AgentController | None' = None
     delegate: 'AgentController | None' = None
     _pending_action: Action | None = None
+    history: ShortTermHistory
 
     def __init__(
         self,
@@ -344,7 +345,7 @@ class AgentController:
         self.update_state_before_step()
         action: Action = NullAction()
         try:
-            action = self.agent.step(self.state)
+            action = self.agent.step(self.state, self.history)
             if action is None:
                 raise LLMNoActionError('No action was returned')
         except (LLMMalformedActionError, LLMNoActionError, LLMResponseError) as e:

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -382,6 +382,14 @@ class AgentController:
         else:
             self.state = state
 
+        # initialize short term memory
+        history = (
+            ShortTermHistory()
+            if state is None or not hasattr(state, 'history') or state.history is None
+            else state.history
+        )
+        history.init_memory_condenser(self.agent.llm)
+        history.set_event_stream(self.event_stream)
         # when restored from a previous session, the State object will have history, start_id, and end_id
         # connect it to the event stream
         self.state.history.set_event_stream(self.event_stream)

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -53,7 +53,6 @@ class AgentController:
     parent: 'AgentController | None' = None
     delegate: 'AgentController | None' = None
     _pending_action: Action | None = None
-    history: ShortTermHistory
 
     def __init__(
         self,
@@ -345,7 +344,7 @@ class AgentController:
         self.update_state_before_step()
         action: Action = NullAction()
         try:
-            action = self.agent.step(self.state, self.history)
+            action = self.agent.step(self.state)
             if action is None:
                 raise LLMNoActionError('No action was returned')
         except (LLMMalformedActionError, LLMNoActionError, LLMResponseError) as e:

--- a/opendevin/controller/state/state.py
+++ b/opendevin/controller/state/state.py
@@ -115,6 +115,7 @@ class State:
         self.history.end_id = self.end_id
 
         # remove the restored data from the state if any
+        self.delegate_summaries = {}
 
     def get_current_user_intent(self):
         """

--- a/opendevin/controller/state/state.py
+++ b/opendevin/controller/state/state.py
@@ -13,10 +13,6 @@ from opendevin.events.action import (
 from opendevin.events.action.agent import (
     AgentDelegateSummaryAction,
     AgentFinishAction,
-    AgentSummarizeAction,
-)
-from opendevin.events.observation import (
-    CmdOutputObservation,
 )
 from opendevin.storage import get_file_store
 
@@ -111,7 +107,7 @@ class State:
         if not hasattr(self, 'history'):
             self.history = ShortTermHistory()
 
-        # restore the relevant data in history from the state
+            # restore the relevant data in history from the state
             if hasattr(self, 'delegate_summaries'):
                 self.history.delegate_summaries = self.delegate_summaries
         self.history.start_id = self.start_id

--- a/opendevin/controller/state/state.py
+++ b/opendevin/controller/state/state.py
@@ -14,6 +14,7 @@ from opendevin.events.action.agent import (
     AgentDelegateSummaryAction,
     AgentFinishAction,
 )
+from opendevin.memory.history import ShortTermHistory
 from opendevin.storage import get_file_store
 
 
@@ -51,7 +52,7 @@ class State:
     # root agent has level 0, and every delegate increases the level by one
     delegate_level: int = 0
     # start_id and end_id track the range of events in history
-    start_id: int = -1  # where in the event stream does history start
+    start_id: int = -1
     end_id: int = -1
     almost_stuck: int = 0
     delegate_summaries: dict[tuple[int, int], AgentDelegateSummaryAction] = field(

--- a/opendevin/core/schema/action.py
+++ b/opendevin/core/schema/action.py
@@ -62,6 +62,8 @@ class ActionTypeSchema(BaseModel):
 
     SUMMARIZE: str = Field(default='summarize')
 
+    SUMMARIZE_DELEGATE: str = Field(default='summarize_delegate')
+
     ADD_TASK: str = Field(default='add_task')
 
     MODIFY_TASK: str = Field(default='modify_task')

--- a/opendevin/events/action/agent.py
+++ b/opendevin/events/action/agent.py
@@ -60,7 +60,8 @@ class AgentDelegateSummaryAction(Action):
     agent: str = ''
     task: str = ''
     summary: str = ''
-    action: str = ActionType.SUMMARIZE
+    relevant_info: str = ''
+    action: str = ActionType.SUMMARIZE_DELEGATE
     _chunk_start: int = -1
     _chunk_end: int = -1
 

--- a/opendevin/events/action/agent.py
+++ b/opendevin/events/action/agent.py
@@ -47,6 +47,34 @@ class AgentSummarizeAction(Action):
 
 
 @dataclass
+class AgentDelegateSummaryAction(Action):
+    """
+    Action to summarize a list of events.
+
+    Attributes:
+    - agent: What agent was delegated to.
+    - task: The task that was delegated.
+    - summary: A single sentence summarizing all the delegate's actions and observations.
+    """
+
+    agent: str = ''
+    task: str = ''
+    summary: str = ''
+    action: str = ActionType.SUMMARIZE
+    _chunk_start: int = -1
+    _chunk_end: int = -1
+
+    @property
+    def message(self) -> str:
+        return self.summary
+
+    def __str__(self) -> str:
+        ret = '**AgentDelegateSummaryAction**\n'
+        ret += f'SUMMARY: {self.summary}'
+        return ret
+
+
+@dataclass
 class AgentFinishAction(Action):
     outputs: dict = field(default_factory=dict)
     thought: str = ''
@@ -54,7 +82,7 @@ class AgentFinishAction(Action):
 
     @property
     def message(self) -> str:
-        if self.thought != "":
+        if self.thought != '':
             return self.thought
         return "All done! What's next on the agenda?"
 

--- a/opendevin/events/serialization/action.py
+++ b/opendevin/events/serialization/action.py
@@ -2,6 +2,7 @@ from opendevin.core.exceptions import LLMMalformedActionError
 from opendevin.events.action.action import Action
 from opendevin.events.action.agent import (
     AgentDelegateAction,
+    AgentDelegateSummaryAction,
     AgentFinishAction,
     AgentRecallAction,
     AgentRejectAction,
@@ -33,6 +34,7 @@ actions = (
     ModifyTaskAction,
     ChangeAgentStateAction,
     MessageAction,
+    AgentDelegateSummaryAction,
 )
 
 ACTION_TYPE_TO_CLASS = {action_class.action: action_class for action_class in actions}  # type: ignore[attr-defined]

--- a/opendevin/memory/__init__.py
+++ b/opendevin/memory/__init__.py
@@ -1,5 +1,15 @@
 from .condenser import MemoryCondenser
 from .history import ShortTermHistory
 from .memory import LongTermMemory
+from .prompts import (
+    get_delegate_summarize_prompt,
+    parse_delegate_summary_response,
+)
 
-__all__ = ['LongTermMemory', 'ShortTermHistory', 'MemoryCondenser']
+__all__ = [
+    'get_delegate_summarize_prompt',
+    'parse_delegate_summary_response',
+    'LongTermMemory',
+    'ShortTermHistory',
+    'MemoryCondenser',
+]

--- a/opendevin/memory/condenser.py
+++ b/opendevin/memory/condenser.py
@@ -1,5 +1,16 @@
 from opendevin.core.logger import opendevin_logger as logger
+from opendevin.events.action.agent import (
+    AgentDelegateSummaryAction,
+)
+from opendevin.events.event import Event
+from opendevin.events.serialization.event import event_to_memory
 from opendevin.llm.llm import LLM
+from opendevin.memory.prompts import (
+    get_delegate_summarize_prompt,
+    parse_delegate_summary_response,
+)
+
+MAX_USER_MESSAGE_CHAR_COUNT = 200  # max char count for user messages
 
 
 class MemoryCondenser:
@@ -23,4 +34,34 @@ class MemoryCondenser:
             logger.error('Error condensing thoughts: %s', str(e), exc_info=False)
 
             # TODO If the llm fails with ContextWindowExceededError, we can try to condense the monologue chunk by chunk
+            raise
+
+    def delegate_summary(
+        self, delegate_events: list[Event], delegate_agent: str, delegate_task: str
+    ) -> AgentDelegateSummaryAction:
+        """
+        Summarizes the given list of events into a concise summary.
+
+        Parameters:
+        - delegate_events: List of events of the delegate.
+        - delegate_agent: The agent that was delegated to.
+        - delegate_task: The task that was delegated.
+
+        Returns:
+        - The summary of the delegate's activities.
+        """
+        try:
+            event_dicts = [event_to_memory(event) for event in delegate_events]
+            prompt = get_delegate_summarize_prompt(
+                event_dicts, delegate_agent, delegate_task
+            )
+
+            messages = [{'role': 'user', 'content': prompt}]
+            response = self.llm.completion(messages=messages)
+
+            action_response: str = response['choices'][0]['message']['content']
+            action = parse_delegate_summary_response(action_response)
+            return action
+        except Exception as e:
+            logger.error(f'Failed to summarize delegate events: {e}')
             raise

--- a/opendevin/memory/condenser.py
+++ b/opendevin/memory/condenser.py
@@ -36,7 +36,7 @@ class MemoryCondenser:
             # TODO If the llm fails with ContextWindowExceededError, we can try to condense the monologue chunk by chunk
             raise
 
-    def delegate_summary(
+    def summarize_delegate(
         self, delegate_events: list[Event], delegate_agent: str, delegate_task: str
     ) -> AgentDelegateSummaryAction:
         """

--- a/opendevin/memory/condenser.py
+++ b/opendevin/memory/condenser.py
@@ -61,6 +61,8 @@ class MemoryCondenser:
 
             action_response: str = response['choices'][0]['message']['content']
             action = parse_delegate_summary_response(action_response)
+            action.task = delegate_task
+            action.agent = delegate_agent
             return action
         except Exception as e:
             logger.error(f'Failed to summarize delegate events: {e}')

--- a/opendevin/memory/history.py
+++ b/opendevin/memory/history.py
@@ -4,6 +4,7 @@ from opendevin.core.logger import opendevin_logger as logger
 from opendevin.events.action.action import Action
 from opendevin.events.action.agent import (
     AgentDelegateAction,
+    AgentDelegateSummaryAction,
     ChangeAgentStateAction,
 )
 from opendevin.events.action.empty import NullAction
@@ -28,7 +29,8 @@ class ShortTermHistory(list[Event]):
     start_id: int
     end_id: int
     _event_stream: EventStream
-    delegates: dict[tuple[int, int], tuple[str, str]]
+    delegate_summaries: dict[tuple[int, int], AgentDelegateSummaryAction]
+
     filter_out: ClassVar[tuple[type[Event], ...]] = (
         NullAction,
         NullObservation,
@@ -40,7 +42,7 @@ class ShortTermHistory(list[Event]):
         super().__init__()
         self.start_id = -1
         self.end_id = -1
-        self.delegates = {}
+        self.delegate_summaries = {}
 
     def set_event_stream(self, event_stream: EventStream):
         self._event_stream = event_stream
@@ -81,7 +83,7 @@ class ShortTermHistory(list[Event]):
                 # AgentDelegateAction has id = delegate_start
                 # AgentDelegateObservation has id = delegate_end
                 delegate_start < event.id < delegate_end
-                for delegate_start, delegate_end in self.delegates.keys()
+                for delegate_start, delegate_end in self.delegate_summaries.keys()
             ):
                 yield event
 
@@ -174,14 +176,18 @@ class ShortTermHistory(list[Event]):
         delegate_start = -1
         delegate_agent: str = ''
         delegate_task: str = ''
+        delegate_events: list[Event] = [event]
         for prev_event in self._event_stream.get_events(
-            end_id=event.id - 1, reverse=True
+            end_id=event.id - 1, reverse=True, filter_out_type=self.filter_out
         ):
             if isinstance(prev_event, AgentDelegateAction):
                 delegate_start = prev_event.id
                 delegate_agent = prev_event.agent
                 delegate_task = prev_event.inputs.get('task', '')
+                delegate_events.append(prev_event)
                 break
+            else:
+                delegate_events.append(prev_event)
 
         if delegate_start == -1:
             logger.error(
@@ -189,9 +195,17 @@ class ShortTermHistory(list[Event]):
             )
             return
 
-        self.delegates[(delegate_start, delegate_end)] = (delegate_agent, delegate_task)
-        logger.debug(
-            f'Delegate {delegate_agent} with task {delegate_task} ran from id={delegate_start} to id={delegate_end}'
+        # restore correct order
+        delegate_events.reverse()
+
+        # summarize the delegate's actions and observations
+        delegate_summary_action = self.memory_condenser.summarize_delegate(
+            delegate_events, delegate_agent, delegate_task
+        )
+
+        # add the summary to history
+        self.delegate_summaries[(delegate_start, delegate_end)] = (
+            delegate_summary_action
         )
 
     # TODO remove me when unnecessary

--- a/opendevin/memory/history.py
+++ b/opendevin/memory/history.py
@@ -17,6 +17,8 @@ from opendevin.events.observation.empty import NullObservation
 from opendevin.events.observation.observation import Observation
 from opendevin.events.serialization.event import event_to_dict
 from opendevin.events.stream import EventStream
+from opendevin.llm.llm import LLM
+from opendevin.memory.condenser import MemoryCondenser
 
 
 class ShortTermHistory(list[Event]):
@@ -29,6 +31,7 @@ class ShortTermHistory(list[Event]):
     start_id: int
     end_id: int
     _event_stream: EventStream
+    memory_condenser: MemoryCondenser
     delegate_summaries: dict[tuple[int, int], AgentDelegateSummaryAction]
 
     filter_out: ClassVar[tuple[type[Event], ...]] = (
@@ -38,11 +41,12 @@ class ShortTermHistory(list[Event]):
         AgentStateChangedObservation,
     )
 
-    def __init__(self):
+    def __init__(self, llm: LLM):
         super().__init__()
         self.start_id = -1
         self.end_id = -1
         self.delegate_summaries = {}
+        self.memory_condenser = MemoryCondenser(llm)
 
     def set_event_stream(self, event_stream: EventStream):
         self._event_stream = event_stream

--- a/opendevin/memory/history.py
+++ b/opendevin/memory/history.py
@@ -18,7 +18,6 @@ from opendevin.events.observation.observation import Observation
 from opendevin.events.serialization.event import event_to_dict
 from opendevin.events.stream import EventStream
 from opendevin.llm.llm import LLM
-from opendevin.memory.condenser import MemoryCondenser
 
 
 class ShortTermHistory(list[Event]):
@@ -31,7 +30,6 @@ class ShortTermHistory(list[Event]):
     start_id: int
     end_id: int
     _event_stream: EventStream
-    memory_condenser: MemoryCondenser
     delegate_summaries: dict[tuple[int, int], AgentDelegateSummaryAction]
 
     filter_out: ClassVar[tuple[type[Event], ...]] = (
@@ -41,15 +39,19 @@ class ShortTermHistory(list[Event]):
         AgentStateChangedObservation,
     )
 
-    def __init__(self, llm: LLM):
+    def __init__(self):
         super().__init__()
         self.start_id = -1
         self.end_id = -1
         self.delegate_summaries = {}
-        self.memory_condenser = MemoryCondenser(llm)
 
     def set_event_stream(self, event_stream: EventStream):
         self._event_stream = event_stream
+
+    def init_memory_condenser(self, llm: LLM):
+        from opendevin.memory.condenser import MemoryCondenser
+
+        self.memory_condenser = MemoryCondenser(llm)
 
     def get_events_as_list(self) -> list[Event]:
         """

--- a/opendevin/memory/prompts.py
+++ b/opendevin/memory/prompts.py
@@ -1,0 +1,100 @@
+from opendevin.core.exceptions import LLMResponseError
+from opendevin.core.logger import opendevin_logger as logger
+from opendevin.core.utils import json
+from opendevin.events.action.agent import (
+    AgentDelegateSummaryAction,
+    AgentSummarizeAction,
+)
+from opendevin.events.serialization.action import action_from_dict
+
+SUMMARY_PROMPT = """
+Given the following actions and observations, create a JSON response with:
+    - "action": "summarize"
+    - args:
+      - "summarized_actions": A comma-separated list of unique action names from the provided actions
+      - "summary": A single sentence summarizing all the provided observations
+"""
+
+DELEGATE_SUMMARY_PROMPT = """
+The delegate agent "%(delegate_agent)s" was assigned the task: "%(delegate_task)s".
+Given the following actions and observations performed by the delegate, create a JSON response with:
+    - "action": "summarize_delegate"
+    - "args":
+      - "summary": A concise summary of the delegate's activities and findings, focusing on the key information relevant to the delegator.
+      - "relevant_info": A list of key points or information that the delegator might need to know or can find in the delegate's detailed history if needed.
+
+Delegate's actions and observations:
+"""
+
+
+def get_summarize_prompt(events: list[dict]) -> str:
+    """
+    Gets the prompt for summarizing a chunk of events.
+
+    Returns:
+    - A formatted string with the events within the prompt
+    """
+    events_str = '\n'.join(json.dumps(events, indent=2))
+    return SUMMARY_PROMPT + events_str
+
+
+def get_delegate_summarize_prompt(
+    delegate_events: list[dict], delegate_agent: str, delegate_task: str
+) -> str:
+    """
+    Gets the prompt for summarizing a delegate's events.
+
+    Returns:
+    - A formatted string with the delegate's events within the prompt
+    """
+    events_str = '\n'.join(json.dumps(delegate_events, indent=2))
+    return (
+        DELEGATE_SUMMARY_PROMPT
+        % {
+            'delegate_agent': delegate_agent,
+            'delegate_task': delegate_task,
+        }
+        + events_str
+    )
+
+
+def parse_summary_response(response: str) -> AgentSummarizeAction:
+    """
+    Parses a JSON summary of events.
+
+    Parameters:
+    - response: The response string to be parsed
+    Returns:
+    - The summary action output by the model
+    """
+    action_dict = json.loads(response)
+    action = action_from_dict(action_dict)
+    if action is None or not isinstance(action, AgentSummarizeAction):
+        logger.error(
+            f"Expected 'summarize' action, got {str(type(action)) if action else None}"
+        )
+        raise LLMResponseError(
+            'Expected a summarize action, but the LLM response was invalid'
+        )
+    return action
+
+
+def parse_delegate_summary_response(response: str) -> AgentDelegateSummaryAction:
+    """
+    Parses a JSON summary of a delegate's events.
+
+    Parameters:
+    - response: The response string to be parsed
+    Returns:
+    - The summary action output by the model
+    """
+    action_dict = json.loads(response)
+    action = action_from_dict(action_dict)
+    if action is None or not isinstance(action, AgentDelegateSummaryAction):
+        logger.error(
+            f"Expected 'summarize_delegate' action, got {str(type(action)) if action else None}"
+        )
+        raise LLMResponseError(
+            'Expected a summarize_delegate action, but the LLM response was invalid'
+        )
+    return action

--- a/opendevin/memory/prompts.py
+++ b/opendevin/memory/prompts.py
@@ -24,6 +24,7 @@ Given the following actions and observations performed by the delegate, create a
       - "relevant_info": A list of key points or information that the delegator might need to know or can find in the delegate's detailed history if needed.
 
 Delegate's actions and observations:
+%(events_str)s
 """
 
 
@@ -34,7 +35,7 @@ def get_summarize_prompt(events: list[dict]) -> str:
     Returns:
     - A formatted string with the events within the prompt
     """
-    events_str = '\n'.join(json.dumps(events, indent=2))
+    events_str = json.dumps(events, indent=2)
     return SUMMARY_PROMPT + events_str
 
 
@@ -47,15 +48,12 @@ def get_delegate_summarize_prompt(
     Returns:
     - A formatted string with the delegate's events within the prompt
     """
-    events_str = '\n'.join(json.dumps(delegate_events, indent=2))
-    return (
-        DELEGATE_SUMMARY_PROMPT
-        % {
-            'delegate_agent': delegate_agent,
-            'delegate_task': delegate_task,
-        }
-        + events_str
-    )
+    events_str = json.dumps(delegate_events, indent=2)
+    return DELEGATE_SUMMARY_PROMPT % {
+        'delegate_agent': delegate_agent,
+        'delegate_task': delegate_task,
+        'events_str': events_str,
+    }
 
 
 def parse_summary_response(response: str) -> AgentSummarizeAction:


### PR DESCRIPTION
Status: on hold.

For the diff for this PR, please see: 
https://github.com/OpenDevin/OpenDevin/compare/enyst/memories-condenser...enyst/memories-delegates

This PR completes #2021 with a proposal to add delegates' summaries.
Example prompt sent to the LLM when a delegate finished:
```
Ask the user what your task is

----------

Sure! What task would you like me to perform for you today?

----------

Delegate to browsing agent to get the page at http://localhost:8001, or report back if it's an error. You know how to delegate, just do it.

----------

You delegated to BrowsingAgent for task: Sure! Let me browse the page at http://localhost:8001 and report back the content or any errors.. I should start with: Get the content on "http://localhost:8001". 
The result was: The delegate agent 'BrowsingAgent' attempted multiple times to access the page at 'http://localhost:8001' but encountered repeated errors, resulting in a failure to retrieve any content from the page.. 

The agent tried to navigate to 'http://localhost:8001' multiple times.
Each attempt resulted in an error with the URL 'chrome-error://chromewebdata/' and a status code of 200.
The agent waited for various durations to allow the page to load, but no content was retrieved.
The task ultimately failed due to too many errors encountered.
```

Notes:
- If regular summaries might be too small/uninformative, these seem to go too far the other way? The first 2 lines in the last message above say it all, the last 4 seem overkill... Not sure it will be better for successes.
- another special delegate action (AgentDelegateSummaryAction) might not be quite necessary, I just found it handy to experiment with delegate-specific fields like 'task' and 'agent'. The parent doesn't see the initial delegate action nor the last delegate observation, so this way it knows what happened: it delegated to agent x, for task y, with result z.
- some WIP/wonky code isn't quite right yet, with history using condenser and condenser using history, oops.
- (fix) cleans up and uses summary prompts and responses as intended. ~~I'll backport this to PR 2021.~~ Done.