### PR TITLE
Remove legacy dummy action from CI

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -261,11 +261,3 @@ jobs:
               $image_name:${tag}_amd64 \
               $image_name:${tag}_arm64
           done
-
-  # FIXME: an admin needs to mark this as non-mandatory, and then we can remove it
-  docker_build_success:
-    name: Docker Build Success
-    runs-on: ubuntu-latest
-    needs: ghcr_build
-    steps:
-    - run: echo Done!


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

It doesn't fix any problem. It only prettifies `ghcr.yml` and our build.

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**

Remove legacy dummy action.

**Other references**

This PR won't pass CI gates until an admin actually unmarks `docker_build_success` as mandatory in branch protection rules.

We don't need to add anything else to branch protection rules because `Integration Tests on Linux`, a mandatory check, depends on `ghcr_build` check.