### PR TITLE
fix: improve exit_code processing (ssh_box)

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -504,17 +504,12 @@ class DockerSSHBox(Sandbox):
 
         # once out, make sure that we have *every* output, we while loop until we get an empty output
         while True:
-            logger.debug('WAITING FOR .prompt()')
             self.ssh.sendline('\n')
             timeout_not_reached = self.ssh.prompt(timeout=1)
             if not timeout_not_reached:
                 logger.debug('TIMEOUT REACHED')
                 break
-            logger.debug('WAITING FOR .before')
             output = self.ssh.before
-            logger.debug(
-                f'WAITING FOR END OF command output ({bool(output)}): {output}'
-            )
             if isinstance(output, str) and output.strip() == '':
                 break
             command_output += output
@@ -528,7 +523,6 @@ class DockerSSHBox(Sandbox):
         while not exit_code_str:
             self.ssh.prompt(timeout=1)
             exit_code_str = self.ssh.before.strip()
-            logger.debug(f'WAITING FOR exit code: {exit_code_str}')
             if time.time() - _start_time > timeout:
                 return self._send_interrupt(
                     cmd, command_output, ignore_last_output=True

--- a/opendevin/runtime/plugins/mixin.py
+++ b/opendevin/runtime/plugins/mixin.py
@@ -70,7 +70,7 @@ class PluginMixin:
                     for line in output:
                         # Removes any trailing whitespace, including \n and \r\n
                         line = line.rstrip()
-                        logger.debug(line)
+                        # logger.debug(line)
                         # Avoid text from lines running into each other
                         total_output += line + ' '
                     _exit_code = output.exit_code()


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Improved exit_code handling to avoid "invalid literal" error message.

Fixes: https://github.com/OpenDevin/OpenDevin/issues/2702
The same error also happens during evaluations.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

SSHExecCancellableStream -> exit_code rewritten to make the detection of the actual exit code more robust.
