### PR TITLE
style: refine the copy button and add copy feedback for the icon.

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -34,7 +34,7 @@ function ChatInput({ disabled = false, onSendMessage }: ChatInputProps) {
   };
 
   return (
-    <div className="w-full relative text-base flex">
+    <div className="w-full relative text-base flex pt-3">
       <Textarea
         value={message}
         onChange={(e) => setMessage(e.target.value)}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import Markdown from "react-markdown";
-import { FaClipboard } from "react-icons/fa";
+import { FaClipboard, FaClipboardCheck } from "react-icons/fa";
 import { twMerge } from "tailwind-merge";
 import { useTranslation } from "react-i18next";
 import { code } from "../markdown/code";
@@ -12,6 +12,7 @@ interface MessageProps {
 }
 
 function ChatMessage({ message }: MessageProps) {
+  const [isCopy, setIsCopy] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
 
   const className = twMerge(
@@ -25,6 +26,10 @@ function ChatMessage({ message }: MessageProps) {
     navigator.clipboard
       .writeText(message.content)
       .then(() => {
+        setIsCopy(true);
+        setTimeout(() => {
+          setIsCopy(false);
+        }, 1500);
         toast.info(t(I18nKey.CHAT_INTERFACE$CHAT_MESSAGE_COPIED));
       })
       .catch(() => {
@@ -45,11 +50,11 @@ function ChatMessage({ message }: MessageProps) {
       {isHovering && (
         <button
           onClick={copyToClipboard}
-          className="absolute top-1 right-1 p-1 bg-neutral-600 rounded hover:bg-neutral-500 transition-opacity opacity-75 hover:opacity-100"
+          className="absolute top-1 right-1 p-1 bg-neutral-600 rounded hover:bg-neutral-700"
           aria-label={t(I18nKey.CHAT_INTERFACE$TOOLTIP_COPY_MESSAGE)}
           type="button"
         >
-          <FaClipboard />
+          {isCopy ? <FaClipboardCheck /> : <FaClipboard />}
         </button>
       )}
       <Markdown components={{ code }}>{message.content}</Markdown>


### PR DESCRIPTION
* Refine the copy button and add copy feedback for the icon.
* Add padding on top for input to overlay the message bubbles.

Before:
<img width="561" alt="Xnip2024-07-01_21-36-42" src="https://github.com/OpenDevin/OpenDevin/assets/16201837/908d3c59-cf3a-450e-b136-ba146fe791b6">

After:
<img width="557" alt="Xnip2024-07-01_21-36-57" src="https://github.com/OpenDevin/OpenDevin/assets/16201837/efa45c5a-c999-4b07-ab32-613116bc1ce3">

The copy button:

https://github.com/OpenDevin/OpenDevin/assets/16201837/d1b47aac-ecbc-4a2d-a70a-0e0c15121bf4


