### PR TITLE
Default makefile for persist_sandbox to be false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,8 @@ setup-config-prompts:
 	 workspace_dir=$${workspace_dir:-$(DEFAULT_WORKSPACE_DIR)}; \
 	 echo "workspace_base=\"$$workspace_dir\"" >> $(CONFIG_FILE).tmp
 
-	@read -p "Do you want to persist the sandbox container? [true/false] [default: true]: " persist_sandbox; \
-	 persist_sandbox=$${persist_sandbox:-true}; \
+	@read -p "Do you want to persist the sandbox container? [true/false] [default: false]: " persist_sandbox; \
+	 persist_sandbox=$${persist_sandbox:-false}; \
 	 if [ "$$persist_sandbox" = "true" ]; then \
 		 read -p "Enter a password for the sandbox container: " ssh_password; \
 		 echo "ssh_password=\"$$ssh_password\"" >> $(CONFIG_FILE).tmp; \


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
This comment was not resolved before PR was merged: https://github.com/OpenDevin/OpenDevin/pull/2591#issuecomment-2184131712

Just defaulting the persist_sandbox to false in the makefile

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**
