### PR TITLE
[Fix] Minor bug in parse_response of CodeActResponseParser

### DIFF
--- a/agenthub/browsing_agent/response_parser.py
+++ b/agenthub/browsing_agent/response_parser.py
@@ -20,7 +20,10 @@ class BrowsingResponseParser(ResponseParser):
         return self.parse_action(action_str)
 
     def parse_response(self, response) -> str:
-        action_str = response['choices'][0]['message']['content'].strip()
+        action_str = response['choices'][0]['message']['content']
+        if action_str is None:
+            return ''
+        action_str = action_str.strip()
         if not action_str.endswith('```'):
             action_str = action_str + ')```'
         logger.info(action_str)

--- a/agenthub/codeact_agent/action_parser.py
+++ b/agenthub/codeact_agent/action_parser.py
@@ -38,6 +38,8 @@ class CodeActResponseParser(ResponseParser):
 
     def parse_response(self, response) -> str:
         action = response.choices[0].message.content
+        if action is None:
+            return ''
         for lang in ['bash', 'ipython', 'browse']:
             if f'<execute_{lang}>' in action and f'</execute_{lang}>' not in action:
                 action += f'</execute_{lang}>'

--- a/agenthub/codeact_swe_agent/response_parser.py
+++ b/agenthub/codeact_swe_agent/response_parser.py
@@ -33,6 +33,8 @@ class CodeActSWEResponseParser(ResponseParser):
 
     def parse_response(self, response) -> str:
         action = response.choices[0].message.content
+        if action is None:
+            return ''
         for lang in ['bash', 'ipython']:
             if f'<execute_{lang}>' in action and f'</execute_{lang}>' not in action:
                 action += f'</execute_{lang}>'


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
No Open issues for this bug.
Error log:
File "/google/src/cloud/rajmaheshwari/OpenDevin/google3/experimental/users/rajmaheshwari/OpenDevin/OpenDevin/opendevin/controller/agent_controller.py", line 135, in _start_step_loop
await self.step()
File "/google/src/cloud/rajmaheshwari/OpenDevin/google3/experimental/users/rajmaheshwari/OpenDevin/OpenDevin/opendevin/controller/agent_controller.py", line 339, in step
action = self.agent.step(self.state)
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/google/src/cloud/rajmaheshwari/OpenDevin/google3/experimental/users/rajmaheshwari/OpenDevin/OpenDevin/agenthub/codeact_agent/codeact_agent.py", line 209, in step
return self.action_parser.parse(response)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/google/src/cloud/rajmaheshwari/OpenDevin/google3/experimental/users/rajmaheshwari/OpenDevin/OpenDevin/agenthub/codeact_agent/action_parser.py", line 36, in parse
action_str = self.parse_response(response)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/google/src/cloud/rajmaheshwari/OpenDevin/google3/experimental/users/rajmaheshwari/OpenDevin/OpenDevin/agenthub/codeact_agent/action_parser.py", line 42, in parse_response
if f'<execute{lang}>' in action and f'</execute{lang}>' not in action:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable

**Give a brief summary of what the PR does, explaining any non-trivial design decisions**
If the response from the LLM is None, we replace it with empty string.

**Other references**
