### PR TITLE
Codecov after_n_builds=5

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,6 +1,7 @@
 codecov:
   notify:
     wait_for_ci: true
+    after_n_builds: 2
 
 coverage:
   status:

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,7 +1,9 @@
 codecov:
   notify:
     wait_for_ci: true
-    after_n_builds: 2
+    # our project is large, so 6 builds are typically uploaded. this waits till 5/6
+    # See https://docs.codecov.com/docs/notifications#section-preventing-notifications-until-after-n-builds
+    after_n_builds: 5
 
 coverage:
   status:


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fixes https://github.com/OpenDevin/OpenDevin/issues/2369

Basically, codecov uploads results incrementally for larger projects, and if the intermediate result is not good coverage then tests are listed as failing temporarily. 

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

This uses the codecov `after_n_builds` option to only report after the five are finished: https://docs.codecov.com/docs/notifications#section-preventing-notifications-until-after-n-builds

Currently our project is large enough that it uploads 6 reports, so I set this to only update after sending 5/6 (this seems to usually be more than enough to pass our thresholds).

I have confirmed that this does indeed only show codecov after 5 jobs finish, and that that is sufficient to pass tests 

**Other references**

SupersedeS https://github.com/OpenDevin/OpenDevin/pull/2462