### PR TITLE
Revert "Always pull sandbox image"

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -348,18 +348,19 @@ class DockerSSHBox(Sandbox):
                 )
             # check the miniforge3 directory exist
             exit_code, logs = self.container.exec_run(
-                [
-                    '/bin/bash',
-                    '-c',
-                    '[ -d "/opendevin/miniforge3" ] && exit 0 || exit 1',
-                ],
+                ['/bin/bash', '-c', '[ -d "/opendevin/miniforge3" ] && exit 0 || exit 1'],
                 workdir=self.sandbox_workspace_dir,
                 environment=self._env,
             )
             if exit_code != 0:
-                raise Exception(
-                    f'An error occurred while checking if miniforge3 directory exists: {logs}'
-                )
+                if exit_code == 1:
+                    raise Exception(
+                        f'OPENDEVIN_PYTHON_INTERPRETER is not usable. Please pull the latest Docker image: docker pull ghcr.io/opendevin/sandbox:main'
+                    )
+                else:
+                    raise Exception(
+                        f'An error occurred while checking if miniforge3 directory exists: {logs}'
+                    )
             # chown the miniforge3
             exit_code, logs = self.container.exec_run(
                 ['/bin/bash', '-c', 'chown -R opendevin:root /opendevin/miniforge3'],


### PR DESCRIPTION
Reverts OpenDevin/OpenDevin#2538

The code now depends on `/opendevin/miniforge3/bin/python`. If it doesn't exist, it tells the user need to repull `ghcr.io/opendevin/sandbox:main`. But this was removed in this PR.