### PR TITLE
fix client pexpect remove permission todo

### DIFF
--- a/opendevin/runtime/client/client.py
+++ b/opendevin/runtime/client/client.py
@@ -41,7 +41,7 @@ class RuntimeClient():
         loop.run_forever()
     
     def init_shell(self) -> None:
-        # TODO: we need to figure a way to support different users. Maybe the runtime cli should be run as root
+        # run as root
         self.shell = pexpect.spawn('/bin/bash', encoding='utf-8')
         self.shell.expect(r'[$#] ')
 
@@ -202,11 +202,13 @@ def test_shell(message):
     shell.expect(r'[$#] ')
     output = shell.before.strip().split('\r\n', 1)[1].strip()
     shell.close()
+    print(output)
 
 if __name__ == "__main__":
     # print(test_shell("ls -l"))
     client = RuntimeClient()
     # test_run_commond()
     # client.init_sandbox_plugins([AgentSkillsRequirement,JupyterRequirement])
+    # print(test_shell("whoami"))
 
     


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
Question proposed [here](https://github.com/OpenDevin/OpenDevin/pull/2603#discussion_r1668963066), after test, the default pexpect running in docker image is already root permission.
Here is the execution result:
```
# python client.py
Received command: whoami
root
root@4e38acaed5b1:/Users/yufansong/code/OpenDevin/opt/workspace_base/opendevin/runtime/client

```

In `exec_box` which we already removed, we create `root` and user `devin`, currently we directly use `root` in `od-runtime-client`, not sure whether we still need a non-root user permission in the future.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**
