### PR TITLE
feat: default timezone in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ pull-docker-image:
 
 install-python-dependencies:
 	@echo "$(GREEN)Installing Python dependencies...$(RESET)"
+	@if [ -z "${TZ}" ]; then \
+		echo "Defaulting TZ (timezone) to UTC"; \
+		export TZ="UTC"; \
+	fi
 	poetry env use python$(PYTHON_VERSION)
 	@if [ "$(shell uname)" = "Darwin" ]; then \
 		echo "$(BLUE)Installing chroma-hnswlib...$(RESET)"; \


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

During make build set a default timezone (here: UTC). 

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

This prevents e.g. the `tzdata` package to interactively prompt for one.
In the past there were issues with hung installations, which could be caused
by packages going interactive but can't be answered.

**Other references**

It was a little while back when I saw that package asking me (running on WSL),
but for the life of me I can't right now say how/when that happened.