### PR TITLE
Remove plugin_initialized sandbox var

### DIFF
--- a/opendevin/runtime/plugins/mixin.py
+++ b/opendevin/runtime/plugins/mixin.py
@@ -36,9 +36,6 @@ class PluginMixin:
     def init_plugins(self: SandboxProtocol, requirements: list[PluginRequirement]):
         """Load a plugin into the sandbox."""
 
-        if hasattr(self, 'plugin_initialized') and self.plugin_initialized:
-            return
-
         if self.initialize_plugins:
             logger.info('Initializing plugins in the sandbox')
 
@@ -95,5 +92,3 @@ class PluginMixin:
 
         if len(requirements) > 0:
             _source_bashrc(self)
-
-        self.plugin_initialized = True


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
Remove redundant var. The code will skip reinitialization when called `init_plugins` again. But it's only called once throughout the program.

![image](https://github.com/OpenDevin/OpenDevin/assets/7231077/31b593c9-eeb6-4c65-a8e5-428a3c925844)
