### PR TITLE
Add test for auto_lint after file edit

### DIFF
--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -301,25 +301,68 @@ def _test_sandbox_jupyter_agentskills_fileop_pwd_impl(box):
     print(output)
     assert exit_code == 0, 'The exit code should be 0 for ' + box.__class__.__name__
 
-    exit_code, output = box.execute('echo "create_file(\'a.txt\')" | execute_cli')
+    exit_code, output = box.execute('echo "create_file(\'hello.py\')" | execute_cli')
     print(output)
     assert exit_code == 0, 'The exit code should be 0 for ' + box.__class__.__name__
     assert output.strip().split('\r\n') == (
-        '[File: /workspace/a.txt (1 lines total)]\r\n' '1|\r\n' '[File a.txt created.]'
+        '[File: /workspace/hello.py (1 lines total)]\r\n'
+        '1|\r\n'
+        '[File hello.py created.]'
     ).strip().split('\r\n')
 
     exit_code, output = box.execute('cd test')
     print(output)
     assert exit_code == 0, 'The exit code should be 0 for ' + box.__class__.__name__
 
-    exit_code, output = box.execute('echo "create_file(\'a.txt\')" | execute_cli')
+    exit_code, output = box.execute('echo "create_file(\'hello.py\')" | execute_cli')
     print(output)
     assert exit_code == 0, 'The exit code should be 0 for ' + box.__class__.__name__
     assert output.strip().split('\r\n') == (
-        '[File: /workspace/test/a.txt (1 lines total)]\r\n'
+        '[File: /workspace/test/hello.py (1 lines total)]\r\n'
         '1|\r\n'
-        '[File a.txt created.]'
+        '[File hello.py created.]'
     ).strip().split('\r\n')
+
+    if config.enable_auto_lint:
+        # edit file, but make a mistake in indentation
+        exit_code, output = box.execute(
+            'echo "edit_file(\'hello.py\', 1, 1, \'  print(\\"hello world\\")\')" | execute_cli'
+        )
+        print(output)
+        assert exit_code == 0, 'The exit code should be 0 for ' + box.__class__.__name__
+        assert output.strip().split('\r\n') == (
+            """
+[Your proposed edit has introduced new syntax error(s). Please understand the errors and retry your edit command.]
+ERRORS:
+hello.py:1:3: E999 IndentationError: unexpected indent
+[This is how your edit would have looked if applied]
+-------------------------------------------------
+1|  print("hello world")
+-------------------------------------------------
+
+[This is the original code before your edit]
+-------------------------------------------------
+1|
+-------------------------------------------------
+Your changes have NOT been applied. Please fix your edit command and try again.
+You either need to 1) Specify the correct start/end line arguments or 2) Correct your edit code.
+DO NOT re-run the same failed edit command. Running it again will lead to the same error.
+"""
+        ).strip().split('\n')
+
+    # edit file with correct indentation
+    exit_code, output = box.execute(
+        'echo "edit_file(\'hello.py\', 1, 1, \'print(\\"hello world\\")\')" | execute_cli'
+    )
+    print(output)
+    assert exit_code == 0, 'The exit code should be 0 for ' + box.__class__.__name__
+    assert output.strip().split('\r\n') == (
+        """
+[File: /workspace/test/hello.py (1 lines total after edit)]
+1|print("hello world")
+[File updated. Please review the changes and make sure they are correct (correct indentation, no duplicate lines, etc). Edit the file again if necessary.]
+"""
+    ).strip().split('\n')
 
     exit_code, output = box.execute('rm -rf /workspace/*')
     assert exit_code == 0, 'The exit code should be 0 for ' + box.__class__.__name__
@@ -330,9 +373,10 @@ def test_sandbox_jupyter_agentskills_fileop_pwd(temp_dir):
     # get a temporary directory
     with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
         config, 'workspace_mount_path', new=temp_dir
-    ), patch.object(config, 'run_as_devin', new='true'), patch.object(
+    ), patch.object(config, 'run_as_devin', new=True), patch.object(
         config, 'sandbox_type', new='ssh'
-    ):
+    ), patch.object(config, 'enable_auto_lint', new=True):
+        assert config.enable_auto_lint
         for box in [DockerSSHBox()]:
             _test_sandbox_jupyter_agentskills_fileop_pwd_impl(box)
 
@@ -346,8 +390,11 @@ def test_agnostic_sandbox_jupyter_agentskills_fileop_pwd(temp_dir):
         # get a temporary directory
         with patch.object(config, 'workspace_base', new=temp_dir), patch.object(
             config, 'workspace_mount_path', new=temp_dir
-        ), patch.object(config, 'run_as_devin', new='true'), patch.object(
+        ), patch.object(config, 'run_as_devin', new=True), patch.object(
             config, 'sandbox_type', new='ssh'
-        ), patch.object(config, 'sandbox_container_image', new=base_sandbox_image):
+        ), patch.object(
+            config, 'sandbox_container_image', new=base_sandbox_image
+        ), patch.object(config, 'enable_auto_lint', new=False):
+            assert not config.enable_auto_lint
             for box in [DockerSSHBox()]:
                 _test_sandbox_jupyter_agentskills_fileop_pwd_impl(box)


### PR DESCRIPTION
`config.enable_auto_lint` is a very important feature to guide LLMs to make edit commands right, since LLM often messes around with indentation and line numbers. It currently only works for python, and is disabled by default. We turn it on for SWE-bench evaluation purpose, though.

This PR adds a basic test for AUTO_LINT feature.