### PR TITLE
Integration tests: check agent error and fix test_edits

### DIFF
--- a/tests/integration/mock/CodeActSWEAgent/test_edits/prompt_003.log
+++ b/tests/integration/mock/CodeActSWEAgent/test_edits/prompt_003.log
@@ -564,12 +564,9 @@ Let's correct the typos in the `bad.txt` file.
 1. "stupid typoo" should be "stupid typo".
 2. "No mor typos!" should be "No more typos!".
 
-I will make these corrections now.
+I will make these changes now.
 <execute_ipython>
-edit_file("bad.txt", start=1, end=4, content="""This is a stupid typo.
-Really?
-No more typos!
-Enjoy!""")
+edit_file("bad.txt", start=1, end=4, content="This is a stupid typo.\nReally?\nNo more typos!\nEnjoy!")
 </execute_ipython>
 
 ----------

--- a/tests/integration/mock/CodeActSWEAgent/test_ipython_module/prompt_003.log
+++ b/tests/integration/mock/CodeActSWEAgent/test_ipython_module/prompt_003.log
@@ -555,21 +555,19 @@ Package installed successfully
 
 ----------
 
-Next, let's import `pymsgbox`, print its version, and save the output to `/workspace/test.txt`.
+Next, let's import `pymsgbox` and print its version to `/workspace/test.txt`.
 <execute_ipython>
 import pymsgbox
 
-version_info = pymsgbox.__version__
+version = pymsgbox.__version__
 
 with open("/workspace/test.txt", "w") as file:
-    file.write(f"pymsgbox version: {version_info}\n")
-
-version_info
+    file.write(f"pymsgbox version: {version}\n")
 </execute_ipython>
 
 ----------
 
 OBSERVATION:
-'1.0.9'
+[Code executed successfully with no output]
 
 ENVIRONMENT REMINDER: You have 7 turns left to complete the task.

--- a/tests/integration/mock/CodeActSWEAgent/test_ipython_module/prompt_004.log
+++ b/tests/integration/mock/CodeActSWEAgent/test_ipython_module/prompt_004.log
@@ -555,26 +555,24 @@ Package installed successfully
 
 ----------
 
-Next, let's import `pymsgbox`, print its version, and save the output to `/workspace/test.txt`.
+Next, let's import `pymsgbox` and print its version to `/workspace/test.txt`.
 <execute_ipython>
 import pymsgbox
 
-version_info = pymsgbox.__version__
+version = pymsgbox.__version__
 
 with open("/workspace/test.txt", "w") as file:
-    file.write(f"pymsgbox version: {version_info}\n")
-
-version_info
+    file.write(f"pymsgbox version: {version}\n")
 </execute_ipython>
 
 ----------
 
 OBSERVATION:
-'1.0.9'
+[Code executed successfully with no output]
 
 ----------
 
-The version of `pymsgbox` has been successfully written to `/workspace/test.txt`. Let's verify the content of the file to ensure everything is correct.
+The version of `pymsgbox` has been written to `/workspace/test.txt`. Let's verify the content of the file to ensure it was written correctly.
 <execute_bash>
 cat /workspace/test.txt
 </execute_bash>

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -40,6 +40,7 @@ def test_write_simple_script():
     task = "Write a shell script 'hello.sh' that prints 'hello'. Do not ask me for confirmation at any point."
     final_state: State = asyncio.run(main(task, exit_on_message=True))
     assert final_state.agent_state == AgentState.STOPPED
+    assert final_state.error is None
 
     # Verify the script file exists
     script_path = os.path.join(workspace_base, 'hello.sh')
@@ -85,6 +86,7 @@ def test_edits():
     task = 'Fix typos in bad.txt. Do not ask me for confirmation at any point.'
     final_state: State = asyncio.run(main(task, exit_on_message=True))
     assert final_state.agent_state == AgentState.STOPPED
+    assert final_state.error is None
 
     # Verify bad.txt has been fixed
     text = """This is a stupid typo.
@@ -110,6 +112,7 @@ def test_ipython():
     task = "Use Jupyter IPython to write a text file containing 'hello world' to '/workspace/test.txt'. Do not ask me for confirmation at any point."
     final_state: State = asyncio.run(main(task, exit_on_message=True))
     assert final_state.agent_state == AgentState.STOPPED
+    assert final_state.error is None
 
     # Verify the file exists
     file_path = os.path.join(workspace_base, 'test.txt')
@@ -137,6 +140,7 @@ def test_simple_task_rejection():
     task = 'Write a git commit message for the current staging area. Do not ask me for confirmation at any point.'
     final_state: State = asyncio.run(main(task))
     assert final_state.agent_state == AgentState.STOPPED
+    assert final_state.error is None
     assert isinstance(final_state.history[-1][0], AgentRejectAction)
 
 
@@ -153,6 +157,7 @@ def test_ipython_module():
     task = "Install and import pymsgbox==1.0.9 and print it's version in /workspace/test.txt. Do not ask me for confirmation at any point."
     final_state: State = asyncio.run(main(task, exit_on_message=True))
     assert final_state.agent_state == AgentState.STOPPED
+    assert final_state.error is None
 
     # Verify the file exists
     file_path = os.path.join(workspace_base, 'test.txt')
@@ -181,5 +186,6 @@ def test_browse_internet(http_server):
     task = 'Browse localhost:8000, and tell me the ultimate answer to life. Do not ask me for confirmation at any point.'
     final_state: State = asyncio.run(main(task, exit_on_message=True))
     assert final_state.agent_state == AgentState.STOPPED
+    assert final_state.error is None
     assert isinstance(final_state.history[-1][0], AgentFinishAction)
     assert 'OpenDevin is all you need!' in str(final_state.history)


### PR DESCRIPTION
From the latest build on main branch, https://github.com/OpenDevin/OpenDevin/actions/runs/9539046253/job/26288933811#step:7:775, we can see the agent already fails, but since the required file is generated, the test still pass. We should assert that the agent finishes without errors.

This PR checks agent error in each test, and fix prompt mismatches for CodeActAgent test_edits test.