### PR TITLE
Revert "Show relevant error in UI"

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -120,9 +120,9 @@ class AgentController:
         - the string message should be user-friendly, it will be shown in the UI
         - an ErrorObservation can be sent to the LLM by the agent, with the exception message, so it can self-correct next time
         """
-        if exception:
-            message += f': {exception}'
         self.state.error = message
+        if exception:
+            self.state.error += f': {str(exception)}'
         await self.event_stream.add_event(ErrorObservation(message), EventSource.AGENT)
 
     async def add_history(self, action: Action, observation: Observation):
@@ -140,6 +140,7 @@ class AgentController:
                 logger.info('AgentController task was cancelled')
                 break
             except Exception as e:
+                traceback.print_exc()
                 logger.error(f'Error while running the agent: {e}')
                 logger.error(traceback.format_exc())
                 await self.report_error(


### PR DESCRIPTION
This PR proposes a revert of OpenDevin/OpenDevin#2516.

Please check out the history of this issue:
- sending `str(e)` in the ErrorObservation has been shown to leak private info: [screenshot](https://private-user-images.githubusercontent.com/1708914/326360829-d055f819-b857-47cc-8075-cab9d79c9f01.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTk0NzUwNjQsIm5iZiI6MTcxOTQ3NDc2NCwicGF0aCI6Ii8xNzA4OTE0LzMyNjM2MDgyOS1kMDU1ZjgxOS1iODU3LTQ3Y2MtODA3NS1jYWI5ZDc5YzlmMDEucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDYyNyUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA2MjdUMDc1MjQ0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9YjIyMjU0YjUyMmQxOWUzNjEzNTJhMTUxN2I2OGI4NDhhYTc2NjNiY2Q0NDQwMjZlZWFmMzYzYmM0NTQ5MzkwZiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.6kO6VKnlHU0KmjXXiKHC2HY_D9Lz4Fu621TEvnDJmGw)
- we have tried a while ago to remove the raw exceptions from the UI chat box. Ref https://github.com/OpenDevin/OpenDevin/pull/1296: this PR has removed all exceptions / errors from being displayed in the chat box. Instead, it replaces them with some custom exceptions that have user-friendly messages, expressing the problem in plain language or directing the user to the logs
- it can be unexpected to users and to the agent, to get in chat (and in history) some backend errors that the agent tried to fix even though it cannot do that ([example](https://opendevin.slack.com/archives/C06P5NCGSFP/p1713820053801349?thread_ts=1713798893.439339&channel=C06P5NCGSFP&message_ts=1713820053.801349))

I re-opened https://github.com/OpenDevin/OpenDevin/issues/1451 to look for a better way.

Maybe we could split the `send_error` function into the UI part and the backend stuff we do there? The `exception` there was intended only to be saved in state for use in evals, and not for user's chatbox, but that might be the problem here, we do different things in that spot, and it's not always clear how to keep them separate. 😅 I don't know, but I do think it's better to revert this and choose an alternative.