### PR TITLE
[LLM] Retry for internal server error

### DIFF
--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -8,6 +8,7 @@ from litellm import completion as litellm_completion
 from litellm import completion_cost as litellm_completion_cost
 from litellm.exceptions import (
     APIConnectionError,
+    InternalServerError,
     RateLimitError,
     ServiceUnavailableError,
 )
@@ -184,7 +185,12 @@ class LLM:
             stop=stop_after_attempt(num_retries),
             wait=wait_random_exponential(min=retry_min_wait, max=retry_max_wait),
             retry=retry_if_exception_type(
-                (RateLimitError, APIConnectionError, ServiceUnavailableError)
+                (
+                    RateLimitError,
+                    APIConnectionError,
+                    ServiceUnavailableError,
+                    InternalServerError,
+                )
             ),
             after=attempt_on_error,
         )


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

When evaluating on anthropic claude 3.5, we sometimes get error like this that break the `run_infer` loop;

```
There was an unexpected error while running the agent: litellm.InternalServerError: VertexAIException InternalServerError - Reauthentication is needed. Please run `gcloud auth application-default login` to reauthenticate.
```

and/or

```
litellm.InternalServerError: VertexAIException InternalServerError - Error code: 500 - {'type': 'error', 'error': {'type': 'api_error', 'message': 'Internal server error'}}
```

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Add retries when hitting litellm.InternalServerError.

**Other references**
