### PR TITLE
fix(frontend): Disable eslint rule that throws `useEffect` warning

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -55,7 +55,8 @@
               "some": [ "nesting", "id" ]
           }
         }],
-        "react/no-array-index-key": "off"
+        "react/no-array-index-key": "off",
+        "react-hooks/exhaustive-deps": "off"
       },"parserOptions": {
         "project": ["**/tsconfig.json"]
       }


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
Disables the ESLint rule that throws the annoying exhaustive dependency warning for `useEffect` hooks that don't fill their dependency arrays.

The developer should decide which dependencies they need to add to appropriately trigger the `useEffect`, the dependency array does not need to contain all artifacts used within the `useEffect`.
