### PR TITLE
remove gcc

### DIFF
--- a/opendevin/runtime/plugins/jupyter/setup.sh
+++ b/opendevin/runtime/plugins/jupyter/setup.sh
@@ -10,9 +10,6 @@ if [ -z "$OPENDEVIN_PYTHON_INTERPRETER" ] ||  [ ! -x "$OPENDEVIN_PYTHON_INTERPRE
     exit 1
 fi
 
-# use mamba to install c library
-/opendevin/miniforge3/bin/mamba install -y gcc
-
 # Install dependencies
 $OPENDEVIN_PYTHON_INTERPRETER -m pip install jupyterlab notebook jupyter_kernel_gateway
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

We no longer need gcc. Installing GCC will increase the load time of jupyter plugin. After removing GCC, it still works finely on Ubuntu 22.04, Debian 11, and ghcr.io/opendevin/sandbox:main.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Remove gcc installation in jupyter's setup.sh

**Other references**
