### PR TITLE
Refractor: move image agnostic util to shared runtime util

### DIFF
--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -16,10 +16,10 @@ from opendevin.core.config import config
 from opendevin.core.const.guide_url import TROUBLESHOOTING_URL
 from opendevin.core.logger import opendevin_logger as logger
 from opendevin.core.schema import CancellableStream
-from opendevin.runtime.docker.image_agnostic_util import get_od_sandbox_image
 from opendevin.runtime.plugins import AgentSkillsRequirement, JupyterRequirement
 from opendevin.runtime.sandbox import Sandbox
 from opendevin.runtime.utils import find_available_tcp_port
+from opendevin.runtime.utils.image_agnostic import get_od_sandbox_image
 
 
 class SSHExecCancellableStream(CancellableStream):

--- a/opendevin/runtime/utils/image_agnostic.py
+++ b/opendevin/runtime/utils/image_agnostic.py
@@ -49,7 +49,9 @@ def _build_sandbox_image(
                 file.write(dockerfile_content)
 
             api_client = docker_client.api
-            build_logs = api_client.build(path=temp_dir, tag=target_image_name, rm=True, decode=True)
+            build_logs = api_client.build(
+                path=temp_dir, tag=target_image_name, rm=True, decode=True
+            )
 
             for log in build_logs:
                 if 'stream' in log:

--- a/tests/unit/test_image_agnostic_util.py
+++ b/tests/unit/test_image_agnostic_util.py
@@ -31,8 +31,8 @@ def test_get_new_image_name():
     assert new_image_name == 'od_sandbox:ubuntu__latest'
 
 
-@patch('opendevin.runtime.docker.image_agnostic_util._build_sandbox_image')
-@patch('opendevin.runtime.docker.image_agnostic_util.docker.DockerClient')
+@patch('opendevin.runtime.utils.image_agnostic._build_sandbox_image')
+@patch('opendevin.runtime.utils.image_agnostic.docker.DockerClient')
 def test_get_od_sandbox_image(mock_docker_client, mock_build_sandbox_image):
     base_image = 'debian:11'
     mock_docker_client.images.list.return_value = [

--- a/tests/unit/test_image_agnostic_util.py
+++ b/tests/unit/test_image_agnostic_util.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from opendevin.runtime.docker.image_agnostic_util import (
+from opendevin.runtime.utils.image_agnostic import (
     _get_new_image_name,
     generate_dockerfile_content,
     get_od_sandbox_image,


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Make image agnostic util a shared utility that can be used by other runtime implementation (https://github.com/OpenDevin/OpenDevin/pull/2603)

**Other references**
