### PR TITLE
[Eval] initialize llm inside process_instance to circumvent "AttributeError:…

### DIFF
--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -202,7 +202,7 @@ def process_instance(
     reset_logger: bool = True,
 ):
     # Create the agent
-    agent = Agent.get_cls(agent_class)(llm=LLM(llm_config))
+    agent = Agent.get_cls(agent_class)(llm=LLM(llm_config=llm_config))
 
     workspace_mount_path = os.path.join(config.workspace_mount_path, '_eval_workspace')
     # create process-specific workspace dir

--- a/evaluation/swe_bench/run_infer.py
+++ b/evaluation/swe_bench/run_infer.py
@@ -193,13 +193,17 @@ def get_test_result(instance, sandbox, workspace_dir_name):
 
 
 def process_instance(
-    agent: Agent,
+    agent_class: str,
+    llm_config: dict,
     instance: Any,
     metadata: dict,
     skip_workspace_mount: bool,
     eval_output_dir: str,
     reset_logger: bool = True,
 ):
+    # Create the agent
+    agent = Agent.get_cls(agent_class)(llm=LLM(llm_config))
+
     workspace_mount_path = os.path.join(config.workspace_mount_path, '_eval_workspace')
     # create process-specific workspace dir
     # if `not skip_workspace_mount` - we will create a workspace directory for EACH process
@@ -496,9 +500,6 @@ if __name__ == '__main__':
     skip_workspace_mount = agent_class == 'CodeActAgent'
     logger.info(f'Skipping workspace mount: {skip_workspace_mount}')
 
-    # Create the agent
-    agent = Agent.get_cls(agent_class)(llm=LLM(config.llm))
-
     try:
         with ProcessPoolExecutor(num_workers) as executor:
             futures = []
@@ -506,7 +507,8 @@ if __name__ == '__main__':
             for row_idx, instance in swe_bench_tests.iterrows():
                 future = executor.submit(
                     process_instance,
-                    agent,
+                    agent_class,
+                    config.llm,
                     instance,
                     metadata,
                     skip_workspace_mount,


### PR DESCRIPTION
… Can't pickle local object"

**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Got the following error when running eval:
```
ERROR:root:<class 'AttributeError'>: Can't pickle local object 'LLM.__init__.<locals>.wrapper'
```

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Initialize `agent` inside each process for multi-processing. Ideally, will need to propagate this changes to other evaluation, but not sure if we should wait https://github.com/OpenDevin/OpenDevin/pull/2775 to go it first before making the change?

**Other references**
