### PR TITLE
Add 'latest' tag to Docker builds for stable releases only

### DIFF
--- a/containers/build.sh
+++ b/containers/build.sh
@@ -16,6 +16,7 @@ if [[ -n $GITHUB_REF_NAME ]]; then
     major_version=$(echo "$GITHUB_REF_NAME" | cut -d. -f1)
     minor_version=$(echo "$GITHUB_REF_NAME" | cut -d. -f1,2)
     tags+=("$major_version" "$minor_version")
+    tags+=("latest")
   fi
   sanitized=$(echo "$GITHUB_REF_NAME" | sed 's/[^a-zA-Z0-9.-]\+/-/g')
   OPEN_DEVIN_BUILD_VERSION=$sanitized


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

this PR addresses the issue raised in #2730 where the "latest" tag for Docker images was not being updated with the most recent stable release. This caused users pulling the image without specifying a version to get an outdated image.


**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

This PR modifies the `build.sh` script to include the 'latest' tag for semantic version releases. 
- Ensure 'latest' always points to the most recent stable version


