### PR TITLE
ghcr: Fix local built image name in tests

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -177,7 +177,7 @@ jobs:
   ghcr_push:
     runs-on: ubuntu-latest
     # don't push if integration tests or sandbox tests fail
-    needs: [ghcr_build, integration-tests-on-linux, test-for-sandbox]
+    needs: [ghcr_build]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
 
     env:
@@ -212,7 +212,8 @@ jobs:
       - name: Load images and push to registry
         run: |
           mv /tmp/${{ matrix.platform }}/${{ matrix.image }}_image_${{ matrix.platform }}.tar .
-          loaded_image=$(docker load -i ${{ matrix.image }}_image_${{ matrix.platform }}.tar | grep "Loaded image:" | awk '{print $3}')
+          loaded_image=$(docker load -i ${{ matrix.image }}_image_${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}')
+          echo "loaded image = $loaded_image"
           tags=$(echo ${tags} | tr ' ' '\n')
           image_name=$(echo "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}" | tr '[:upper:]' '[:lower:]')
           echo "image name = $image_name"

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -177,7 +177,7 @@ jobs:
   ghcr_push:
     runs-on: ubuntu-latest
     # don't push if integration tests or sandbox tests fail
-    needs: [ghcr_build]
+    needs: [ghcr_build, integration-tests-on-linux, test-for-sandbox]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
 
     env:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     # don't push if integration tests or sandbox tests fail
     needs: [ghcr_build, integration-tests-on-linux, test-for-sandbox]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
 
     env:
       tags: ${{ needs.ghcr_build.outputs.tags }}
@@ -225,7 +225,7 @@ jobs:
   create_manifest:
     runs-on: ubuntu-latest
     needs: [ghcr_build, ghcr_push]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
 
     env:
       tags: ${{ needs.ghcr_build.outputs.tags }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -109,8 +109,8 @@ jobs:
           # Load the Docker image and capture the output
           output=$(docker load -i /tmp/sandbox_image_amd64.tar)
 
-          # Extract the image name from the output
-          image_name=$(echo "$output" | grep -oP 'Loaded image: \K.*')
+          # Extract the first image name from the output
+          image_name=$(echo "$output" | grep -oP 'Loaded image: \K.*' | head -n 1)
 
           # Print the full name of the image
           echo "Loaded Docker image: $image_name"
@@ -161,8 +161,8 @@ jobs:
           # Load the Docker image and capture the output
           output=$(docker load -i /tmp/sandbox_image_amd64.tar)
 
-          # Extract the image name from the output
-          image_name=$(echo "$output" | grep -oP 'Loaded image: \K.*')
+          # Extract the first image name from the output
+          image_name=$(echo "$output" | grep -oP 'Loaded image: \K.*' | head -n 1)
 
           # Print the full name of the image
           echo "Loaded Docker image: $image_name"


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

#2456 introduces a bug: when there are multiple tags (which happens during releases, e.g. we tag the docker image as 0, 0.7, and 0.7.0), the tests don't run.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

When loading locally built image names, only take the first one if there are multiple.

**Other references**

I am testing it by releasing 0.7.0 on my fork: https://github.com/li-boxuan/OpenDevin/releases/tag/0.7.0 with CI/CD: https://github.com/li-boxuan/OpenDevin/actions/runs/9722823185 (I changed dependency order so that the CD doesn't wait for tests, but that shouldn't matter)

Looks good: https://github.com/li-boxuan/OpenDevin/pkgs/container/opendevin/236865052?tag=0.7
