### PR TITLE
fix: Makefile shall pull sandbox:main, not :latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 # Makefile for OpenDevin project
 
 # Variables
-DOCKER_IMAGE = ghcr.io/opendevin/sandbox
+DOCKER_IMAGE = ghcr.io/opendevin/sandbox:main
 BACKEND_PORT = 3000
 BACKEND_HOST = "127.0.0.1:$(BACKEND_PORT)"
 FRONTEND_PORT = 3001


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

`Makefile` was pulling the `latest` as default sandbox image since no tag was specified.
Fixed by adding `:main` to `DOCKER_IMAGE` variable.

Reference: https://github.com/OpenDevin/OpenDevin/pull/2101