### PR TITLE
fix: improve toml parsing exception in config class

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -340,9 +340,9 @@ def load_from_toml(config: AppConfig, toml_file: str = 'config.toml'):
     except FileNotFoundError as e:
         logger.info(f'Config file not found: {e}')
         return
-    except toml.TomlDecodeError:
+    except toml.TomlDecodeError as e:
         logger.warning(
-            'Cannot parse config from toml, toml values have not been applied.',
+            f'Cannot parse config from toml, toml values have not been applied.\nError: {e}',
             exc_info=False,
         )
         return
@@ -368,9 +368,9 @@ def load_from_toml(config: AppConfig, toml_file: str = 'config.toml'):
 
         # update the config object with the new values
         config = AppConfig(llm=llm_config, agent=agent_config, **core_config)
-    except (TypeError, KeyError):
+    except (TypeError, KeyError) as e:
         logger.warning(
-            'Cannot parse config from toml, toml values have not been applied.',
+            f'Cannot parse config from toml, toml values have not been applied.\nError: {e}',
             exc_info=False,
         )
 


### PR DESCRIPTION
If there was even a simple typo in the `config.toml`, the existing exception handlers in `config.py` did not log the actual exception text itself.

With this PR, the exception text actually is logged. In my use case, the toml had a wrong-cased boolean value,
e.g. "True" (wrong) instead of "true" (correct).