### PR TITLE
fix: Runtime import

### DIFF
--- a/opendevin/runtime/__init__.py
+++ b/opendevin/runtime/__init__.py
@@ -1,15 +1,10 @@
-from typing import TYPE_CHECKING, Type
-
 from .docker.local_box import LocalBox
 from .docker.ssh_box import DockerSSHBox
 from .e2b.sandbox import E2BBox
 from .sandbox import Sandbox
 
-if TYPE_CHECKING:
-    from .runtime import Runtime
 
-
-def get_runtime_cls(name: str) -> Type['Runtime']:
+def get_runtime_cls(name: str):
     # Local imports to avoid circular imports
     if name == 'server':
         from .server.runtime import ServerRuntime

--- a/opendevin/server/session/agent.py
+++ b/opendevin/server/session/agent.py
@@ -9,7 +9,8 @@ from opendevin.core.logger import opendevin_logger as logger
 from opendevin.core.schema import ConfigType
 from opendevin.events.stream import EventStream
 from opendevin.llm.llm import LLM
-from opendevin.runtime import DockerSSHBox, Runtime, get_runtime_cls
+from opendevin.runtime import DockerSSHBox, get_runtime_cls
+from opendevin.runtime.runtime import Runtime
 
 
 class AgentSession:


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fix the following issue when try to run docker run command - reported by @mamoodi:
```
ERROR:root:  File "/app/.venv/bin/uvicorn", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/main.py", line 410, in main
    run(
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/main.py", line 577, in run
    server.run()
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 69, in serve
    await self._serve(sockets)
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/server.py", line 76, in _serve
    config.load()
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/config.py", line 434, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/app/opendevin/server/listen.py", line 43, in <module>
    from opendevin.server.session import session_manager
  File "/app/opendevin/server/session/__init__.py", line 1, in <module>
    from .manager import SessionManager
  File "/app/opendevin/server/session/manager.py", line 9, in <module>
    from .session import Session
  File "/app/opendevin/server/session/session.py", line 20, in <module>
    from .agent import AgentSession
  File "/app/opendevin/server/session/agent.py", line 12, in <module>
    from opendevin.runtime import DockerSSHBox, Runtime, get_runtime_cls

ERROR:root:<class 'ImportError'>: cannot import name 'Runtime' from 'opendevin.runtime' (/app/opendevin/runtime/__init__.py)
```

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

**Other references**
