### PR TITLE
[WIP] Remove global config

### DIFF
--- a/agenthub/browsing_agent/browsing_agent.py
+++ b/agenthub/browsing_agent/browsing_agent.py
@@ -6,6 +6,7 @@ from browsergym.utils.obs import flatten_axtree_to_str
 from agenthub.browsing_agent.response_parser import BrowsingResponseParser
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
+from opendevin.core.config import AgentConfig
 from opendevin.core.logger import opendevin_logger as logger
 from opendevin.events.action import (
     Action,
@@ -97,6 +98,7 @@ class BrowsingAgent(Agent):
     def __init__(
         self,
         llm: LLM,
+        config: AgentConfig,
     ) -> None:
         """
         Initializes a new instance of the BrowsingAgent class.
@@ -104,7 +106,7 @@ class BrowsingAgent(Agent):
         Parameters:
         - llm (LLM): The llm to be used by this agent
         """
-        super().__init__(llm)
+        super().__init__(llm, config)
         # define a configurable action space, with chat functionality, web navigation, and webpage grounding using accessibility tree and HTML.
         # see https://github.com/ServiceNow/BrowserGym/blob/main/core/src/browsergym/core/action/highlevel.py for more details
         action_subsets = ['chat', 'bid']

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -8,6 +8,7 @@ from agenthub.codeact_agent.prompt import (
 )
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
+from opendevin.core.config import AgentConfig
 from opendevin.events.action import (
     Action,
     AgentDelegateAction,
@@ -151,6 +152,7 @@ class CodeActAgent(Agent):
     def __init__(
         self,
         llm: LLM,
+        config: AgentConfig,
     ) -> None:
         """
         Initializes a new instance of the CodeActAgent class.
@@ -158,7 +160,7 @@ class CodeActAgent(Agent):
         Parameters:
         - llm (LLM): The llm to be used by this agent
         """
-        super().__init__(llm)
+        super().__init__(llm, config)
         self.reset()
 
     def reset(self) -> None:

--- a/agenthub/codeact_swe_agent/codeact_swe_agent.py
+++ b/agenthub/codeact_swe_agent/codeact_swe_agent.py
@@ -7,6 +7,7 @@ from agenthub.codeact_swe_agent.prompt import (
 from agenthub.codeact_swe_agent.response_parser import CodeActSWEResponseParser
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
+from opendevin.core.config import AgentConfig
 from opendevin.events.action import (
     Action,
     AgentFinishAction,
@@ -108,6 +109,7 @@ class CodeActSWEAgent(Agent):
     def __init__(
         self,
         llm: LLM,
+        config: AgentConfig,
     ) -> None:
         """
         Initializes a new instance of the CodeActAgent class.
@@ -115,7 +117,7 @@ class CodeActSWEAgent(Agent):
         Parameters:
         - llm (LLM): The llm to be used by this agent
         """
-        super().__init__(llm)
+        super().__init__(llm, config)
         self.reset()
 
     def reset(self) -> None:

--- a/agenthub/delegator_agent/agent.py
+++ b/agenthub/delegator_agent/agent.py
@@ -1,5 +1,6 @@
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
+from opendevin.core.config import AgentConfig
 from opendevin.events.action import Action, AgentDelegateAction, AgentFinishAction
 from opendevin.events.observation import AgentDelegateObservation
 from opendevin.llm.llm import LLM
@@ -13,14 +14,15 @@ class DelegatorAgent(Agent):
 
     current_delegate: str = ''
 
-    def __init__(self, llm: LLM):
+    def __init__(self, llm: LLM, config: AgentConfig):
         """
         Initialize the Delegator Agent with an LLM
 
         Parameters:
-        - llm (LLM): The llm to be used by this agent
+        - llm: The llm to be used by this agent
+        - config: The configuration for this agent
         """
-        super().__init__(llm)
+        super().__init__(llm, config)
 
     def step(self, state: State) -> Action:
         """

--- a/agenthub/dummy_agent/agent.py
+++ b/agenthub/dummy_agent/agent.py
@@ -3,6 +3,7 @@ from typing import TypedDict
 
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
+from opendevin.core.config import AgentConfig
 from opendevin.events.action import (
     Action,
     AddTaskAction,
@@ -49,8 +50,8 @@ class DummyAgent(Agent):
     without making any LLM calls.
     """
 
-    def __init__(self, llm: LLM):
-        super().__init__(llm)
+    def __init__(self, llm: LLM, config: AgentConfig):
+        super().__init__(llm, config)
         self.steps: list[ActionObs] = [
             {
                 'action': AddTaskAction(parent='0', goal='check the current directory'),

--- a/agenthub/micro/agent.py
+++ b/agenthub/micro/agent.py
@@ -2,6 +2,7 @@ from jinja2 import BaseLoader, Environment
 
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
+from opendevin.core.config import AgentConfig
 from opendevin.core.utils import json
 from opendevin.events.action import Action
 from opendevin.events.serialization.action import action_from_dict
@@ -46,8 +47,8 @@ class MicroAgent(Agent):
     prompt = ''
     agent_definition: dict = {}
 
-    def __init__(self, llm: LLM):
-        super().__init__(llm)
+    def __init__(self, llm: LLM, config: AgentConfig):
+        super().__init__(llm, config)
         if 'name' not in self.agent_definition:
             raise ValueError('Agent definition must contain a name')
         self.prompt_template = Environment(loader=BaseLoader).from_string(self.prompt)

--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -3,7 +3,7 @@ from agenthub.monologue_agent.response_parser import MonologueResponseParser
 from agenthub.monologue_agent.utils.prompts import INITIAL_THOUGHTS
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
-from opendevin.core.config import config
+from opendevin.core.config import AgentConfig
 from opendevin.core.exceptions import AgentNoInstructionError
 from opendevin.core.schema import ActionType
 from opendevin.events.action import (
@@ -27,10 +27,8 @@ from opendevin.events.observation import (
 from opendevin.events.serialization.event import event_to_memory
 from opendevin.llm.llm import LLM
 from opendevin.memory.condenser import MemoryCondenser
+from opendevin.memory.memory import LongTermMemory
 from opendevin.runtime.tools import RuntimeTool
-
-if config.agent.memory_enabled:
-    from opendevin.memory.memory import LongTermMemory
 
 MAX_TOKEN_COUNT_PADDING = 512
 MAX_OUTPUT_LENGTH = 5000
@@ -51,14 +49,14 @@ class MonologueAgent(Agent):
     runtime_tools: list[RuntimeTool] = [RuntimeTool.BROWSER]
     response_parser = MonologueResponseParser()
 
-    def __init__(self, llm: LLM):
+    def __init__(self, llm: LLM, config: AgentConfig):
         """
         Initializes the Monologue Agent with an llm.
 
         Parameters:
         - llm (LLM): The llm to be used by this agent
         """
-        super().__init__(llm)
+        super().__init__(llm, config)
 
     def _initialize(self, task: str):
         """
@@ -81,7 +79,7 @@ class MonologueAgent(Agent):
             raise AgentNoInstructionError()
 
         self.initial_thoughts = []
-        if config.agent.memory_enabled:
+        if self.config.memory_enabled:
             self.memory = LongTermMemory()
         else:
             self.memory = None

--- a/agenthub/monologue_agent/utils/prompts.py
+++ b/agenthub/monologue_agent/utils/prompts.py
@@ -1,13 +1,12 @@
-from opendevin.core.config import config
 from opendevin.core.utils import json
-from opendevin.events.observation import (
-    CmdOutputObservation,
-)
 from opendevin.events.action import (
     Action,
 )
-
+from opendevin.events.observation import (
+    CmdOutputObservation,
+)
 from opendevin.events.serialization.action import action_from_dict
+
 ACTION_PROMPT = """
 You're a thoughtful robot. Your main task is this:
 %(task)s
@@ -153,7 +152,10 @@ def get_request_action_prompt(
     task: str,
     thoughts: list[dict],
     recent_events: list[dict],
-    background_commands_obs: list[CmdOutputObservation] | None = None,
+    background_commands_obs: list[CmdOutputObservation] | None,
+    run_as_devin: bool,
+    sandbox_timeout: int,
+    workspace_mount_path_in_sandbox: str,
 ):
     """
     Gets the action prompt formatted with appropriate values.
@@ -196,7 +198,7 @@ def get_request_action_prompt(
             )
         bg_commands_message += '\nYou can end any process by sending a `kill` action with the numerical `command_id` above.'
 
-    user = 'opendevin' if config.run_as_devin else 'root'
+    user = 'opendevin' if run_as_devin else 'root'
 
     monologue = thoughts + recent_events
 
@@ -206,8 +208,8 @@ def get_request_action_prompt(
         'background_commands': bg_commands_message,
         'hint': hint,
         'user': user,
-        'timeout': config.sandbox_timeout,
-        'WORKSPACE_MOUNT_PATH_IN_SANDBOX': config.workspace_mount_path_in_sandbox,
+        'timeout': sandbox_timeout,
+        'WORKSPACE_MOUNT_PATH_IN_SANDBOX': workspace_mount_path_in_sandbox,
     }
 
 

--- a/agenthub/planner_agent/agent.py
+++ b/agenthub/planner_agent/agent.py
@@ -1,6 +1,7 @@
 from agenthub.monologue_agent.response_parser import MonologueResponseParser
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
+from opendevin.core.config import AgentConfig
 from opendevin.events.action import Action, AgentFinishAction
 from opendevin.llm.llm import LLM
 from opendevin.runtime.tools import RuntimeTool
@@ -17,14 +18,14 @@ class PlannerAgent(Agent):
     runtime_tools: list[RuntimeTool] = [RuntimeTool.BROWSER]
     response_parser = MonologueResponseParser()
 
-    def __init__(self, llm: LLM):
+    def __init__(self, llm: LLM, config: AgentConfig):
         """
         Initialize the Planner Agent with an LLM
 
         Parameters:
         - llm (LLM): The llm to be used by this agent
         """
-        super().__init__(llm)
+        super().__init__(llm, config)
 
     def step(self, state: State) -> Action:
         """

--- a/evaluation/agent_bench/run_infer.py
+++ b/evaluation/agent_bench/run_infer.py
@@ -21,7 +21,7 @@ from evaluation.agent_bench.helper import (
 )
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
-from opendevin.core.config import config, get_llm_config_arg, parse_arguments
+from opendevin.core.config import get_llm_config_arg, parse_arguments
 from opendevin.core.logger import get_console_handler
 from opendevin.core.logger import opendevin_logger as logger
 from opendevin.core.main import run_agent_controller
@@ -84,6 +84,8 @@ def process_instance(
     instance,
     metadata,
     eval_output_dir,
+    workspace_base,
+    workspace_mount_path_in_sandbox,
     reset_logger: bool = True,
 ):
     # =============================================

--- a/opendevin/controller/agent.py
+++ b/opendevin/controller/agent.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Type
 if TYPE_CHECKING:
     from opendevin.controller.state.state import State
     from opendevin.events.action import Action
+from opendevin.core.config import AgentConfig
 from opendevin.core.exceptions import (
     AgentAlreadyRegisteredError,
     AgentNotRegisteredError,
@@ -29,8 +30,10 @@ class Agent(ABC):
     def __init__(
         self,
         llm: LLM,
+        config: AgentConfig,
     ):
         self.llm = llm
+        self.config = config
         self._complete = False
 
     @property


### PR DESCRIPTION
**This is WIP! No need to review yet.**

**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This PR is going to try to remove the global variable for "config" and replace it with a function that can load the global variable and more explicit passing of config between different objects.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

1. I replaced the singleton config objects with pydantic classes.
2. Agents are now passed an `LLM` *and* `AgentConfig`, instead of getting their configuration implicitly from the global variable.

**Other references**

Fixes #2758 
I am going to try to fix #2759 first to make this easier to implement.