### PR TITLE
Display real-time build logs for the agnostic image

### DIFF
--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -30,11 +30,12 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # ==== OpenDevin Runtime Client ====
 RUN mkdir -p /opendevin && mkdir -p /opendevin/logs && chmod 777 /opendevin/logs
-RUN wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opendevin/miniforge3
+RUN wget --progress=bar:force -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+RUN bash Miniforge3.sh -b -p /opendevin/miniforge3
 RUN chmod -R g+w /opendevin/miniforge3
 RUN bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge"
 RUN echo "" > /opendevin/bash.bashrc
+RUN rm -f Miniforge3.sh
 
 # - agentskills dependencies
 RUN /opendevin/miniforge3/bin/pip install --upgrade pip

--- a/opendevin/runtime/docker/image_agnostic_util.py
+++ b/opendevin/runtime/docker/image_agnostic_util.py
@@ -1,4 +1,7 @@
+import curses
+import os
 import tempfile
+from collections import deque
 
 import docker
 
@@ -19,8 +22,8 @@ def generate_dockerfile_content(base_image: str) -> str:
         'RUN mkdir -p /opendevin && mkdir -p /opendevin/logs && chmod 777 /opendevin/logs\n'
         'RUN echo "" > /opendevin/bash.bashrc\n'
         'RUN if [ ! -d /opendevin/miniforge3 ]; then \\\n'
-        '        wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \\\n'
-        '        bash Miniforge3-$(uname)-$(uname -m).sh -b -p /opendevin/miniforge3 && \\\n'
+        '        wget --progress=bar:force -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \\\n'
+        '        bash Miniforge3.sh -b -p /opendevin/miniforge3 && \\\n'
         '        chmod -R g+w /opendevin/miniforge3 && \\\n'
         '        bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge"; \\\n'
         '    fi\n'
@@ -48,15 +51,18 @@ def _build_sandbox_image(
             with open(f'{temp_dir}/Dockerfile', 'w') as file:
                 file.write(dockerfile_content)
 
-            image, logs = docker_client.images.build(
-                path=temp_dir, tag=target_image_name
-            )
+            api_client = docker_client.api
+            build_logs = api_client.build(path=temp_dir, tag=target_image_name, rm=True, decode=True)
 
-        for log in logs:
-            if 'stream' in log:
-                print(log['stream'].strip())
+            for log in build_logs:
+                if 'stream' in log:
+                    print(log['stream'].strip())
+                elif 'error' in log:
+                    logger.error(log['error'].strip())
+                else:
+                    logger.info(str(log))
 
-        logger.info(f'Image {image} built successfully')
+        logger.info(f'Image {target_image_name} built successfully')
     except docker.errors.BuildError as e:
         logger.error(f'Sandbox image build failed: {e}')
         raise e

--- a/opendevin/runtime/docker/image_agnostic_util.py
+++ b/opendevin/runtime/docker/image_agnostic_util.py
@@ -1,7 +1,4 @@
-import curses
-import os
 import tempfile
-from collections import deque
 
 import docker
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
Resolve 3 problems.
1. Now during the agnostic image build process, real-time output isn't shown, and the whole build can take about a minute. Users might feel anxious while waiting.
2. Sometimes using wget default dot progress seems to cause log display issues (on my computer, one line gets split into multiple lines) . In contrast, the bar style doesn't have this issue and doesn't produce as many logs as the dot style.
<img width="524" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33391300/19a7fcfb-500f-4156-af1b-70805f56848e">
<img width="527" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33391300/a1c1e543-a98a-4349-bc57-f4a49a20cb3a">
3. After installing Miniforge3, the installation script remains in the image, taking up disk space. It should be deleted.


**Give a brief summary of what the PR does, explaining any non-trivial design decisions**
1. Display real-time agnostic docker build logs.
2. Use wget's `progress:bar` style.
3. Remove miniforge3 installation script

<img width="1352" alt="image" src="https://github.com/OpenDevin/OpenDevin/assets/33391300/d056a700-b2f9-4bd3-b943-87e6332439db">

**Other references**
