### PR TITLE
feat: add LLM 'stream' flag (for litelllm)

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -47,6 +47,7 @@ class LLMConfig(metaclass=Singleton):
         max_output_tokens: The maximum number of output tokens. This is sent to the LLM.
         input_cost_per_token: The cost per input token. This will available in logs for the user to check.
         output_cost_per_token: The cost per output token. This will available in logs for the user to check.
+        stream: bool = False: litellm attribute whether to enable streaming of responses.
     """
 
     model: str = 'gpt-4o'
@@ -71,6 +72,7 @@ class LLMConfig(metaclass=Singleton):
     max_output_tokens: int | None = None
     input_cost_per_token: float | None = None
     output_cost_per_token: float | None = None
+    stream: bool = False
 
     def defaults_to_dict(self) -> dict:
         """

--- a/opendevin/core/schema/config.py
+++ b/opendevin/core/schema/config.py
@@ -42,3 +42,4 @@ class ConfigType(str, Enum):
     SSH_HOSTNAME = 'SSH_HOSTNAME'
     DISABLE_COLOR = 'DISABLE_COLOR'
     DEBUG = 'DEBUG'
+    STREAM = 'STREAM'

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -42,6 +42,7 @@ class LLM:
         max_output_tokens (int): The maximum number of tokens to receive from the LLM per task.
         llm_timeout (int): The maximum time to wait for a response in seconds.
         custom_llm_provider (str): A custom LLM provider.
+        stream (bool): Enable LLM responses as a stream.
     """
 
     def __init__(
@@ -62,6 +63,7 @@ class LLM:
         llm_config=None,
         metrics=None,
         cost_metric_supported=True,
+        stream=None,
     ):
         """
         Initializes the LLM. If LLMConfig is passed, its values will be the fallback.
@@ -83,6 +85,7 @@ class LLM:
             llm_temperature (float, optional): The temperature for LLM sampling. Defaults to LLM_TEMPERATURE.
             metrics (Metrics, optional): The metrics object to use. Defaults to None.
             cost_metric_supported (bool, optional): Whether the cost metric is supported. Defaults to True.
+            stream (bool, optional): Whether to enable LLM responses as a stream. Defaults to None.
         """
         if llm_config is None:
             llm_config = config.llm
@@ -118,6 +121,7 @@ class LLM:
             else llm_config.max_output_tokens
         )
         metrics = metrics if metrics is not None else Metrics()
+        stream = stream if stream is not None else llm_config.stream
 
         logger.info(f'Initializing LLM with model: {model}')
         self.model_name = model
@@ -130,6 +134,7 @@ class LLM:
         self.custom_llm_provider = custom_llm_provider
         self.metrics = metrics
         self.cost_metric_supported = cost_metric_supported
+        self.stream = stream
 
         # litellm actually uses base Exception here for unknown model
         self.model_info = None
@@ -168,6 +173,7 @@ class LLM:
             timeout=self.llm_timeout,
             temperature=llm_temperature,
             top_p=llm_top_p,
+            stream=self.stream,
         )
 
         completion_unwrapped = self._completion

--- a/opendevin/server/session/agent.py
+++ b/opendevin/server/session/agent.py
@@ -92,9 +92,10 @@ class AgentSession:
         api_base = config.llm.base_url
         max_iterations = args.get(ConfigType.MAX_ITERATIONS, config.max_iterations)
         max_chars = args.get(ConfigType.MAX_CHARS, config.llm.max_chars)
+        stream = args.get(ConfigType.STREAM, config.llm.stream)
 
         logger.info(f'Creating agent {agent_cls} using LLM {model}')
-        llm = LLM(model=model, api_key=api_key, base_url=api_base)
+        llm = LLM(model=model, api_key=api_key, base_url=api_base, stream=stream)
         agent = Agent.get_cls(agent_cls)(llm)
         if isinstance(agent, CodeActAgent):
             if not self.runtime or not isinstance(self.runtime.sandbox, DockerSSHBox):


### PR DESCRIPTION
This PR adds the flag `stream` (bool, default None) to the LLM configuration.

Streaming is for LLM responses to be returned in a stream, like in chunks, instead of waiting for a full reply (with delay).

This was partially done with the help of OpenDevin itself. 😀
