### PR TITLE
Enable "vz" vm-type for MacOS CI

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   test-on-macos:
     name: Test on macOS
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       INSTALL_DOCKER: "1" # Set to '0' to skip Docker installation
     strategy:
@@ -49,13 +49,13 @@ jobs:
           # Uninstall colima to upgrade to the latest version
           if brew list colima &>/dev/null; then
               brew uninstall colima
-              # unlinking colima dependency: go
+              # uninstall colima dependency: go
               brew uninstall go@1.21
           fi
           brew install --HEAD colima
           brew services start colima
           brew install docker
-          colima start  --network-address --arch x86_64
+          colima start  --network-address --arch x86_64 --vm-type=vz
 
           # For testcontainers to find the Colima socket
           # https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#cannot-connect-to-the-docker-daemon-at-unixvarrundockersock-is-the-docker-daemon-running


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

[Current Action Link](https://github.com/OpenDevin/OpenDevin/actions/runs/9622270197/job/26543320014?pr=2433)
Error: msg="[hostagent] QEMU did not exit in 3m0s, forcibly killing QEMU"
Related issue: https://github.com/abiosoft/colima/issues/777

---

In PR #2499, got the above error once and the below error twice. And the runner get Intel images only and not ARM.

Error:  msg="did not receive an event with the \"running\" status"
Related issue: https://github.com/abiosoft/colima/issues/629

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**
So, as suggested in https://github.com/abiosoft/colima/issues/629#issuecomment-1912389908, Using vz vm-type which seems fast which requires mac os >=13

If this fails too, need to reinstall or upgrade qemu as suggested in https://github.com/abiosoft/colima/issues/777#issuecomment-1878399603

**Other references**
[Flowchart to choose the best vmType](https://lima-vm.io/docs/config/vmtype/#:~:text=flowchart%20to%20choose%20the%20best%20vmType) 