### PR TITLE
Bypass MAX_ITERATIONS and MAX_BUDGET_PER_TASK on web GUI

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -215,6 +215,8 @@ class AgentController:
 
     def get_agent_state(self):
         """Returns the current state of the agent task."""
+        if self.delegate is not None:
+            return self.delegate.get_agent_state()
         return self.state.agent_state
 
     async def start_delegate(self, action: AgentDelegateAction):

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -314,8 +314,7 @@ class AgentController:
                 )
                 await self.set_agent_state_to(AgentState.PAUSED)
                 return
-
-        if self.max_budget_per_task is not None:
+        elif self.max_budget_per_task is not None:
             current_cost = self.state.metrics.accumulated_cost
             if current_cost > self.max_budget_per_task:
                 if self.state.traffic_control_state == TRAFFIC_CONTROL_STATE.PAUSED:

--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -308,6 +308,7 @@ class AgentController:
                 )
                 self.state.traffic_control_state = TRAFFIC_CONTROL_STATE.NORMAL
             else:
+                self.state.traffic_control_state = TRAFFIC_CONTROL_STATE.THROTTLING
                 await self.report_error(
                     f'Agent reached maximum number of iterations, task paused. {TRAFFIC_CONTROL_REMINDER}'
                 )
@@ -323,6 +324,7 @@ class AgentController:
                     )
                     self.state.traffic_control_state = TRAFFIC_CONTROL_STATE.NORMAL
                 else:
+                    self.state.traffic_control_state = TRAFFIC_CONTROL_STATE.THROTTLING
                     await self.report_error(
                         f'Task budget exceeded. Current cost: {current_cost:.2f}, Max budget: {self.max_budget_per_task:.2f}, task paused. {TRAFFIC_CONTROL_REMINDER}'
                     )

--- a/opendevin/controller/state/state.py
+++ b/opendevin/controller/state/state.py
@@ -1,6 +1,7 @@
 import base64
 import pickle
 from dataclasses import dataclass, field
+from enum import Enum
 
 from opendevin.controller.state.task import RootTask
 from opendevin.core.logger import opendevin_logger as logger
@@ -15,6 +16,18 @@ from opendevin.events.observation import (
     Observation,
 )
 from opendevin.storage import get_file_store
+
+
+class TRAFFIC_CONTROL_STATE(str, Enum):
+    # default state, no rate limiting
+    NORMAL = 'normal'
+
+    # task paused due to traffic control
+    THROTTLING = 'throttling'
+
+    # traffic control is temporarily paused
+    PAUSED = 'paused'
+
 
 RESUMABLE_STATES = [
     AgentState.RUNNING,
@@ -37,6 +50,7 @@ class State:
     error: str | None = None
     agent_state: AgentState = AgentState.LOADING
     resume_state: AgentState | None = None
+    traffic_control_state: TRAFFIC_CONTROL_STATE = TRAFFIC_CONTROL_STATE.NORMAL
     metrics: Metrics = Metrics()
     # root agent has level 0, and every delegate increases the level by one
     delegate_level: int = 0


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Closes #1493 

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Introduced `TRAFFIC_CONTROL_STATE` to allow OpenDevin to switch between normal traffic limiting mode and temporarily disabled mode.

**Demo**

I set `MAX_ITERATIONS=1` so I have to hit "RESUME" button multiple times to get the result step by step. I think it's also useful when you'd like the agent to solve the task step-by-step under your surveillance.

<img width="1387" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/25746010/56e0dec2-dcce-4d4b-9648-b0a2bc3a0456">

This feature is only available on web GUI. If you are using `main.py`, then the control flow would be paused and there's nothing you could do but quit the program:

<img width="1122" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/25746010/58f63c43-bf33-4597-b0e9-9be3cef925ff">
