### PR TITLE
test: fix the failed unit tests.

### DIFF
--- a/frontend/src/components/chat/ChatInterface.test.tsx
+++ b/frontend/src/components/chat/ChatInterface.test.tsx
@@ -3,11 +3,13 @@ import { screen, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "test-utils";
+import { useTranslation } from "react-i18next";
 import ChatInterface from "./ChatInterface";
 import Session from "#/services/session";
 import ActionType from "#/types/ActionType";
 import { addAssistantMessage } from "#/state/chatSlice";
 import AgentState from "#/types/AgentState";
+import { I18nKey } from "#/i18n/declaration";
 
 // avoid typing side-effect
 vi.mock("#/hooks/useTyping", () => ({
@@ -113,7 +115,11 @@ describe("ChatInterface", () => {
       },
     });
 
-    const submitButton = screen.getByLabelText(/send message/i);
+    const { t } = useTranslation();
+
+    const submitButton = screen.getByLabelText(
+      t(I18nKey.CHAT_INTERFACE$TOOLTIP_SEND_MESSAGE),
+    );
 
     expect(submitButton).toBeDisabled();
   });

--- a/frontend/src/components/terminal/Terminal.test.tsx
+++ b/frontend/src/components/terminal/Terminal.test.tsx
@@ -13,6 +13,8 @@ const openMock = vi.fn();
 const writeMock = vi.fn();
 const writelnMock = vi.fn();
 const disposeMock = vi.fn();
+const onKeyMock = vi.fn();
+const attachCustomKeyEventHandlerMock = vi.fn();
 
 vi.mock("@xterm/xterm", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@xterm/xterm")>()),
@@ -21,6 +23,8 @@ vi.mock("@xterm/xterm", async (importOriginal) => ({
     write: writeMock,
     writeln: writelnMock,
     dispose: disposeMock,
+    onKey: onKeyMock,
+    attachCustomKeyEventHandler: attachCustomKeyEventHandlerMock,
     loadAddon: vi.fn(),
   })),
 }));
@@ -42,7 +46,7 @@ describe("Terminal", () => {
   it("should render a terminal", () => {
     renderTerminal();
 
-    expect(screen.getByText("Terminal (read-only)")).toBeInTheDocument();
+    expect(screen.getByText("Terminal")).toBeInTheDocument();
     expect(openMock).toHaveBeenCalledTimes(1);
 
     expect(writeMock).toHaveBeenCalledWith("$ ");


### PR DESCRIPTION
Before:
<img width="930" alt="Xnip2024-07-01_22-41-16" src="https://github.com/OpenDevin/OpenDevin/assets/16201837/fa7350c1-0b5f-4de0-a284-2678ba6b33e5">

After:
<img width="955" alt="Xnip2024-07-01_22-41-02" src="https://github.com/OpenDevin/OpenDevin/assets/16201837/f310eb76-7ae6-4c58-a09d-07c90a84208d">

It's wired, it seems the GitHub workflow doesn't check the FE's unit tests. why do the UTs usually fail but no one is blocked by the git hook? 🥶