### PR TITLE
test: revert 2 mock prompts to same regen run

### DIFF
--- a/tests/integration/mock/CodeActSWEAgent/test_edits/prompt_003.log
+++ b/tests/integration/mock/CodeActSWEAgent/test_edits/prompt_003.log
@@ -564,9 +564,12 @@ Let's correct the typos in the `bad.txt` file.
 1. "stupid typoo" should be "stupid typo".
 2. "No mor typos!" should be "No more typos!".
 
-I will make these changes now.
+I will make these corrections now.
 <execute_ipython>
-edit_file("bad.txt", start=1, end=4, content="This is a stupid typo.\nReally?\nNo more typos!\nEnjoy!")
+edit_file("bad.txt", start=1, end=4, content="""This is a stupid typo.
+Really?
+No more typos!
+Enjoy!""")
 </execute_ipython>
 
 ----------

--- a/tests/integration/mock/CodeActSWEAgent/test_ipython_module/prompt_003.log
+++ b/tests/integration/mock/CodeActSWEAgent/test_ipython_module/prompt_003.log
@@ -555,19 +555,21 @@ Package installed successfully
 
 ----------
 
-Next, let's import `pymsgbox` and print its version to `/workspace/test.txt`.
+Next, let's import `pymsgbox`, print its version, and save the output to `/workspace/test.txt`.
 <execute_ipython>
 import pymsgbox
 
-version = pymsgbox.__version__
+version_info = pymsgbox.__version__
 
 with open("/workspace/test.txt", "w") as file:
-    file.write(f"pymsgbox version: {version}\n")
+    file.write(f"pymsgbox version: {version_info}\n")
+
+version_info
 </execute_ipython>
 
 ----------
 
 OBSERVATION:
-[Code executed successfully with no output]
+'1.0.9'
 
 ENVIRONMENT REMINDER: You have 7 turns left to complete the task.


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This restores 2 intermittent mock log files from integration tests.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Earlier today my PR https://github.com/OpenDevin/OpenDevin/pull/2477 got merged, including fully regenerated mock logs for test_ipython, which was necessary due to the very bug the PR fixes.

A little later, @li-boxuan 's PR https://github.com/OpenDevin/OpenDevin/pull/2473 was in the works and merged. Due to the time lag he had to _locally_ fix _his_ tests and had included these 2 files.

The restoration brings the prompts and responses back in sync.