### PR TITLE
Evaluation time travel: build sandbox on the fly

### DIFF
--- a/evaluation/EDA/scripts/run_infer.sh
+++ b/evaluation/EDA/scripts/run_infer.sh
@@ -57,5 +57,3 @@ fi
 # Run the command
 echo $COMMAND
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/agent_bench/scripts/run_infer.sh
+++ b/evaluation/agent_bench/scripts/run_infer.sh
@@ -36,5 +36,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/biocoder/scripts/run_infer.sh
+++ b/evaluation/biocoder/scripts/run_infer.sh
@@ -39,5 +39,3 @@ fi
 # Run the command
 echo $COMMAND
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/bird/scripts/run_infer.sh
+++ b/evaluation/bird/scripts/run_infer.sh
@@ -36,5 +36,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/gaia/scripts/run_infer.sh
+++ b/evaluation/gaia/scripts/run_infer.sh
@@ -47,5 +47,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/gorilla/scripts/run_infer.sh
+++ b/evaluation/gorilla/scripts/run_infer.sh
@@ -45,5 +45,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/gpqa/scripts/run_infer.sh
+++ b/evaluation/gpqa/scripts/run_infer.sh
@@ -44,5 +44,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/humanevalfix/scripts/run_infer.sh
+++ b/evaluation/humanevalfix/scripts/run_infer.sh
@@ -74,5 +74,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/logic_reasoning/scripts/run_infer.sh
+++ b/evaluation/logic_reasoning/scripts/run_infer.sh
@@ -40,5 +40,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/miniwob/scripts/run_infer.sh
+++ b/evaluation/miniwob/scripts/run_infer.sh
@@ -46,5 +46,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/mint/scripts/run_infer.sh
+++ b/evaluation/mint/scripts/run_infer.sh
@@ -42,5 +42,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/ml_bench/scripts/run_infer.sh
+++ b/evaluation/ml_bench/scripts/run_infer.sh
@@ -46,5 +46,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/toolqa/scripts/run_infer.sh
+++ b/evaluation/toolqa/scripts/run_infer.sh
@@ -61,5 +61,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch

--- a/evaluation/webarena/scripts/run_infer.sh
+++ b/evaluation/webarena/scripts/run_infer.sh
@@ -44,5 +44,3 @@ fi
 
 # Run the command
 eval $COMMAND
-
-checkout_original_branch


### PR DESCRIPTION
After #2356, we support "time-travel" for benchmarks (this PR contains some minor fixes for that functionality, but that's not the point). One missing piece is time-travel for sandboxes. Most evaluations (except SWE-bench) simply use the default sandbox for evaluation, i.e. the one from `config.sandbox_container_image`, which is usually `ghcr.io/opendevin/sandbox:latest`. This could make evaluations non-reproducible.

This PR is almost as simple as two lines of code:

```python
docker build -t eval-sandbox -f containers/sandbox/Dockerfile /tmp
export SANDBOX_CONTAINER_IMAGE="eval-sandbox"
```

It builds a sandbox image locally and uses it for evaluation. Problem solved.

What about SWE-bench? SWE-bench is an exception - it already has a built-in mechanism that builds a special sandbox on the fly. For completeness, we would still build a local sandbox image when running swe-bench-eval, but it won't be used. Ideally it would just work, but unfortunately the special sandbox is built on top of `SWE_BENCH_CONTAINER_IMAGE`, whose version is hard-coded in `swe_env_box.py`... So when we time travel, we MAY NOT be able to reproduce the results due to the discrepancy between `SWE_BENCH_CONTAINER_IMAGE`. Probably the best way for swe-bench-eval is to just `git checkout <target_branch_or_hash>`.