### PR TITLE
fix pexpect output code error in docker image

### DIFF
--- a/opendevin/runtime/client/client.py
+++ b/opendevin/runtime/client/client.py
@@ -4,6 +4,7 @@ import websockets
 import pexpect
 import json
 import shutil
+import re
 from typing import Any
 from websockets.exceptions import ConnectionClosed
 from opendevin.events.serialization import event_to_dict, event_from_dict
@@ -75,13 +76,23 @@ class RuntimeClient():
             )
         except UnicodeDecodeError:
             return ErrorObservation('Command output could not be decoded as utf-8')
-           
+
+    def clean_up(self,input_text):
+        # Remove escape sequences
+        cleaned_text = re.sub(r'\x1b\[[0-9;?]*[a-zA-Z]', '', input_text)
+        # Remove carriage returns and other control characters
+        cleaned_text = re.sub(r'[\r\n\t]', '', cleaned_text)
+        return cleaned_text
+
     def execute(self, command):
         print(f"Received command: {command}")
         self.shell.sendline(command)
         self.shell.expect(r'[$#] ')
         output = self.shell.before.strip().split('\r\n', 1)[1].strip()
-        exit_code = output[-1].strip()
+        # Get the exit code
+        self.shell.sendline('echo $?')
+        self.shell.expect(r'[$#] ')
+        exit_code = self.clean_up(self.shell.before.strip().split('\r\n')[1].strip())
         return output, exit_code
 
     def run_ipython(self, action: IPythonRunCellAction) -> Observation:
@@ -192,6 +203,9 @@ def test_run_commond():
     command = CmdRunAction(command="ls -l")
     obs = client.run_action(command)
     print(obs)
+    command = CmdRunAction(command="pwd")
+    obs = client.run_action(command)
+    print(obs)
 
 
 def test_shell(message):
@@ -205,8 +219,8 @@ def test_shell(message):
 
 if __name__ == "__main__":
     # print(test_shell("ls -l"))
-    client = RuntimeClient()
-    # test_run_commond()
+    # client = RuntimeClient()
+    test_run_commond()
     # client.init_sandbox_plugins([AgentSkillsRequirement,JupyterRequirement])
 
     


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
As title, do some specific fix for bash in our sandbox image when running pexpect. The output of pexpect in our env may include various escape sequences and control characters that are used by the terminal to control formatting, cursor movement, and other terminal behaviors. Do `re` replacement to clean it.

Here is a example output of test code when execute `ls -l` and `pwd`
```
Received command: ls -l
**CmdOutputObservation (source=None, exit code=0)**
total 24
-rw-r--r-- 1 root root  8777 Jul  9 00:32 client.py
drwxr-xr-x 6 root root   192 Jul  9 00:00 logs
drwxr-xr-x 5 root root   160 Jul  8 18:30 mock_test
-rw-r--r-- 1 root root 10205 Jul  8 18:30 runtime.py
drwxr-xr-x 2 root root    64 Jul  8 14:42 workspace
root@4e38acaed5b1:/Users/yufansong/code/OpenDevin/opt/workspace_base/opendevin/runtime/client
Received command: pwd
**CmdOutputObservation (source=None, exit code=0)**
/Users/yufansong/code/OpenDevin/opt/workspace_base/opendevin/runtime/client
root@4e38acaed5b1:/Users/yufansong/code/OpenDevin/opt/workspace_base/opendevin/runtime/client
# exit
```


**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**
