### PR TITLE
[Arch] `EventStreamRuntime` supports browser

### DIFF
--- a/opendevin/runtime/browser/__init__.py
+++ b/opendevin/runtime/browser/__init__.py
@@ -1,0 +1,3 @@
+from .utils import browse
+
+__all__ = ['browse']

--- a/opendevin/runtime/browser/utils.py
+++ b/opendevin/runtime/browser/utils.py
@@ -2,25 +2,31 @@ import os
 
 from opendevin.core.exceptions import BrowserUnavailableException
 from opendevin.core.schema import ActionType
+from opendevin.events.action import BrowseInteractiveAction, BrowseURLAction
 from opendevin.events.observation import BrowserOutputObservation
 from opendevin.runtime.browser.browser_env import BrowserEnv
 
 
-async def browse(action, browser: BrowserEnv | None) -> BrowserOutputObservation:
+async def browse(
+    action: BrowseURLAction | BrowseInteractiveAction, browser: BrowserEnv | None
+) -> BrowserOutputObservation:
     if browser is None:
         raise BrowserUnavailableException()
-    if action.action == ActionType.BROWSE:
+
+    if isinstance(action, BrowseURLAction):
         # legacy BrowseURLAction
         asked_url = action.url
         if not asked_url.startswith('http'):
             asked_url = os.path.abspath(os.curdir) + action.url
         action_str = f'goto("{asked_url}")'
-    elif action.action == ActionType.BROWSE_INTERACTIVE:
+
+    elif isinstance(action, BrowseInteractiveAction):
         # new BrowseInteractiveAction, supports full featured BrowserGym actions
         # action in BrowserGym: see https://github.com/ServiceNow/BrowserGym/blob/main/core/src/browsergym/core/action/functions.py
         action_str = action.browser_actions
     else:
         raise ValueError(f'Invalid action type: {action.action}')
+
     try:
         # obs provided by BrowserGym: see https://github.com/ServiceNow/BrowserGym/blob/main/core/src/browsergym/core/env.py#L396
         obs = browser.step(action_str)

--- a/opendevin/runtime/client/runtime.py
+++ b/opendevin/runtime/client/runtime.py
@@ -173,6 +173,11 @@ class EventStreamRuntime(Runtime):
         for container in containers:
             try:
                 if container.name.startswith(self.container_name_prefix):
+                    # tail the logs before removing the container
+                    logs = container.logs(tail=1000).decode('utf-8')
+                    logger.info(
+                        f'==== Container logs ====\n{logs}\n==== End of container logs ===='
+                    )
                     container.remove(force=True)
             except docker.errors.NotFound:
                 pass
@@ -180,10 +185,11 @@ class EventStreamRuntime(Runtime):
             self.docker_client.close()
 
     async def on_event(self, event: Event) -> None:
-        print('EventStreamRuntime: on_event triggered')
+        logger.info(f'EventStreamRuntime: on_event triggered: {event}')
         if isinstance(event, Action):
+            logger.info(event, extra={'msg_type': 'ACTION'})
             observation = await self.run_action(event)
-            print('EventStreamRuntime: observation', observation)
+            logger.info(observation, extra={'msg_type': 'OBSERVATION'})
             # observation._cause = event.id  # type: ignore[attr-defined]
             source = event.source if event.source else EventSource.AGENT
             await self.event_stream.add_event(observation, source)

--- a/opendevin/runtime/server/runtime.py
+++ b/opendevin/runtime/server/runtime.py
@@ -20,7 +20,7 @@ from opendevin.runtime import Sandbox
 from opendevin.runtime.runtime import Runtime
 from opendevin.storage.local import LocalFileStore
 
-from .browse import browse
+from ..browser import browse
 from .files import read_file, write_file
 
 

--- a/opendevin/runtime/utils/image_agnostic.py
+++ b/opendevin/runtime/utils/image_agnostic.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 
 import docker
@@ -67,7 +68,9 @@ def generate_dockerfile_for_eventstream_runtime(
     filename = filename.removesuffix('.tar.gz')
 
     # move the tarball to temp_dir
-    os.rename(tarball_path, os.path.join(temp_dir, 'project.tar.gz'))
+    _res = shutil.copy(tarball_path, os.path.join(temp_dir, 'project.tar.gz'))
+    if _res:
+        os.remove(tarball_path)
     logger.info(
         f'Source distribution moved to {os.path.join(temp_dir, "project.tar.gz")}'
     )

--- a/opendevin/runtime/utils/image_agnostic.py
+++ b/opendevin/runtime/utils/image_agnostic.py
@@ -49,7 +49,9 @@ def generate_dockerfile_for_eventstream_runtime(
     else:
         dockerfile_content = (
             f'FROM {base_image}\n'
+            # FIXME: make this more generic / cross-platform
             'RUN apt update && apt install -y wget sudo\n'
+            'RUN apt-get update && apt-get install -y libgl1-mesa-glx\n'  # Extra dependency for OpenCV
             'RUN mkdir -p /opendevin && mkdir -p /opendevin/logs && chmod 777 /opendevin/logs\n'
             'RUN echo "" > /opendevin/bash.bashrc\n'
             'RUN if [ ! -d /opendevin/miniforge3 ]; then \\\n'
@@ -59,8 +61,8 @@ def generate_dockerfile_for_eventstream_runtime(
             '        chmod -R g+w /opendevin/miniforge3 && \\\n'
             '        bash -c ". /opendevin/miniforge3/etc/profile.d/conda.sh && conda config --set changeps1 False && conda config --append channels conda-forge"; \\\n'
             '    fi\n'
-            'RUN /opendevin/miniforge3/bin/mamba install python=3.11\n'
-            'RUN /opendevin/miniforge3/bin/mamba install conda-forge::poetry\n'
+            'RUN /opendevin/miniforge3/bin/mamba install python=3.11 -y\n'
+            'RUN /opendevin/miniforge3/bin/mamba install conda-forge::poetry -y\n'
         )
 
     tarball_path = create_project_source_dist()
@@ -91,6 +93,8 @@ def generate_dockerfile_for_eventstream_runtime(
         'RUN cd /opendevin/code && '
         '/opendevin/miniforge3/bin/mamba run -n base poetry env use python3.11 && '
         '/opendevin/miniforge3/bin/mamba run -n base poetry install\n'
+        # for browser (update if needed)
+        'RUN apt-get update && cd /opendevin/code && /opendevin/miniforge3/bin/mamba run -n base poetry run playwright install --with-deps chromium\n'
     )
     return dockerfile_content
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This is part of https://github.com/OpenDevin/OpenDevin/issues/2404.

Right now, the `RuntimeClient` running inside the sandbox supports running Browser actions.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

- Move the browser into `RuntimeClient` to be executed inside sandbox.
- Tweak the dependency a bit to make sure it works.

Command to test `python3 opendevin/runtime/client/runtime.py`

Example output:
![image](https://github.com/user-attachments/assets/3781c761-33df-442e-a768-84ac398d8480)

**Other references**
