### PR TITLE
add od runtime clinet dependencies in sandbox image

### DIFF
--- a/containers/sandbox/Dockerfile
+++ b/containers/sandbox/Dockerfile
@@ -41,3 +41,4 @@ RUN rm -f Miniforge3.sh
 RUN /opendevin/miniforge3/bin/pip install --upgrade pip
 RUN /opendevin/miniforge3/bin/pip install jupyterlab notebook jupyter_kernel_gateway flake8
 RUN /opendevin/miniforge3/bin/pip install python-docx PyPDF2 python-pptx pylatexenc openai
+RUN /opendevin/miniforge3/bin/pip install python-dotenv toml termcolor pydantic python-docx pyyaml docker pexpect tenacity e2b browsergym minio


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
In order to run runtime client introduced here #2603  in snadbox docker image, we need to add more new dependency. Maybe we will introduce poetry to management this environment, but let's use pip now first.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**
