### PR TITLE
workspace_mount_path sentinel: an undefined string

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -5,6 +5,7 @@ import pathlib
 import platform
 import uuid
 from dataclasses import dataclass, field, fields, is_dataclass
+from enum import Enum
 from types import UnionType
 from typing import Any, ClassVar, get_args, get_origin
 
@@ -122,6 +123,10 @@ class AgentConfig(metaclass=Singleton):
         return dict
 
 
+class UndefinedString(str, Enum):
+    UNDEFINED = 'UNDEFINED'
+
+
 @dataclass
 class AppConfig(metaclass=Singleton):
     """
@@ -159,7 +164,9 @@ class AppConfig(metaclass=Singleton):
     file_store: str = 'memory'
     file_store_path: str = '/tmp/file_store'
     workspace_base: str = os.path.join(os.getcwd(), 'workspace')
-    workspace_mount_path: str | None = None
+    workspace_mount_path: str = (
+        UndefinedString.UNDEFINED  # this path should always be set when config is fully loaded
+    )
     workspace_mount_path_in_sandbox: str = '/workspace'
     workspace_mount_rewrite: str | None = None
     cache_dir: str = '/tmp/cache'
@@ -374,7 +381,7 @@ def finalize_config(config: AppConfig):
     """
 
     # Set workspace_mount_path if not set by the user
-    if config.workspace_mount_path is None:
+    if config.workspace_mount_path is UndefinedString.UNDEFINED:
         config.workspace_mount_path = os.path.abspath(config.workspace_base)
     config.workspace_base = os.path.abspath(config.workspace_base)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,6 +6,7 @@ from opendevin.core.config import (
     AgentConfig,
     AppConfig,
     LLMConfig,
+    UndefinedString,
     finalize_config,
     load_from_env,
     load_from_toml,
@@ -76,6 +77,10 @@ def test_load_from_old_style_env(monkeypatch, default_config):
     assert default_config.agent.memory_enabled is True
     assert default_config.agent.name == 'PlannerAgent'
     assert default_config.workspace_base == '/opt/files/workspace'
+    assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
+    assert (
+        default_config.workspace_mount_path_in_sandbox is not UndefinedString.UNDEFINED
+    )
 
 
 def test_load_from_new_style_toml(default_config, temp_toml_file):
@@ -102,6 +107,18 @@ workspace_base = "/opt/files2/workspace"
     assert default_config.agent.memory_enabled is True
     assert default_config.workspace_base == '/opt/files2/workspace'
 
+    # before finalize_config, workspace_mount_path is UndefinedString.UNDEFINED if it was not set
+    assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
+    assert (
+        default_config.workspace_mount_path_in_sandbox is not UndefinedString.UNDEFINED
+    )
+    assert default_config.workspace_mount_path_in_sandbox == '/workspace'
+
+    finalize_config(default_config)
+
+    # after finalize_config, workspace_mount_path is set to the absolute path of workspace_base if it was undefined
+    assert default_config.workspace_mount_path == '/opt/files2/workspace'
+
 
 def test_env_overrides_toml(monkeypatch, default_config, temp_toml_file):
     # Test that environment variables override TOML values using monkeypatch
@@ -118,23 +135,40 @@ disable_color = true
 """)
 
     monkeypatch.setenv('LLM_API_KEY', 'env-api-key')
-    monkeypatch.setenv('WORKSPACE_BASE', '/opt/files4/workspace')
+    monkeypatch.setenv('WORKSPACE_BASE', 'UNDEFINED')
     monkeypatch.setenv('SANDBOX_TYPE', 'ssh')
 
     load_from_toml(default_config, temp_toml_file)
+
+    # before finalize, workspace_mount_path is UndefinedString.UNDEFINED if it was not set
+    assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
+
     load_from_env(default_config, os.environ)
 
     assert os.environ.get('LLM_MODEL') is None
     assert default_config.llm.model == 'test-model'
     assert default_config.llm.api_key == 'env-api-key'
-    assert default_config.workspace_base == '/opt/files4/workspace'
+
+    # after we set the string to 'UNDEFINED' in the environment, it should be set to that and it's not UndefinedString.UNDEFINED
+    assert default_config.workspace_base is not UndefinedString.UNDEFINED
+    assert default_config.workspace_base == 'UNDEFINED'
+    assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
+    assert default_config.workspace_mount_path == 'UNDEFINED'
+
     assert default_config.sandbox_type == 'ssh'
     assert default_config.disable_color is True
+
+    finalize_config(default_config)
+    # after finalize_config, workspace_mount_path is set to an absolute path
+    assert default_config.workspace_mount_path == os.getcwd() + '/UNDEFINED'
 
 
 def test_defaults_dict_after_updates(default_config):
     # Test that `defaults_dict` retains initial values after updates.
     initial_defaults = default_config.defaults_dict
+    assert (
+        initial_defaults['workspace_mount_path']['default'] is UndefinedString.UNDEFINED
+    )
     updated_config = AppConfig()
     updated_config.llm.api_key = 'updated-api-key'
     updated_config.agent.name = 'MonologueAgent'
@@ -142,14 +176,17 @@ def test_defaults_dict_after_updates(default_config):
     defaults_after_updates = updated_config.defaults_dict
     assert defaults_after_updates['llm']['api_key']['default'] is None
     assert defaults_after_updates['agent']['name']['default'] == 'CodeActAgent'
+    assert (
+        defaults_after_updates['workspace_mount_path']['default']
+        is UndefinedString.UNDEFINED
+    )
     assert defaults_after_updates == initial_defaults
-
-    AppConfig.reset()
 
 
 def test_invalid_toml_format(monkeypatch, temp_toml_file, default_config):
     # Invalid TOML format doesn't break the configuration
     monkeypatch.setenv('LLM_MODEL', 'gpt-5-turbo-1106')
+    monkeypatch.setenv('WORKSPACE_MOUNT_PATH', '/home/user/project')
     monkeypatch.delenv('LLM_API_KEY', raising=False)
     with open(temp_toml_file, 'w', encoding='utf-8') as toml_file:
         toml_file.write('INVALID TOML CONTENT')
@@ -162,10 +199,12 @@ def test_invalid_toml_format(monkeypatch, temp_toml_file, default_config):
     assert default_config.llm.custom_llm_provider is None
     if default_config.llm.api_key is not None:  # prevent leak
         pytest.fail('LLM API key should be empty.')
+    assert default_config.workspace_mount_path == '/home/user/project'
 
 
 def test_finalize_config(default_config):
     # Test finalize config
+    assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
     default_config.sandbox_type = 'local'
     finalize_config(default_config)
 
@@ -173,11 +212,14 @@ def test_finalize_config(default_config):
         default_config.workspace_mount_path_in_sandbox
         == default_config.workspace_mount_path
     )
+    assert default_config.workspace_mount_path == os.path.abspath(
+        default_config.workspace_base
+    )
 
 
 # tests for workspace, mount path, path in sandbox, cache dir
 def test_workspace_mount_path_default(default_config):
-    assert default_config.workspace_mount_path is None
+    assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
     finalize_config(default_config)
     assert default_config.workspace_mount_path == os.path.abspath(
         default_config.workspace_base

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -77,7 +77,9 @@ def test_load_from_old_style_env(monkeypatch, default_config):
     assert default_config.agent.memory_enabled is True
     assert default_config.agent.name == 'PlannerAgent'
     assert default_config.workspace_base == '/opt/files/workspace'
-    assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
+    assert (
+        default_config.workspace_mount_path is UndefinedString.UNDEFINED
+    )  # before finalize_config
     assert (
         default_config.workspace_mount_path_in_sandbox is not UndefinedString.UNDEFINED
     )
@@ -116,7 +118,8 @@ workspace_base = "/opt/files2/workspace"
 
     finalize_config(default_config)
 
-    # after finalize_config, workspace_mount_path is set to the absolute path of workspace_base if it was undefined
+    # after finalize_config, workspace_mount_path is set to the absolute path of workspace_base
+    # if it was undefined
     assert default_config.workspace_mount_path == '/opt/files2/workspace'
 
 
@@ -140,7 +143,7 @@ disable_color = true
 
     load_from_toml(default_config, temp_toml_file)
 
-    # before finalize, workspace_mount_path is UndefinedString.UNDEFINED if it was not set
+    # before finalize_config, workspace_mount_path is UndefinedString.UNDEFINED if it was not set
     assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
 
     load_from_env(default_config, os.environ)
@@ -149,7 +152,9 @@ disable_color = true
     assert default_config.llm.model == 'test-model'
     assert default_config.llm.api_key == 'env-api-key'
 
-    # after we set the string to 'UNDEFINED' in the environment, it should be set to that and it's not UndefinedString.UNDEFINED
+    # after we set workspace_base to 'UNDEFINED' in the environment,
+    # workspace_base should be set to that
+    # workspace_mount path is still UndefinedString.UNDEFINED
     assert default_config.workspace_base is not UndefinedString.UNDEFINED
     assert default_config.workspace_base == 'UNDEFINED'
     assert default_config.workspace_mount_path is UndefinedString.UNDEFINED
@@ -159,7 +164,7 @@ disable_color = true
     assert default_config.disable_color is True
 
     finalize_config(default_config)
-    # after finalize_config, workspace_mount_path is set to an absolute path
+    # after finalize_config, workspace_mount_path is set to absolute path of workspace_base if it was undefined
     assert default_config.workspace_mount_path == os.getcwd() + '/UNDEFINED'
 
 


### PR DESCRIPTION
workspace_mount_path proves a little confusing in that:
- it has to be optional - the user can set it or not, more often not when running without app docker, and we don't have a working default
- but it's a necessary config var and, at runtime, the code after the config is fully loaded should be able to work with it as if it was set.
We currently use `str or None` for this case, although that makes mypy unhappy when we try to use it as a string.

PR https://github.com/OpenDevin/OpenDevin/pull/2412 proposes to make it an empty string, so we can define it as `str`. That works to shut up mypy, but it has its downsides, and it seems more error-prone. (please see the discussion in linked PR)

This PR proposes an explicit UNDEFINED value to be initial value. It's checked for identity at the end of config loading, to set its runtime value, and, it's a string. It behaves kinda like the empty string, except for humans: it yells that it's a different kind of string and not supposed to remain "UNDEFINED". 😅 Hey, one can hope.

Cc: @SmartManoj for some reason I cannot raise a PR to your branch. How about this alternative? I think it does the same thing you wish to achieve: calm mypy and allow us to use a string elsewhere in peace. It seems also fairly standard: it's intended to be a special value like None, except a string. Other examples [here](https://python-patterns.guide/python/sentinel-object/) and [here](https://treyhunner.com/2019/03/unique-and-sentinel-values-in-python/).
Cc: @tobitege 