### PR TITLE
fix git diff TIMEOUT problem in swe_bench evaluation

### DIFF
--- a/evaluation/swe_bench/swe_env_box.py
+++ b/evaluation/swe_bench/swe_env_box.py
@@ -138,7 +138,7 @@ class SWEBenchSSHBox(DockerSSHBox):
             return ''
 
         exit_code, output = self.execute('git config --global core.pager ""')
-        
+
         # add everything to the index
         exit_code, output = self.execute('git add -A')
         if exit_code != 0:

--- a/evaluation/swe_bench/swe_env_box.py
+++ b/evaluation/swe_bench/swe_env_box.py
@@ -137,6 +137,8 @@ class SWEBenchSSHBox(DockerSSHBox):
             logger.error('Failed to cd to the repo')
             return ''
 
+        exit_code, output = self.execute('git config --global core.pager ""')
+        
         # add everything to the index
         exit_code, output = self.execute('git add -A')
         if exit_code != 0:

--- a/evaluation/swe_bench/swe_env_box.py
+++ b/evaluation/swe_bench/swe_env_box.py
@@ -137,7 +137,10 @@ class SWEBenchSSHBox(DockerSSHBox):
             logger.error('Failed to cd to the repo')
             return ''
 
-        exit_code, output = self.execute('git config --global core.pager ""')
+        exit_code, _output = self.execute('git config --global core.pager ""')
+        if exit_code != 0:
+            logger.error('Failed to change git config')
+            return ''
 
         # add everything to the index
         exit_code, output = self.execute('git add -A')


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This PR is to fix issue # https://github.com/OpenDevin/OpenDevin/issues/2755

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

During the evaluation on the swe-bench dataset, if you directly use ssh to connect the docker, Git will give paginated output if the diff is large enough. We should close the `pager` setting to enable the `git diff` command, otherwise it will stuck at the `git diff` command.

