### PR TITLE
Remove Colima and lima directory after uninstalling for Mac OS CI

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -52,6 +52,7 @@ jobs:
               # unlinking colima dependency: go
               brew uninstall go@1.21
           fi
+          rm -rf ~/.colima
           brew install --HEAD colima
           brew services start colima
           brew install docker

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -52,7 +52,7 @@ jobs:
               # unlinking colima dependency: go
               brew uninstall go@1.21
           fi
-          rm -rf ~/.colima
+          rm -rf ~/.colima ~/.lima
           brew install --HEAD colima
           brew services start colima
           brew install docker


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

[Current Action Link](https://github.com/OpenDevin/OpenDevin/actions/runs/9622270197/job/26543320014?pr=2433)
Error: msg="[hostagent] QEMU did not exit in 3m0s, forcibly killing QEMU"
Relevant issue: https://github.com/abiosoft/colima/issues/913

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**
Remove the Colima directory after uninstalling as suggested in https://github.com/abiosoft/colima/issues/913#issuecomment-2111925289 as it contains ssh_config and some other configs.

**Other references**
