### PR TITLE
Track metrics throughout delegation & Polish UX for out of budget error

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -316,10 +316,12 @@ class AgentController:
         else:
             await self.add_history(action, NullObservation(''))
 
+        await self.update_state_after_step()
+        if self.state.agent_state == AgentState.ERROR:
+            return
+
         if not isinstance(action, NullAction):
             await self.event_stream.add_event(action, EventSource.AGENT)
-
-        await self.update_state_after_step()
 
         if self._is_stuck():
             await self.report_error('Agent got stuck in a loop')

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -23,6 +23,10 @@ class Metrics:
     def costs(self) -> list:
         return self._costs
 
+    def merge(self, other: 'Metrics') -> None:
+        self._accumulated_cost += other._accumulated_cost
+        self._costs += other._costs
+
     def add_cost(self, value: float) -> None:
         if value < 0:
             raise ValueError('Added cost cannot be negative.')

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -23,10 +23,6 @@ class Metrics:
     def costs(self) -> list:
         return self._costs
 
-    def merge(self, other: 'Metrics') -> None:
-        self._accumulated_cost += other._accumulated_cost
-        self._costs += other._costs
-
     def add_cost(self, value: float) -> None:
         if value < 0:
             raise ValueError('Added cost cannot be negative.')

--- a/opendevin/core/metrics.py
+++ b/opendevin/core/metrics.py
@@ -44,3 +44,6 @@ class Metrics:
         for key, value in metrics.items():
             logs += f'{key}: {value}\n'
         return logs
+
+    def __repr__(self):
+        return f'Metrics({self.get()}'

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -237,7 +237,7 @@ class LLM:
             cur_cost = 0
         if self.cost_metric_supported:
             logger.info(
-                'Cost: %.2f USD | Accumulated Cost: %.2f USD',
+                'Cost: %.2f USD | Accumulated Cost (current agent): %.2f USD',
                 cur_cost,
                 self.metrics.accumulated_cost,
             )

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -237,7 +237,7 @@ class LLM:
             cur_cost = 0
         if self.cost_metric_supported:
             logger.info(
-                'Cost: %.2f USD | Accumulated Cost (current agent): %.2f USD',
+                'Cost: %.2f USD | Accumulated Cost: %.2f USD',
                 cur_cost,
                 self.metrics.accumulated_cost,
             )


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

OpenDevin tracks costs and allow users to set up a max budget for each task, but it doesn't work for delegates. Specifically, parents and children don't share the budget. This means execution for a task can exceed its preset budget.

Moreover, when OpenDevin sees an out-of-budget error, it displays the messages in a weird order. See the screenshots in next comment.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

1. Fix messaging order when there's out-of-budget error to improve UX
2. Make parents and children share metrics object (share costs)

**Other references**

Currently this is not testable (especially the message order part). I am considering adding trajectory replay support and then we could replay trajectories in tests.