### PR TITLE
CI: Delete colima default profile

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -56,6 +56,7 @@ jobs:
           brew install --HEAD colima
           brew services start colima
           brew install docker
+          colima delete
           colima start  --network-address --arch x86_64 --cpu=1 --memory=1
 
           # For testcontainers to find the Colima socket


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
Sometimes CI fails with `msg="did not receive an event with the \"running\" status"`

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Applied the suggestion from https://github.com/abiosoft/colima/issues/215#issuecomment-1065864891
Seems there is a bug in the default profile.



