### PR TITLE
[SWE-bench] Util: Compare files modified between gold patches and OpenDevin patches

### DIFF
--- a/evaluation/swe_bench/scripts/setup/compare_patch_filename.py
+++ b/evaluation/swe_bench/scripts/setup/compare_patch_filename.py
@@ -1,0 +1,55 @@
+"""
+This script compares gold patches with OpenDevin-generated patches and check whether
+OpenDevin found the right (set of) files to modify.
+"""
+
+import argparse
+import json
+import re
+
+
+def extract_modified_files(patch):
+    modified_files = set()
+    file_pattern = re.compile(r'^diff --git a/(.*?) b/')
+
+    for line in patch.split('\n'):
+        match = file_pattern.match(line)
+        if match:
+            modified_files.add(match.group(1))
+
+    return modified_files
+
+
+def process_report(od_output_file):
+    succ = 0
+    fail = 0
+    for line in open(od_output_file):
+        line = json.loads(line)
+        instance_id = line['instance_id']
+        gold_patch = line['swe_instance']['patch']
+        generated_patch = line['git_patch']
+        gold_modified_files = extract_modified_files(gold_patch)
+        # swe-bench lite only: a gold patch always contains exactly one file
+        assert len(gold_modified_files) == 1
+        generated_modified_files = extract_modified_files(generated_patch)
+
+        # Check if all files in gold_patch are also in generated_patch
+        all_files_in_generated = gold_modified_files.issubset(generated_modified_files)
+        if all_files_in_generated:
+            succ += 1
+        else:
+            fail += 1
+            print(
+                f'{instance_id}: file mismatch, gold = {gold_modified_files}, generated = {generated_modified_files}'
+            )
+    print(
+        f'\nSUMMARY: {succ} out of {succ + fail} instances found correct files to edit, success rate = {succ / float(succ + fail)}'
+    )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--od_output_file', help='Path to the OD output file')
+    args = parser.parse_args()
+
+    process_report(args.od_output_file)


### PR DESCRIPTION
https://aider.chat/2024/05/22/swe-bench-lite.html says it finds correct files to edit in 70.3% of benchmark tests. This PR adds a utility script that computes the number for OpenDevin.

Usage Example:

```bash
poetry run python evaluation/swe_bench/scripts/setup/compare_patch_filename.py --od_output_file /Users/liboxuan/workspace/OpenDevin/evaluation/evaluation_outputs/outputs/swe_bench_lite/CodeActAgent/claude-3-5-sonnet@20240620_maxiter_30_N_v1.8-no-hint/output.jsonl
```

`claude-3-5-sonnet@20240620_maxiter_30_N_v1.8-no-hint` result says OpenDevin found correct files to edit in 64% of benchmark tests. The real number might be even lower because I consider success as long as OpenDevin modifies *the* correct file even though it might have modified other files erroneously and caused the test to fail.

