### PR TITLE
Stop always pulling the latest image.

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -247,9 +247,6 @@ class DockerSSHBox(Sandbox):
             logger.info('Detected initial session.')
         if not config.persist_sandbox or self.is_initial_session:
             logger.info('Creating new Docker container')
-            # update the container image
-            if self.container_image.endswith(':main'):
-                self.docker_client.images.pull(self.container_image)
             n_tries = 5
             while n_tries > 0:
                 try:


### PR DESCRIPTION
#2555 

**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

From [#2555 Comment ](https://github.com/OpenDevin/OpenDevin/issues/2555#issue-2365611560)
> https://github.com/OpenDevin/OpenDevin/pull/2538 possibly makes startup time much slower. I just pulled the most recent version of OpenDevin and it's stuck at this log step for minutes:

We shouldn't always pull the latest image, or startup will be very slow.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Stop always pulling the latest image

**Other references**
