### PR TITLE
Fix: Add scroll functionality to file explorer sidepane

### DIFF
--- a/frontend/src/components/file-explorer/FileExplorer.tsx
+++ b/frontend/src/components/file-explorer/FileExplorer.tsx
@@ -216,10 +216,10 @@ function FileExplorer() {
       <div
         className={twMerge(
           "bg-neutral-800 h-full border-r-1 border-r-neutral-600 flex flex-col transition-all ease-soft-spring",
-          isHidden ? "min-w-[48px]" : "min-w-[228px]",
+          isHidden ? "w-12" : "w-60",
         )}
       >
-        <div className="flex flex-col relative h-full">
+        <div className="flex flex-col relative h-full p-4">
           <div className="sticky top-0 bg-neutral-800 z-10">
             <div
               className={twMerge(

--- a/frontend/src/components/file-explorer/FileExplorer.tsx
+++ b/frontend/src/components/file-explorer/FileExplorer.tsx
@@ -219,7 +219,7 @@ function FileExplorer() {
           isHidden ? "w-12" : "w-60",
         )}
       >
-        <div className="flex flex-col relative h-full p-4">
+        <div className="flex flex-col relative h-full p-2">
           <div className="sticky top-0 bg-neutral-800 z-10">
             <div
               className={twMerge(

--- a/frontend/src/components/file-explorer/TreeNode.tsx
+++ b/frontend/src/components/file-explorer/TreeNode.tsx
@@ -20,9 +20,11 @@ function Title({ name, type, isOpen, onClick }: TitleProps) {
       onClick={onClick}
       className="cursor-pointer rounded-[5px] p-1 nowrap flex items-center gap-2 aria-selected:bg-neutral-600 aria-selected:text-white hover:text-white"
     >
-      {type === "folder" && <FolderIcon isOpen={isOpen} />}
-      {type === "file" && <FileIcon filename={name} />}
-      {name}
+      <div className="flex-shrink-0">
+        {type === "folder" && <FolderIcon isOpen={isOpen} />}
+        {type === "file" && <FileIcon filename={name} />}
+      </div>
+      <div className="flex-grow">{name}</div>
     </div>
   );
 }


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fixes issue [#2714](https://github.com/OpenDevin/OpenDevin/issues/2714) Adds more width control and scroll functionality to the File Explorer side pane.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

- Adds scroll functionality for overflow content
- Updates width transition for improved UX

**Other references**

N/A

