### PR TITLE
[Evaluation] Improve patch apply in SWE-Bench

### DIFF
--- a/evaluation/swe_bench/scripts/eval/convert_od_output_to_swe_json.py
+++ b/evaluation/swe_bench/scripts/eval/convert_od_output_to_swe_json.py
@@ -17,7 +17,9 @@ model_name = os.path.basename(os.path.dirname(args.od_output_file))
 def convert_row_to_swebench_format(row):
     return {
         'instance_id': row['instance_id'],
-        'model_patch': row['git_patch'].replace('\r\n', '\n').rstrip() + '\n',
+        'model_patch': row['git_patch'].replace('\r\n', '\n').rstrip() + '\n'
+        if row['git_patch'].strip()
+        else '',
         'model_name_or_path': model_name,
     }
 

--- a/evaluation/swe_bench/scripts/eval/convert_od_output_to_swe_json.py
+++ b/evaluation/swe_bench/scripts/eval/convert_od_output_to_swe_json.py
@@ -17,7 +17,7 @@ model_name = os.path.basename(os.path.dirname(args.od_output_file))
 def convert_row_to_swebench_format(row):
     return {
         'instance_id': row['instance_id'],
-        'model_patch': row['git_patch'].replace('\r\n', '\n'),
+        'model_patch': row['git_patch'].replace('\r\n', '\n').rstrip() + '\n',
         'model_name_or_path': model_name,
     }
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

`.rstrip()` removes the last newline of the git patch that affects the applied "rate of the generated patch," which hurts the pass rate a little bit.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

This adds a new line at the end of the git patch (if it is not already empty) and improves "CodeAct v1.6 no-hint" from 56 (18.6%) to 58 (19.3%): https://huggingface.co/spaces/OpenDevin/evaluation/commit/a4e8ae805efa8b76a9f7353465baf57bdec415bf

I'm in the process of re-running all the existing runs.