### PR TITLE
Make monologue length configurable

### DIFF
--- a/agenthub/monologue_agent/agent.py
+++ b/agenthub/monologue_agent/agent.py
@@ -33,7 +33,7 @@ if config.agent.memory_enabled:
     from opendevin.memory.memory import LongTermMemory
 
 MAX_TOKEN_COUNT_PADDING = 512
-MAX_OUTPUT_LENGTH = 5000
+MAX_OUTPUT_LENGTH = config.agent.max_monologue_length if hasattr(config.agent, 'max_monologue_length') else 5000
 
 
 class MonologueAgent(Agent):


### PR DESCRIPTION
Configurable Monologue Length
This PR introduces the ability to configure the maximum monologue length for the MonologueAgent. The hard-coded MAX_OUTPUT_LENGTH has been replaced with a configurable option that uses config.agent.max_monologue_length if available, otherwise defaulting to 5000.

Changes Made
Updated agent.py to use the new configuration option for maximum monologue length.
Set local Ollama as the AI agent.
Resolved Docker build and setup issues, including hostname resolution for SSH connection, port conflicts, and Docker socket mounting.
Adjusted Dockerfile paths and environment variables for container startup.
Link to [Devin Run](https://preview.devin.ai/devin/15a83521a3764ddf90c7227defe3d1e7)
Devin Run

Requested by
User: Serg

Please review the changes and provide feedback.

[This Devin run](https://preview.devin.ai/devin/15a83521a3764ddf90c7227defe3d1e7) was requested by Serg.