### PR TITLE
workspace_mount_path config datatype changed to not optional 

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -159,7 +159,7 @@ class AppConfig(metaclass=Singleton):
     file_store: str = 'memory'
     file_store_path: str = '/tmp/file_store'
     workspace_base: str = os.path.join(os.getcwd(), 'workspace')
-    workspace_mount_path: str | None = None
+    workspace_mount_path: str = ''
     workspace_mount_path_in_sandbox: str = '/workspace'
     workspace_mount_rewrite: str | None = None
     cache_dir: str = '/tmp/cache'
@@ -373,10 +373,10 @@ def finalize_config(config: AppConfig):
     More tweaks to the config after it's been loaded.
     """
 
-    # Set workspace_mount_path if not set by the user
-    if config.workspace_mount_path is None:
-        config.workspace_mount_path = os.path.abspath(config.workspace_base)
     config.workspace_base = os.path.abspath(config.workspace_base)
+    # Set workspace_mount_path if not set by the user
+    if not config.workspace_mount_path:
+        config.workspace_mount_path = config.workspace_base
 
     # In local there is no sandbox, the workspace will have the same pwd as the host
     if config.sandbox_type == 'local':

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -221,7 +221,9 @@ class DockerSSHBox(Sandbox):
                 raise Exception(
                     'Persistent sandbox is currently designed for opendevin user only. Please set run_as_devin=True in your config.toml'
                 )
-            self.instance_id = 'persisted'
+            self.instance_id = 'persisted ' + config.workspace_mount_path[1:].replace(
+                '/', '_'
+            )
         else:
             self.instance_id = (sid or '') + str(uuid.uuid4())
 

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -748,14 +748,14 @@ class DockerSSHBox(Sandbox):
         containers = self.docker_client.containers.list(all=True)
         for container in containers:
             try:
-                if (
-                    container.name.startswith(self.container_name)
-                    and not config.persist_sandbox
-                ):
-                    # only remove the container we created
-                    # otherwise all other containers with the same prefix will be removed
-                    # which will mess up with parallel evaluation
-                    container.remove(force=True)
+                if container.name.startswith(self.container_name):
+                    if config.persist_sandbox:
+                        container.stop()
+                    else:
+                        # only remove the container we created
+                        # otherwise all other containers with the same prefix will be removed
+                        # which will mess up with parallel evaluation
+                        container.remove(force=True)
             except docker.errors.NotFound:
                 pass
         self.docker_client.close()

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -221,9 +221,9 @@ class DockerSSHBox(Sandbox):
                 raise Exception(
                     'Persistent sandbox is currently designed for opendevin user only. Please set run_as_devin=True in your config.toml'
                 )
-            self.instance_id = 'persisted ' + config.workspace_mount_path[1:].replace(
-                '/', '_'
-            )
+            path = config.workspace_mount_path
+            path = ''.join(c if c.isalnum() else '_' for c in path)
+            self.instance_id = 'persisted ' + path
         else:
             self.instance_id = (sid or '') + str(uuid.uuid4())
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -177,7 +177,7 @@ def test_finalize_config(default_config):
 
 # tests for workspace, mount path, path in sandbox, cache dir
 def test_workspace_mount_path_default(default_config):
-    assert default_config.workspace_mount_path is None
+    assert default_config.workspace_mount_path == ''
     finalize_config(default_config)
     assert default_config.workspace_mount_path == os.path.abspath(
         default_config.workspace_base


### PR DESCRIPTION
~~Solves #2408~~
```py
-   workspace_mount_path: str | None = None
+   workspace_mount_path: str = ''
```
Later a valid value is given..

----

**Context:**
Previously, workspace_mount_path was defined as str | None, allowing it to be either a string or None. However, later in the code, a valid string is always assigned to workspace_mount_path.

**Issue:**
When using MyPy for static type checking, the original type annotation (str | None) causes MyPy to raise warnings/errors because MyPy expects workspace_mount_path to handle both str and None values throughout the code.

**Solution:**
By changing the type annotation to str and initializing workspace_mount_path with an empty string (''), we ensure consistency and correctness in the type. This prevents MyPy from raising unnecessary warnings/errors and aligns with the actual usage of workspace_mount_path in the code.

**Benefits:**

- Ensures type consistency and correctness.
- Eliminates unnecessary warnings/errors from MyPy.
- Reflects the intended usage and later assignment in the code.

---
Currently, workspace_mount_path is given for the docker run command.
for the `make run` command, workspace_base is assigned to workspace_mount_path 
Future changes - removing the default values and making them as required.