### PR TITLE
add workspace text

### DIFF
--- a/frontend/src/components/file-explorer/FileExplorer.tsx
+++ b/frontend/src/components/file-explorer/FileExplorer.tsx
@@ -32,7 +32,7 @@ function ExplorerActions({
   return (
     <div
       className={twMerge(
-        "transform flex h-[24px] items-center gap-1 absolute top-4 right-2",
+        "transform flex h-[24px] items-center gap-1",
         isHidden ? "right-3" : "right-2",
       )}
     >
@@ -168,7 +168,17 @@ function FileExplorer() {
         )}
       >
         <div className="flex flex-col p-2 relative">
-          <div className="flex items-center justify-end mb-8">
+          <div
+            className={twMerge(
+              "flex items-center mt-2 mb-1",
+              isHidden ? "justify-center" : "justify-between",
+            )}
+          >
+            {!isHidden && (
+              <div className="ml-1 text-neutral-300 font-bold text-sm">
+                Workspace
+              </div>
+            )}
             <ExplorerActions
               isHidden={isHidden}
               toggleHidden={() => setIsHidden((prev) => !prev)}


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

I felt the left side of the menu bar looked a bit empty, so I added some text to it. I'm not sure if this will conflict with the design draft.
@amanape Could you take a look for this?

before:
<img width="259" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33391300/774602f0-c4a3-4849-9cc2-7dcc1d9e63ec">



after:
<img width="259" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33391300/1e7ea1dd-4e09-4e31-a7e8-aeaa470809a2">
