### PR TITLE
No longer chown -R the miniforge3 folder

### DIFF
--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -34,6 +34,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN mkdir -p /opendevin && mkdir -p /opendevin/logs && chmod 777 /opendevin/logs
 RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opendevin/miniforge3
+RUN chmod -R g+w /opendevin/miniforge3
 RUN bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge"
 RUN echo "export PATH=/opendevin/miniforge3/bin:$PATH" >> ~/.bashrc
 RUN echo "export PATH=/opendevin/miniforge3/bin:$PATH" >> /opendevin/bash.bashrc

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -361,16 +361,6 @@ class DockerSSHBox(Sandbox):
                     raise Exception(
                         f'An error occurred while checking if miniforge3 directory exists: {logs}'
                     )
-            # chown the miniforge3
-            exit_code, logs = self.container.exec_run(
-                ['/bin/bash', '-c', 'chown -R opendevin:root /opendevin/miniforge3'],
-                workdir=self.sandbox_workspace_dir,
-                environment=self._env,
-            )
-            if exit_code != 0:
-                raise Exception(
-                    f'Failed to chown miniforge3 directory for opendevin in sandbox: {logs}'
-                )
             exit_code, logs = self.container.exec_run(
                 [
                     '/bin/bash',


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
#2555
This code runs very slowly, it takes 10 seconds on my computer. Removing it might fix the slow startup issue.
I tested it, and it still runs fine after removing it.

I originally added this code because I needed to use mamba to install dependencies in setup.sh, otherwise there would be permission issues. Now it's not needed anymore. Even if needed in the future, we can use `sudo /opendevin/miniforge3/bin/mamba install` to install.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**
