### PR TITLE
(test|fix): Task class

### DIFF
--- a/opendevin/controller/state/task.py
+++ b/opendevin/controller/state/task.py
@@ -21,12 +21,12 @@ STATES = [
 class Task:
     id: str
     goal: str
-    parent: 'Task | None'
+    parent: 'Task' | None
     subtasks: list['Task']
 
     def __init__(
         self,
-        parent: 'Task',
+        parent: 'Task' | None,
         goal: str,
         state: str = OPEN_STATE,
         subtasks=None,  # noqa: B006
@@ -41,13 +41,18 @@ class Task:
         """
         if subtasks is None:
             subtasks = []
-        if parent.id:
-            self.id = parent.id + '.' + str(len(parent.subtasks))
+        if parent is None:
+            self.id = '0'
         else:
-            self.id = str(len(parent.subtasks))
+            if parent.id:
+                self.id = parent.id + '.' + str(len(parent.subtasks))
+            else:
+                self.id = str(len(parent.subtasks))
         self.parent = parent
         self.goal = goal
-        logger.debug(f'Creating task {self.id} with parent={parent.id}, goal={goal}')
+        logger.debug(
+            f'Creating task {self.id} with parent={parent.id if parent else None}, goal={goal}'
+        )
         self.subtasks = []
         for subtask in subtasks or []:
             if isinstance(subtask, Task):

--- a/tests/opendevin/controller/state/task_test.py
+++ b/tests/opendevin/controller/state/task_test.py
@@ -1,0 +1,153 @@
+import pytest
+
+from opendevin.controller.state.task import (
+    ABANDONED_STATE,
+    COMPLETED_STATE,
+    IN_PROGRESS_STATE,
+    OPEN_STATE,
+    VERIFIED_STATE,
+    Task,
+)
+from opendevin.core.exceptions import TaskInvalidStateError
+
+
+@pytest.fixture
+def task():
+    return Task(parent=None, goal='Task Goal')
+
+
+@pytest.fixture
+def task_with_subtasks(task: Task):
+    subtask1 = Task(parent=task, goal='Subtask Goal 1')
+    subtask2 = Task(parent=task, goal='Subtask Goal 2')
+
+    task.subtasks.append(subtask1)
+    task.subtasks.append(subtask2)
+    return task
+
+
+class TestTaskInitialisation:
+    def test_task_initialisation(self, task: Task):
+        assert task.id == '0', 'The initial parent task id should be 0'
+        assert task.goal == 'Task Goal'
+        assert task.state == OPEN_STATE, 'The initial parent task state should be open'
+        assert task.subtasks == [], 'The initial parent task should have no subtasks'
+        assert task.parent is None
+
+    def test_task_to_dict(self, task: Task):
+        expected_dict = {
+            'id': '0',
+            'goal': 'Task Goal',
+            'state': 'open',
+            'subtasks': [],
+        }
+
+        assert task.to_dict() == expected_dict
+
+    def test_get_current_task(self, task: Task):
+        assert (
+            task.get_current_task() is None
+        ), 'The current task should be none if it is not in progress'
+
+        task.set_state(IN_PROGRESS_STATE)
+        assert (
+            task.get_current_task() == task
+        ), 'The current task should be itself if it is in progress'
+
+
+class TestTaskState:
+    def test_initial_state(self, task: Task):
+        assert task.state == OPEN_STATE, 'The initial state should be open'
+
+    def test_set_state(self, task: Task):
+        task.set_state(VERIFIED_STATE)
+        assert task.state == VERIFIED_STATE, 'The state should be set to verified'
+
+        task.set_state(COMPLETED_STATE)
+        assert task.state == COMPLETED_STATE, 'The state should be set to completed'
+
+    def test_set_state_error(self, task: Task):
+        with pytest.raises(TaskInvalidStateError):
+            task.set_state('invalid_state')
+
+
+class TestTaskToString:
+    def test_initial_task_to_string(self, task: Task):
+        expected_string = '🔵 0 Task Goal\n'
+        assert (
+            task.to_string() == expected_string
+        ), 'It should initialise with an open state'
+
+    def test_open_task_to_string(self, task: Task):
+        expected_string = '🔵 0 Task Goal\n'
+        assert (
+            task.to_string() == expected_string
+        ), 'It should initialise with an open state'
+
+    def test_verified_task_to_string(self, task: Task):
+        task.set_state(VERIFIED_STATE)
+        expected_string = '✅ 0 Task Goal\n'
+        assert (
+            task.to_string() == expected_string
+        ), 'It should change to a verified state'
+
+    def test_completed_task_to_string(self, task: Task):
+        task.set_state(COMPLETED_STATE)
+        expected_string = '🟢 0 Task Goal\n'
+        assert (
+            task.to_string() == expected_string
+        ), 'It should change to a completed state'
+
+    def test_abandoned_task_to_string(self, task: Task):
+        task.set_state(ABANDONED_STATE)
+        expected_string = '❌ 0 Task Goal\n'
+        assert (
+            task.to_string() == expected_string
+        ), 'It should change to an abandoned state'
+
+    def test_in_progress_task_to_string(self, task: Task):
+        task.set_state(IN_PROGRESS_STATE)
+        expected_string = '💪 0 Task Goal\n'
+        assert (
+            task.to_string() == expected_string
+        ), 'It should change to an in progress state'
+
+
+class TestTaskSubtask:
+    @pytest.mark.xfail(reason='parent task does not update')
+    def test_task_initialises_with_subtasks(self, task: Task):
+        task = Task(parent=task, goal='Subtask Goal')
+        assert task.parent == task, 'The parent task should be set'
+        assert task.subtasks == [task], 'The subtask should be added to the parent task'
+
+    def test_task_initialises_with_subtasks_alt(self, task_with_subtasks: Task):
+        assert (
+            len(task_with_subtasks.subtasks) == 2
+        ), 'The parent task should have two subtasks'
+        assert (
+            task_with_subtasks.subtasks[0].parent == task_with_subtasks
+        ), 'The parent task should be set'
+
+    @pytest.mark.xfail(reason='subtasks have incorrect ids')
+    def test_to_dict(self, task_with_subtasks: Task):
+        expected_dict = {
+            'id': '0',
+            'goal': 'Task Goal',
+            'state': 'open',
+            'subtasks': [
+                {
+                    'id': '0.0',
+                    'goal': 'Subtask Goal 1',
+                    'state': 'open',
+                    'subtasks': [],
+                },
+                {
+                    'id': '0.1',
+                    'goal': 'Subtask Goal 2',
+                    'state': 'open',
+                    'subtasks': [],
+                },
+            ],
+        }
+
+        assert task_with_subtasks.to_dict() == expected_dict


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
This PR introduces unit tests for the `Task` class and proposes a directory structure for the test folder that mimics the actual source directory. It also adds some minor adjustments to the class itself.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**
Implement a variety of unit tests for the `Task` class. The primary reason is for me to get familiar with the Python testing framework, and the other is to allow for modifying/refactoring the `Task` class while ensuring it is still able to perform its functions.

As for the minor adjustments:
- The `self.parent` field was set to be of type `Task | None` but the constructor expects `parent` to be of type `Task`. Seeing its usage within the class, I adjusted the constructor parameter to accept it as `Task | None` as well.
- Since `self.parent` (and `parent`) could be of type `None` as the case of a root task, I adjusted the `if..else` statements to take into account the possibility.

There are additional areas I believe could be improved but I are also slightly confusing if they should, so ask for some feedback for these changes. Namely, the actual parent-child relationship of the task. One issue is since the constructor can accept a parent `Task`, it introduces a disconnect in data between them. For example,

```py
parent_task = Task(parent=None, goal="Parent Task Goal") # Root task
child_task = Task(parent=parent_task, goal="Child Task Goal")

child_task.parent == parent_task # True
parent_task.subtasks == [child_task] # False, actually an empty list
```

Is this intentional?


Please let me know if the changes to the `Task` class are valid

**Other references**
