### PR TITLE
feat: allow SANDBOX_CONTAINER_IMAGEs built from opendevin/sandbox:main

### DIFF
--- a/evaluation/swe_bench/scripts/docker/Dockerfile.full_deps
+++ b/evaluation/swe_bench/scripts/docker/Dockerfile.full_deps
@@ -1,6 +1,6 @@
 FROM ghcr.io/opendevin/eval-swe-bench:builder
 
-# This Dockefile is used to build the Docker image for the evaluation of the SWE-Bench.
+# This Dockerfile is used to build the Docker image for the evaluation of the SWE-Bench.
 # YOU SHOULD ENSURE ./eval_workspace CONTAINS THE EVALUATION WORKSPACE (testbed, conda)
 # Check BUILD_TESTBED_AND_ENV.md for more details.
 

--- a/opendevin/runtime/docker/image_agnostic_util.py
+++ b/opendevin/runtime/docker/image_agnostic_util.py
@@ -17,11 +17,12 @@ def generate_dockerfile_content(base_image: str) -> str:
         'RUN apt update && apt install -y openssh-server wget sudo\n'
         'RUN mkdir -p -m0755 /var/run/sshd\n'
         'RUN mkdir -p /opendevin && mkdir -p /opendevin/logs && chmod 777 /opendevin/logs\n'
-        'RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"\n'
-        'RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opendevin/miniforge3\n'
-        'RUN bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge"\n'
-        'RUN echo "export PATH=/opendevin/miniforge3/bin:$PATH" >> ~/.bashrc\n'
-        'RUN echo "export PATH=/opendevin/miniforge3/bin:$PATH" >> /opendevin/bash.bashrc\n'
+        'RUN { test -d /opendevin/miniforge3 && echo "/opendevin/miniforge3 already in base image"; } || { \\\n'
+        '    wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \\\n'
+        '    bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opendevin/miniforge3 && \\\n'
+        '    bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge" && \\\n'
+        '    echo "export PATH=/opendevin/miniforge3/bin:$PATH" >> ~/.bashrc && \\\n'
+        '    echo "export PATH=/opendevin/miniforge3/bin:$PATH" >> /opendevin/bash.bashrc; }\n'
     ).strip()
     return dockerfile_content
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
If you are building your own `SANDBOX_CONTAINER_IMAGE` from `ghcr.io/opendevin/sandbox:main`, building the final sandbox image in `opendevin/runtime/docker/image_agnostic_util.py` fails because it tried to reinstall `miniforge3`.

You may want to build from `ghcr.io/opendevin/sandbox:main` to install additional Python dependencies.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**
Rather than install `miniforge3` no matter what, check if `/opendevin/miniforge3` is already there

**Other references**
