### PR TITLE
Add links to a feedback sharing site

### DIFF
--- a/frontend/src/components/modals/feedback/FeedbackModal.tsx
+++ b/frontend/src/components/modals/feedback/FeedbackModal.tsx
@@ -6,6 +6,8 @@ import { Feedback, sendFeedback } from "#/services/feedbackService";
 import FeedbackForm from "./FeedbackForm";
 import toast from "#/utils/toast";
 
+const VIEWER_PAGE = "https://od-feedback.vercel.app/show";
+
 interface FeedbackModalProps {
   feedback: Feedback;
   handleEmailChange: (key: string) => void;
@@ -26,13 +28,16 @@ function FeedbackModal({
   const handleSendFeedback = () => {
     sendFeedback(feedback)
       .then((response) => {
-        if (response.message === "Feedback submitted successfully") {
-          toast.info(response.message);
+        if (response.statusCode === 200) {
+          const { message, feedback_id: feedbackId, password } = response.body;
+          const toastMessage = `${message}\nFeedback link: ${VIEWER_PAGE}?feedback_id=${feedbackId}\nPassword: ${password}`;
+          toast.info(toastMessage);
         } else {
           toast.error(
             "share-error",
-            `Failed to share, please contact the developers: ${response.message}`,
+            `Failed to share, please contact the developers: ${response.body.message}`,
           );
+          console.log(response);
         }
       })
       .catch((error) => {
@@ -40,6 +45,7 @@ function FeedbackModal({
           "share-error",
           `Failed to share, please contact the developers: ${error}`,
         );
+        console.log(error);
       });
   };
 

--- a/frontend/src/components/modals/feedback/FeedbackModal.tsx
+++ b/frontend/src/components/modals/feedback/FeedbackModal.tsx
@@ -37,7 +37,6 @@ function FeedbackModal({
             "share-error",
             `Failed to share, please contact the developers: ${response.body.message}`,
           );
-          console.log(response);
         }
       })
       .catch((error) => {
@@ -45,7 +44,6 @@ function FeedbackModal({
           "share-error",
           `Failed to share, please contact the developers: ${error}`,
         );
-        console.log(error);
       });
   };
 

--- a/opendevin/server/data_models/feedback.py
+++ b/opendevin/server/data_models/feedback.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Literal
 
 import requests
@@ -18,7 +19,7 @@ class FeedbackDataModel(BaseModel):
 FEEDBACK_URL = 'https://share-od-trajectory-3u9bw9tx.uc.gateway.dev/share_od_trajectory'
 
 
-def store_feedback(feedback: FeedbackDataModel):
+def store_feedback(feedback: FeedbackDataModel) -> dict[str, str]:
     # Start logging
     display_feedback = feedback.model_dump()
     if 'trajectory' in display_feedback:
@@ -34,6 +35,8 @@ def store_feedback(feedback: FeedbackDataModel):
         headers={'Content-Type': 'application/json'},
         json=feedback.model_dump(),
     )
-    logger.info(f'Stored feedback: {response.status_code} {response.text}')
     if response.status_code != 200:
         raise ValueError(f'Failed to store feedback: {response.text}')
+    response_data = json.loads(response.text)
+    logger.info(f'Stored feedback: {response.text}')
+    return response_data

--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -329,10 +329,8 @@ async def submit_feedback(request: Request, feedback: FeedbackDataModel):
     # Assuming the storage service is already configured in the backend
     # and there is a function  to handle the storage.
     try:
-        store_feedback(feedback)
-        return JSONResponse(
-            status_code=200, content={'message': 'Feedback submitted successfully'}
-        )
+        feedback_data = store_feedback(feedback)
+        return JSONResponse(status_code=200, content=feedback_data)
     except Exception as e:
         logger.error(f'Error submitting feedback: {e}')
         return JSONResponse(


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

When users encounter problems, it would be nice if they could share their interaction history with us so we could examine the agent's behavior and see if there was anything wrong.

Fixes #1802

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

This PR:
1. Exposes a unique feedback ID to the frontend
2. When feedback is successfully uploaded, provides the user with a link to a Vercel app that I set up to display the feedback: https://od-feedback.vercel.app/show

See this video for how the user can copy-paste this link, view it, and share it with us: https://youtu.be/yBf-mT__yKE

And see this link for an example of the shared feedback: https://od-feedback.vercel.app/show?feedback_id=f2e05ad2a2c039ae9379c2864b25f39804a82a6bda1f509d672dd25e5693dd8d
