### PR TITLE
Use the completion decorator with cost logging

### DIFF
--- a/agenthub/SWE_agent/agent.py
+++ b/agenthub/SWE_agent/agent.py
@@ -38,7 +38,7 @@ class SWEAgent(Agent):
         self.cur_line: int = 0
 
     def _think_act(self, messages: list[dict]) -> tuple[Action, str]:
-        resp = self.llm.do_completion(
+        resp = self.llm.completion(
             messages=messages,
             temperature=0.05,
         )

--- a/agenthub/browsing_agent/browsing_agent.py
+++ b/agenthub/browsing_agent/browsing_agent.py
@@ -208,7 +208,7 @@ class BrowsingAgent(Agent):
         prompt = get_prompt(error_prefix, cur_axtree_txt, prev_action_str)
         messages.append({'role': 'user', 'content': prompt})
         logger.info(prompt)
-        response = self.llm.do_completion(
+        response = self.llm.completion(
             messages=messages,
             temperature=0.0,
             stop=[')```', ')\n```'],

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -221,7 +221,7 @@ class CodeActAgent(Agent):
                 f'\n\nENVIRONMENT REMINDER: You have {state.max_iterations - state.iteration} turns left to complete the task.'
             )
 
-        response = self.llm.do_completion(
+        response = self.llm.completion(
             messages=messages,
             stop=[
                 '</execute_ipython>',

--- a/agenthub/codeact_swe_agent/codeact_swe_agent.py
+++ b/agenthub/codeact_swe_agent/codeact_swe_agent.py
@@ -173,7 +173,7 @@ class CodeActSWEAgent(Agent):
                 f'\n\nENVIRONMENT REMINDER: You have {state.max_iterations - state.iteration} turns left to complete the task.'
             )
 
-        response = self.llm.do_completion(
+        response = self.llm.completion(
             messages=messages,
             stop=[
                 '</execute_ipython>',

--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -64,7 +64,7 @@ class MicroAgent(Agent):
             latest_user_message=state.get_current_user_intent(),
         )
         messages = [{'content': prompt, 'role': 'user'}]
-        resp = self.llm.do_completion(messages=messages)
+        resp = self.llm.completion(messages=messages)
         action_resp = resp['choices'][0]['message']['content']
         state.num_of_chars += len(prompt) + len(action_resp)
         action = parse_response(action_resp)

--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -181,7 +181,7 @@ class MonologueAgent(Agent):
         ]
 
         # format all as a single message, a monologue
-        resp = self.llm.do_completion(messages=messages)
+        resp = self.llm.completion(messages=messages)
 
         # keep track of max_chars fallback option
         state.num_of_chars += len(prompt) + len(

--- a/agenthub/planner_agent/agent.py
+++ b/agenthub/planner_agent/agent.py
@@ -47,7 +47,7 @@ class PlannerAgent(Agent):
             return AgentFinishAction()
         prompt = get_prompt(state)
         messages = [{'content': prompt, 'role': 'user'}]
-        resp = self.llm.do_completion(messages=messages)
+        resp = self.llm.completion(messages=messages)
         state.num_of_chars += len(prompt) + len(
             resp['choices'][0]['message']['content']
         )

--- a/opendevin/memory/condenser.py
+++ b/opendevin/memory/condenser.py
@@ -16,7 +16,7 @@ class MemoryCondenser:
 
         try:
             messages = [{'content': summarize_prompt, 'role': 'user'}]
-            resp = llm.do_completion(messages=messages)
+            resp = llm.completion(messages=messages)
             summary_response = resp['choices'][0]['message']['content']
             return summary_response
         except Exception as e:

--- a/tests/unit/test_micro_agents.py
+++ b/tests/unit/test_micro_agents.py
@@ -35,9 +35,7 @@ def test_coder_agent_with_summary():
     """
     mock_llm = MagicMock()
     content = json.dumps({'action': 'finish', 'args': {}})
-    mock_llm.do_completion.return_value = {
-        'choices': [{'message': {'content': content}}]
-    }
+    mock_llm.completion.return_value = {'choices': [{'message': {'content': content}}]}
 
     coder_agent = Agent.get_cls('CoderAgent')(llm=mock_llm)
     assert coder_agent is not None
@@ -49,8 +47,8 @@ def test_coder_agent_with_summary():
     state = State(history=history, inputs={'summary': summary})
     coder_agent.step(state)
 
-    mock_llm.do_completion.assert_called_once()
-    _, kwargs = mock_llm.do_completion.call_args
+    mock_llm.completion.assert_called_once()
+    _, kwargs = mock_llm.completion.call_args
     prompt = kwargs['messages'][0]['content']
     assert task in prompt
     assert "Here's a summary of the codebase, as it relates to this task" in prompt
@@ -64,9 +62,7 @@ def test_coder_agent_without_summary():
     """
     mock_llm = MagicMock()
     content = json.dumps({'action': 'finish', 'args': {}})
-    mock_llm.do_completion.return_value = {
-        'choices': [{'message': {'content': content}}]
-    }
+    mock_llm.completion.return_value = {'choices': [{'message': {'content': content}}]}
 
     coder_agent = Agent.get_cls('CoderAgent')(llm=mock_llm)
     assert coder_agent is not None
@@ -77,8 +73,8 @@ def test_coder_agent_without_summary():
     state = State(history=history)
     coder_agent.step(state)
 
-    mock_llm.do_completion.assert_called_once()
-    _, kwargs = mock_llm.do_completion.call_args
+    mock_llm.completion.assert_called_once()
+    _, kwargs = mock_llm.completion.call_args
     prompt = kwargs['messages'][0]['content']
     assert task in prompt
     assert "Here's a summary of the codebase, as it relates to this task" not in prompt


### PR DESCRIPTION
Split out of #2021 

This PR proposes to use the `completion` call for client code, while including cost logging in the wrapper.

When we added cost logging (I think), we added it to a new method `do_completion`, which wrapped the `completion` decorator and the post-processing for costs. That implies all clients need to call `do_completion` instead of `completion` as usual. This PR proposes to restore the use of the decorator for client code, while keeping the new cost logging as part of post-processing (in other words, no difference in functionality).

It's not a big deal perhaps, but I don't know, it makes sense to me: the `completion` decorator has been designed already to do a little extra stuff apart from calling `litellm.completion`, it already does some logging, so adding a bit more logging doesn't change its main functionality and compatibility with liteLLM. IMHO it's also easier for client code to use liteLLM documentation, and not have to change the call for it to work with opendevin.

**Other references**
Original discussion on `completion`: https://github.com/OpenDevin/OpenDevin/pull/114#discussion_r1537085826