### PR TITLE
trim the sandbox image and install plugin dependencies in agnostic image

### DIFF
--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -1,28 +1,22 @@
 FROM ubuntu:22.04
 
 # install basic packages
+RUN sed -i 's/ports.ubuntu.com/mirrors.bfsu.edu.cn/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
     git \
     vim \
-    nano \
     unzip \
     zip \
-    python3 \
-    python3-pip \
-    python3-venv \
-    python3-dev \
     build-essential \
     openssh-server \
     sudo \
-    bash \
     gcc \
     jq \
     g++ \
     make \
     iproute2 \
-    libgl1-mesa-glx \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p -m0755 /var/run/sshd
@@ -41,4 +35,4 @@ RUN echo "" > /opendevin/bash.bashrc
 # - agentskills dependencies
 RUN /opendevin/miniforge3/bin/pip install --upgrade pip
 RUN /opendevin/miniforge3/bin/pip install jupyterlab notebook jupyter_kernel_gateway flake8
-RUN /opendevin/miniforge3/bin/pip install python-docx PyPDF2 python-pptx pylatexenc openai opencv-python
+RUN /opendevin/miniforge3/bin/pip install python-docx PyPDF2 python-pptx pylatexenc openai

--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     git \
     vim \
+    nano \
     unzip \
     zip \
     python3 \

--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && apt-get install -y \
     vim \
     unzip \
     zip \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-dev \
     build-essential \
     openssh-server \
     sudo \

--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:22.04
 
 # install basic packages
-RUN sed -i 's/ports.ubuntu.com/mirrors.bfsu.edu.cn/g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y \
     curl \
     wget \

--- a/opendevin/runtime/docker/image_agnostic_util.py
+++ b/opendevin/runtime/docker/image_agnostic_util.py
@@ -23,7 +23,7 @@ def generate_dockerfile_content(base_image: str) -> str:
         '        bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opendevin/miniforge3 && \\\n'
         '        chmod -R g+w /opendevin/miniforge3 && \\\n'
         '        bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge"; \\\n'
-        '    fi'
+        '    fi\n'
         'RUN /opendevin/miniforge3/bin/pip install --upgrade pip\n'
         'RUN /opendevin/miniforge3/bin/pip install jupyterlab notebook jupyter_kernel_gateway flake8\n'
         'RUN /opendevin/miniforge3/bin/pip install python-docx PyPDF2 python-pptx pylatexenc openai\n'

--- a/opendevin/runtime/docker/image_agnostic_util.py
+++ b/opendevin/runtime/docker/image_agnostic_util.py
@@ -24,6 +24,9 @@ def generate_dockerfile_content(base_image: str) -> str:
         '        chmod -R g+w /opendevin/miniforge3 && \\\n'
         '        bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge"; \\\n'
         '    fi'
+        'RUN /opendevin/miniforge3/bin/pip install --upgrade pip\n'
+        'RUN /opendevin/miniforge3/bin/pip install jupyterlab notebook jupyter_kernel_gateway flake8\n'
+        'RUN /opendevin/miniforge3/bin/pip install python-docx PyPDF2 python-pptx pylatexenc openai\n'
     ).strip()
     return dockerfile_content
 

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -741,7 +741,7 @@ if __name__ == '__main__':
     )
 
     # Initialize required plugins
-    plugins = []
+    plugins = [AgentSkillsRequirement(), JupyterRequirement()]
     ssh_box.init_plugins(plugins)
     logger.info(
         '--- AgentSkills COMMAND DOCUMENTATION ---\n'

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -741,7 +741,7 @@ if __name__ == '__main__':
     )
 
     # Initialize required plugins
-    plugins = [AgentSkillsRequirement(), JupyterRequirement()]
+    plugins = []
     ssh_box.init_plugins(plugins)
     logger.info(
         '--- AgentSkills COMMAND DOCUMENTATION ---\n'


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
> https://opendevin.slack.com/archives/C06QKSD9UBA/p1719019334249829

As mentioned in the Slack discussion, our current sandbox image is a bit large and has some unnecessary dependencies. I want to remove these unnecessary dependencies to make the sandbox image smaller.

Also, we will install plugin dependencies in the dockerfile of the agnostic image (just like we do in the current sandbox image). This will significantly improve the startup speed for users using custom sandbox container image.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

remove these:
* nano: maybe we can use vim to instead
* bash: system built-in
* libgl1-mesa-glx: opencv-python need it, opencv is only used for `parse_video` in agentskill. It's usually not needed, but it takes up many space. When it's really needed, we can have the LLM install it temporarily.


**Other references**
