### PR TITLE
Draft: add initial autorover skill of search_class

### DIFF
--- a/opendevin/runtime/plugins/agent_skills/agentskills.py
+++ b/opendevin/runtime/plugins/agent_skills/agentskills.py
@@ -54,6 +54,10 @@ OPENAI_PROXY = f'{OPENAI_BASE_URL}/chat/completions'
 
 client = OpenAI(api_key=OPENAI_API_KEY, base_url=OPENAI_BASE_URL)
 
+if __package__ is None or __package__ == '':
+    from autorover import SearchManager
+else:
+    from .autorover import SearchManager
 
 # Define the decorator using the functionality of UpdatePwd
 def update_pwd_decorator(func):
@@ -93,7 +97,6 @@ def _is_valid_path(path) -> bool:
         return os.path.exists(os.path.normpath(path))
     except PermissionError:
         return False
-
 
 def _create_paths(file_name) -> bool:
     try:
@@ -789,6 +792,25 @@ def append_file(file_name: str, content: str) -> None:
     )
     print(ret_str)
 
+@update_pwd_decorator
+def search_class(class_name: str) -> tuple[str, str, bool]:
+    """Search for a class in the codebase.
+
+    Only the signature of the class is returned. The class signature
+    includes class name, base classes, and signatures for all of its methods/properties.
+
+    Args:
+        class_name (string): Name of the class to search for.
+
+    Returns:
+        string: the class signature in string if success;
+                an error message if the class cannot be found.
+        string: a message summarizing the method.
+    """
+    project_path = './'
+    search_manager = SearchManager(project_path)
+    result = search_manager.search_class(class_name)
+    print(result)
 
 @update_pwd_decorator
 def search_dir(search_term: str, dir_path: str = './') -> None:

--- a/opendevin/runtime/plugins/agent_skills/autorover/__init__.py
+++ b/opendevin/runtime/plugins/agent_skills/autorover/__init__.py
@@ -1,0 +1,6 @@
+if __package__ is None or __package__ == '':
+    from search.search_manage import SearchManager
+else:
+    from .search.search_manage import SearchManager
+
+__all__ = ['SearchManager']

--- a/opendevin/runtime/plugins/agent_skills/autorover/manage.py
+++ b/opendevin/runtime/plugins/agent_skills/autorover/manage.py
@@ -1,0 +1,129 @@
+import os
+from pathlib import Path
+
+from search.search_manage import SearchManager
+
+if __package__ is None or __package__ == '':
+    from autorover.manage import *
+else:
+    from .autorover.manage import *
+
+class ProjectApiManager:
+    def __init__(self, project_path: str):
+        # build search manager
+        self.search_manager = SearchManager(project_path)
+
+    # not a search API - just to get full class definition when bug_location only specifies a class
+    def get_class_full_snippet(self, class_name: str):
+        return self.search_manager.get_class_full_snippet(class_name)
+
+    def search_class(self, class_name: str) -> tuple[str, str, bool]:
+        """Search for a class in the codebase.
+
+        Only the signature of the class is returned. The class signature
+        includes class name, base classes, and signatures for all of its methods/properties.
+
+        Args:
+            class_name (string): Name of the class to search for.
+
+        Returns:
+            string: the class signature in string if success;
+                    an error message if the class cannot be found.
+            string: a message summarizing the method.
+        """
+        return self.search_manager.search_class(class_name)
+
+    def search_class_in_file(
+        self, class_name: str, file_name: str
+    ) -> tuple[str, str, bool]:
+        """Search for a class in a given file.
+
+        Returns the actual code of the entire class definition.
+
+        Args:
+            class_name (string): Name of the class to search for.
+            file_name (string): The file to search in. Must be a valid python file name.
+
+        Returns:
+            part 1 - the searched class code or error message.
+            part 2 - summary of the tool call.
+        """
+        return self.search_manager.search_class_in_file(class_name, file_name)
+
+    def search_method_in_file(
+        self, method_name: str, file_name: str
+    ) -> tuple[str, str, bool]:
+        """Search for a method in a given file.
+
+        Returns the actual code of the method.
+
+        Args:
+            method_name (string): Name of the method to search for.
+            file_name (string): The file to search in. Must be a valid python file name.
+
+        Returns:
+            part 1 - the searched code or error message.
+            part 2 - summary of the tool call.
+        """
+        return self.search_manager.search_method_in_file(method_name, file_name)
+
+    def search_method_in_class(
+        self, method_name: str, class_name: str
+    ) -> tuple[str, str, bool]:
+        """Search for a method in a given class.
+
+        Returns the actual code of the method.
+
+        Args:
+            method_name (string): Name of the method to search for.
+            class_name (string): Consider only methods in this class.
+
+        Returns:
+            part 1 - the searched code or error message.
+            part 2 - summary of the tool call.
+        """
+        return self.search_manager.search_method_in_class(method_name, class_name)
+
+    def search_method(self, method_name: str) -> tuple[str, str, bool]:
+        """Search for a method in the entire codebase.
+
+        Returns the actual code of the method.
+
+        Args:
+            method_name (string): Name of the method to search for.
+
+        Returns:
+            part 1 - the searched code or error message.
+            part 2 - summary of the tool call.
+        """
+        return self.search_manager.search_method(method_name)
+
+    def search_code(self, code_str: str) -> tuple[str, str, bool]:
+        """Search for a code snippet in the entire codebase.
+
+        Returns the method that contains the code snippet, if it is found inside a file.
+        Otherwise, returns the region of code surrounding it.
+
+        Args:
+            code_str (string): The code snippet to search for.
+
+        Returns:
+            The region of code containing the searched code string.
+        """
+        return self.search_manager.search_code(code_str)
+
+    def search_code_in_file(
+        self, code_str: str, file_name: str
+    ) -> tuple[str, str, bool]:
+        """Search for a code snippet in a given file file.
+
+        Returns the entire method that contains the code snippet.
+
+        Args:
+            code_str (string): The code snippet to search for.
+            file_name (string): The file to search in. Must be a valid python file name in the project.
+
+        Returns:
+            The method code that contains the searched code string.
+        """
+        return self.search_manager.search_code_in_file(code_str, file_name)

--- a/opendevin/runtime/plugins/agent_skills/autorover/search/search_manage.py
+++ b/opendevin/runtime/plugins/agent_skills/autorover/search/search_manage.py
@@ -1,0 +1,478 @@
+from collections import defaultdict, namedtuple
+from collections.abc import MutableMapping
+
+from . import search_utils
+from .search_utils import SearchResult
+
+LineRange = namedtuple("LineRange", ["start", "end"])
+
+ClassIndexType = MutableMapping[str, list[tuple[str, LineRange]]]
+ClassFuncIndexType = MutableMapping[
+    str, MutableMapping[str, list[tuple[str, LineRange]]]
+]
+FuncIndexType = MutableMapping[str, list[tuple[str, LineRange]]]
+
+RESULT_SHOW_LIMIT = 3
+
+
+class SearchManager:
+    def __init__(self, project_path: str):
+        self.project_path = project_path
+        # list of all files ending with .py, which are likely not test files
+        # These are all ABSOLUTE paths.
+        self.parsed_files: list[str] = []
+
+        # for file name in the indexes, assume they are absolute path
+        # class name -> [(file_name, line_range)]
+        self.class_index: ClassIndexType = {}
+
+        # {class_name -> {func_name -> [(file_name, line_range)]}}
+        # inner dict is a list, since we can have (1) overloading func names,
+        # and (2) multiple classes with the same name, having the same method
+        self.class_func_index: ClassFuncIndexType = {}
+
+        # function name -> [(file_name, line_range)]
+        self.function_index: FuncIndexType = {}
+        self._build_index()
+
+    def _build_index(self):
+        """
+        With all source code of the project, build two indexes:
+            1. From class name to (source file, start line, end line)
+            2. From function name to (source file, start line, end line)
+        Since there can be two classes/functions with the same name, the mapping
+        value is a list of tuples.
+        This is for fast lookup whenever we receive a query.
+        """
+        self._update_indices(*self._build_python_index())
+
+    def _update_indices(
+        self,
+        class_index: ClassIndexType,
+        class_func_index: ClassFuncIndexType,
+        function_index: FuncIndexType,
+        parsed_files: list[str],
+    ) -> None:
+        self.class_index.update(class_index)
+        self.class_func_index.update(class_func_index)
+        self.function_index.update(function_index)
+        self.parsed_files.extend(parsed_files)
+
+    def _build_python_index(
+        self,
+    ) -> tuple[ClassIndexType, ClassFuncIndexType, FuncIndexType, list[str]]:
+        class_index: ClassIndexType = defaultdict(list)
+        class_func_index: ClassFuncIndexType = defaultdict(lambda: defaultdict(list))
+        function_index: FuncIndexType = defaultdict(list)
+
+        py_files = search_utils.find_python_files(self.project_path)
+        # holds the parsable subset of all py files
+        parsed_py_files = []
+        for py_file in py_files:
+            file_info = search_utils.parse_python_file(py_file)
+            if file_info is None:
+                # parsing of this file failed
+                continue
+            parsed_py_files.append(py_file)
+            # extract from file info, and form search index
+            classes, class_to_funcs, top_level_funcs = file_info
+
+            # (1) build class index
+            for c, start, end in classes:
+                class_index[c].append((py_file, LineRange(start, end)))
+
+            # (2) build class-function index
+            for c, class_funcs in class_to_funcs.items():
+                for f, start, end in class_funcs:
+                    class_func_index[c][f].append((py_file, LineRange(start, end)))
+
+            # (3) build (top-level) function index
+            for f, start, end in top_level_funcs:
+                function_index[f].append((py_file, LineRange(start, end)))
+
+        return class_index, class_func_index, function_index, parsed_py_files
+
+    def file_line_to_class_and_func(
+        self, file_path: str, line_no: int
+    ) -> tuple[str | None, str | None]:
+        """
+        Given a file path and a line number, return the class and function name.
+        If the line is not inside a class or function, return None.
+        """
+        # check whether this line is inside a class
+        for class_name in self.class_func_index:
+            func_dict = self.class_func_index[class_name]
+            for func_name, func_info in func_dict.items():
+                for file_name, (start, end) in func_info:
+                    if file_name == file_path and start <= line_no <= end:
+                        return class_name, func_name
+
+        # not in any class; check whether this line is inside a top-level function
+        for func_name in self.function_index:
+            for file_name, (start, end) in self.function_index[func_name]:
+                if file_name == file_path and start <= line_no <= end:
+                    return None, func_name
+
+        # this file-line is not recorded in any of the indexes
+        return None, None
+
+    def _search_func_in_class(
+        self, function_name: str, class_name: str
+    ) -> list[SearchResult]:
+        """
+        Search for the function name in the class.
+        Args:
+            function_name (str): Name of the function.
+            class_name (str): Name of the class.
+        Returns:
+            The list of code snippets searched.
+        """
+        result: list[SearchResult] = []
+        if class_name not in self.class_func_index:
+            return result
+        if function_name not in self.class_func_index[class_name]:
+            return result
+        for fname, (start, end) in self.class_func_index[class_name][function_name]:
+            func_code = search_utils.get_code_snippets(fname, start, end)
+            res = SearchResult(fname, class_name, function_name, func_code)
+            result.append(res)
+        return result
+
+    def _search_func_in_all_classes(self, function_name: str) -> list[SearchResult]:
+        """
+        Search for the function name in all classes.
+        Args:
+            function_name (str): Name of the function.
+        Returns:
+            The list of code snippets searched.
+        """
+        result: list[SearchResult] = []
+        for class_name in self.class_index:
+            res = self._search_func_in_class(function_name, class_name)
+            result.extend(res)
+        return result
+
+    def _search_top_level_func(self, function_name: str) -> list[SearchResult]:
+        """
+        Search for top-level function name in the entire project.
+        Args:
+            function_name (str): Name of the function.
+        Returns:
+            The list of code snippets searched.
+        """
+        result: list[SearchResult] = []
+        if function_name not in self.function_index:
+            return result
+
+        for fname, (start, end) in self.function_index[function_name]:
+            func_code = search_utils.get_code_snippets(fname, start, end)
+            res = SearchResult(fname, None, function_name, func_code)
+            result.append(res)
+        return result
+
+    def _search_func_in_code_base(self, function_name: str) -> list[SearchResult]:
+        """
+        Search for this function, from both top-level and all class definitions.
+        """
+        result: list[SearchResult] = []  # list of (file_name, func_code)
+        # (1) search in top level
+        top_level_res = self._search_top_level_func(function_name)
+        class_res = self._search_func_in_all_classes(function_name)
+        result.extend(top_level_res)
+        result.extend(class_res)
+        return result
+
+    ###############################
+    ### Interfaces ################
+    ###############################
+
+    # not search API - for writing patch
+    # if we are searching for only a class when writing patch, likely we do not have enough info
+    # the result can be too long, so we just show the first two
+    def get_class_full_snippet(self, class_name: str) -> tuple[str, str, bool]:
+        summary = f"Class {class_name} did not appear in the codebase."
+        tool_result = f"Could not find class {class_name} in the codebase."
+
+        if class_name not in self.class_index:
+            return tool_result, summary, False
+        # class name -> [(file_name, start_line, end_line)]
+        search_res: list[SearchResult] = []
+        for fname, (start, end) in self.class_index[class_name]:
+            code = search_utils.get_code_snippets(fname, start, end)
+            res = SearchResult(fname, class_name, None, code)
+            search_res.append(res)
+
+        if not search_res:
+            return tool_result, summary, False
+
+        # the good path
+        # for all the searched result, append them and form the final result
+        tool_result = f"Found {len(search_res)} classes with name {class_name} in the codebase:\n\n"
+        summary = tool_result
+        if len(search_res) > 2:
+            tool_result += "Too many results, showing full code for 2 of them:\n"
+        for idx, res in enumerate(search_res[:2]):
+            res_str = res.to_tagged_str(self.project_path)
+            tool_result += f"- Search result {idx + 1}:\n```\n{res_str}\n```"
+        return tool_result, summary, True
+
+    def search_class(self, class_name: str) -> tuple[str, str, bool]:
+        # initialize them to error case
+        summary = f"Class {class_name} did not appear in the codebase."
+        tool_result = f"Could not find class {class_name} in the codebase."
+        if class_name not in self.class_index:
+            return tool_result, summary, False
+
+        search_res: list[SearchResult] = []
+        for fname, _ in self.class_index[class_name]:
+            # there are some classes; we return their signatures
+            code = search_utils.get_class_signature(fname, class_name)
+            res = SearchResult(fname, class_name, None, code)
+            search_res.append(res)
+        if not search_res:
+            # this should not happen, but just in case
+            return tool_result, summary, False
+
+        # the good path
+        # for all the searched result, append them and form the final result
+        tool_result = f"Found {len(search_res)} classes with name {class_name} in the codebase:\n\n"
+        if len(search_res) > RESULT_SHOW_LIMIT:
+            tool_result += "They appeared in the following files:\n"
+            tool_result += SearchResult.collapse_to_file_level(
+                search_res, self.project_path
+            )
+        else:
+            for idx, res in enumerate(search_res):
+                res_str = res.to_tagged_str(self.project_path)
+                tool_result += f"- Search result {idx + 1}:\n```\n{res_str}\n```\n"
+        summary = f"The tool returned information about class `{class_name}`."
+        return tool_result
+
+    def search_class_in_file(self, class_name, file_name: str) -> tuple[str, str, bool]:
+        # (1) check whether we can get the file
+        candidate_py_abs_paths = [f for f in self.parsed_files if f.endswith(file_name)]
+        if not candidate_py_abs_paths:
+            tool_output = f"Could not find file {file_name} in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # (2) search for this class in the entire code base (we do filtering later)
+        if class_name not in self.class_index:
+            tool_output = f"Could not find class {class_name} in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # (3) class is there, check whether it exists in the file specified.
+        search_res: list[SearchResult] = []
+        for fname, (start_line, end_line) in self.class_index[class_name]:
+            if fname in candidate_py_abs_paths:
+                class_code = search_utils.get_code_snippets(fname, start_line, end_line)
+                res = SearchResult(fname, class_name, None, class_code)
+                search_res.append(res)
+
+        if not search_res:
+            tool_output = f"Could not find class {class_name} in file {file_name}."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # good path; we have result, now just form a response
+        tool_output = f"Found {len(search_res)} classes with name {class_name} in file {file_name}:\n\n"
+        summary = tool_output
+        for idx, res in enumerate(search_res):
+            res_str = res.to_tagged_str(self.project_path)
+            tool_output += f"- Search result {idx + 1}:\n```\n{res_str}\n```\n"
+        return tool_output, summary, True
+
+    def search_method_in_file(
+        self, method_name: str, file_name: str
+    ) -> tuple[str, str, bool]:
+        # (1) check whether we can get the file
+        # supports both when file_name is relative to project root, and when
+        # it is just a short name
+        candidate_py_abs_paths = [f for f in self.parsed_files if f.endswith(file_name)]
+        # print(candidate_py_files)
+        if not candidate_py_abs_paths:
+            tool_output = f"Could not find file {file_name} in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # (2) search for this method in the entire code base (we do filtering later)
+        search_res: list[SearchResult] = self._search_func_in_code_base(method_name)
+        if not search_res:
+            tool_output = f"The method {method_name} does not appear in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # (3) filter the search result => they need to be in one of the files!
+        filtered_res: list[SearchResult] = [
+            res for res in search_res if res.file_path in candidate_py_abs_paths
+        ]
+
+        # (4) done with search, now prepare result
+        if not filtered_res:
+            tool_output = (
+                f"There is no method with name `{method_name}` in file {file_name}."
+            )
+            summary = tool_output
+            return tool_output, summary, False
+
+        tool_output = f"Found {len(filtered_res)} methods with name `{method_name}` in file {file_name}:\n\n"
+        summary = tool_output
+
+        # when searching for a method in one file, it's rare that there are
+        # many candidates, so we do not trim the result
+        for idx, res in enumerate(filtered_res):
+            res_str = res.to_tagged_str(self.project_path)
+            tool_output += f"- Search result {idx + 1}:\n```\n{res_str}\n```\n"
+        return tool_output, summary, True
+
+    def search_method_in_class(
+        self, method_name: str, class_name: str
+    ) -> tuple[str, str, bool]:
+        if class_name not in self.class_index:
+            tool_output = f"Could not find class {class_name} in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # has this class, check its methods
+        search_res: list[SearchResult] = self._search_func_in_class(
+            method_name, class_name
+        )
+        if not search_res:
+            tool_output = f"Could not find method {method_name} in class {class_name}`."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # found some methods, prepare the result
+        tool_output = f"Found {len(search_res)} methods with name {method_name} in class {class_name}:\n\n"
+        summary = tool_output
+
+        # There can be multiple classes defined in multiple files, which contain the same method
+        # still trim the result, just in case
+        if len(search_res) > RESULT_SHOW_LIMIT:
+            tool_output += f"Too many results, showing full code for {RESULT_SHOW_LIMIT} of them, and the rest just file names:\n"
+        first_five = search_res[:RESULT_SHOW_LIMIT]
+        for idx, res in enumerate(first_five):
+            res_str = res.to_tagged_str(self.project_path)
+            tool_output += f"- Search result {idx + 1}:\n```\n{res_str}\n```\n"
+        # for the rest, collect the file names into a set
+        if rest := search_res[RESULT_SHOW_LIMIT:]:
+            tool_output += "Other results are in these files:\n"
+            tool_output += SearchResult.collapse_to_file_level(rest, self.project_path)
+        return tool_output, summary, True
+
+    def search_method(self, method_name: str) -> tuple[str, str, bool]:
+        """
+        Search for a method in the entire codebase.
+        """
+        search_res: list[SearchResult] = self._search_func_in_code_base(method_name)
+        if not search_res:
+            tool_output = f"Could not find method {method_name} in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        tool_output = f"Found {len(search_res)} methods with name {method_name} in the codebase:\n\n"
+        summary = tool_output
+
+        if len(search_res) > RESULT_SHOW_LIMIT:
+            tool_output += "They appeared in the following files:\n"
+            tool_output += SearchResult.collapse_to_file_level(
+                search_res, self.project_path
+            )
+        else:
+            for idx, res in enumerate(search_res):
+                res_str = res.to_tagged_str(self.project_path)
+                tool_output += f"- Search result {idx + 1}:\n```\n{res_str}\n```\n"
+
+        return tool_output, summary, True
+
+    def search_code(self, code_str: str) -> tuple[str, str, bool]:
+        # attempt to search for this code string in all py files
+        all_search_results: list[SearchResult] = []
+        for file_path in self.parsed_files:
+            searched_line_and_code: list[tuple[int, str]] = (
+                search_utils.get_code_region_containing_code(file_path, code_str)
+            )
+            if not searched_line_and_code:
+                continue
+            for searched in searched_line_and_code:
+                line_no, code_region = searched
+                # from line_no, check which function and class we are in
+                class_name, func_name = self.file_line_to_class_and_func(
+                    file_path, line_no
+                )
+                res = SearchResult(file_path, class_name, func_name, code_region)
+                all_search_results.append(res)
+
+        if not all_search_results:
+            tool_output = f"Could not find code {code_str} in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # good path
+        tool_output = f"Found {len(all_search_results)} snippets containing `{code_str}` in the codebase:\n\n"
+        summary = tool_output
+
+        if len(all_search_results) > RESULT_SHOW_LIMIT:
+            tool_output += "They appeared in the following files:\n"
+            tool_output += SearchResult.collapse_to_file_level(
+                all_search_results, self.project_path
+            )
+        else:
+            for idx, res in enumerate(all_search_results):
+                res_str = res.to_tagged_str(self.project_path)
+                tool_output += f"- Search result {idx + 1}:\n```\n{res_str}\n```\n"
+        return tool_output, summary, True
+
+    def search_code_in_file(
+        self, code_str: str, file_name: str
+    ) -> tuple[str, str, bool]:
+        code_str = code_str.removesuffix(")")
+
+        candidate_py_files = [f for f in self.parsed_files if f.endswith(file_name)]
+        if not candidate_py_files:
+            tool_output = f"Could not find file {file_name} in the codebase."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # start searching for code in the filtered files
+        all_search_results: list[SearchResult] = []
+        for file_path in candidate_py_files:
+            searched_line_and_code: list[tuple[int, str]] = (
+                search_utils.get_code_region_containing_code(file_path, code_str)
+            )
+            if not searched_line_and_code:
+                continue
+            for searched in searched_line_and_code:
+                line_no, code_region = searched
+                # from line_no, check which function and class we are in
+                class_name, func_name = self.file_line_to_class_and_func(
+                    file_path, line_no
+                )
+                res = SearchResult(file_path, class_name, func_name, code_region)
+                all_search_results.append(res)
+
+        if not all_search_results:
+            tool_output = f"Could not find code {code_str} in file {file_name}."
+            summary = tool_output
+            return tool_output, summary, False
+
+        # good path
+        # There can be a lot of results, from multiple files.
+        tool_output = f"Found {len(all_search_results)} snippets with code {code_str} in file {file_name}:\n\n"
+        summary = tool_output
+        if len(all_search_results) > RESULT_SHOW_LIMIT:
+            tool_output += "They appeared in the following methods:\n"
+            tool_output += SearchResult.collapse_to_method_level(
+                all_search_results, self.project_path
+            )
+        else:
+            for idx, res in enumerate(all_search_results):
+                res_str = res.to_tagged_str(self.project_path)
+                tool_output += f"- Search result {idx + 1}:\n```\n{res_str}\n```\n"
+        return tool_output, summary, True
+
+    def retrieve_code_snippet(
+        self, file_path: str, start_line: int, end_line: int
+    ) -> str:
+        return search_utils.get_code_snippets(file_path, start_line, end_line)

--- a/opendevin/runtime/plugins/agent_skills/autorover/search/search_utils.py
+++ b/opendevin/runtime/plugins/agent_skills/autorover/search/search_utils.py
@@ -1,0 +1,454 @@
+import ast
+import glob
+import pathlib
+import re
+from dataclasses import dataclass
+from os.path import join as pjoin
+from pathlib import Path
+
+
+@dataclass
+class SearchResult:
+    """Dataclass to hold search results."""
+
+    file_path: str  # this is absolute path
+    class_name: str | None
+    func_name: str | None
+    code: str
+
+    def to_tagged_upto_file(self, project_root: str):
+        """Convert the search result to a tagged string, upto file path."""
+        rel_path = to_relative_path(self.file_path, project_root)
+        file_part = f"<file>{rel_path}</file>"
+        return file_part
+
+    def to_tagged_upto_class(self, project_root: str):
+        """Convert the search result to a tagged string, upto class."""
+        prefix = self.to_tagged_upto_file(project_root)
+        class_part = (
+            f"<class>{self.class_name}</class>" if self.class_name is not None else ""
+        )
+        return f"{prefix}\n{class_part}"
+
+    def to_tagged_upto_func(self, project_root: str):
+        """Convert the search result to a tagged string, upto function."""
+        prefix = self.to_tagged_upto_class(project_root)
+        func_part = (
+            f" <func>{self.func_name}</func>" if self.func_name is not None else ""
+        )
+        return f"{prefix}{func_part}"
+
+    def to_tagged_str(self, project_root: str):
+        """Convert the search result to a tagged string."""
+        prefix = self.to_tagged_upto_func(project_root)
+        code_part = f"<code>\n{self.code}\n</code>"
+        return f"{prefix}\n{code_part}"
+
+    @staticmethod
+    def collapse_to_file_level(lst, project_root: str) -> str:
+        """Collapse search results to file level."""
+        res = dict()  # file -> count
+        for r in lst:
+            if r.file_path not in res:
+                res[r.file_path] = 1
+            else:
+                res[r.file_path] += 1
+        res_str = ""
+        for file_path, count in res.items():
+            rel_path = to_relative_path(file_path, project_root)
+            file_part = f"<file>{rel_path}</file>"
+            res_str += f"- {file_part} ({count} matches)\n"
+        return res_str
+
+    @staticmethod
+    def collapse_to_method_level(lst, project_root: str) -> str:
+        """Collapse search results to method level."""
+        res = dict()  # file -> dict(method -> count)
+        for r in lst:
+            if r.file_path not in res:
+                res[r.file_path] = dict()
+            func_str = r.func_name if r.func_name is not None else "Not in a function"
+            if func_str not in res[r.file_path]:
+                res[r.file_path][func_str] = 1
+            else:
+                res[r.file_path][func_str] += 1
+        res_str = ""
+        for file_path, funcs in res.items():
+            rel_path = to_relative_path(file_path, project_root)
+            file_part = f"<file>{rel_path}</file>"
+            for func, count in funcs.items():
+                if func == "Not in a function":
+                    func_part = func
+                else:
+                    func_part = f" <func>{func}</func>"
+                res_str += f"- {file_part}{func_part} ({count} matches)\n"
+        return res_str
+
+
+def find_python_files(dir_path: str) -> list[str]:
+    """Get all .py files recursively from a directory.
+
+    Skips files that are obviously not from the source code, such third-party library code.
+
+    Args:
+        dir_path (str): Path to the directory.
+    Returns:
+        List[str]: List of .py file paths. These paths are ABSOLUTE path!
+    """
+
+    py_files = glob.glob(pjoin(dir_path, "**/*.py"), recursive=True)
+    res = []
+    for file in py_files:
+        rel_path = file[len(dir_path) + 1 :]
+        if rel_path.startswith("build"):
+            continue
+        if rel_path.startswith("doc"):
+            # discovered this issue in 'pytest-dev__pytest'
+            continue
+        if rel_path.startswith("requests/packages"):
+            # to walkaround issue in 'psf__requests'
+            continue
+        if (
+            rel_path.startswith("tests/regrtest_data")
+            or rel_path.startswith("tests/input")
+            or rel_path.startswith("tests/functional")
+        ):
+            # to walkaround issue in 'pylint-dev__pylint'
+            continue
+        if rel_path.startswith("tests/roots") or rel_path.startswith(
+            "sphinx/templates/latex"
+        ):
+            # to walkaround issue in 'sphinx-doc__sphinx'
+            continue
+        if rel_path.startswith("tests/test_runner_apps/tagged/") or rel_path.startswith(
+            "django/conf/app_template/"
+        ):
+            # to walkaround issue in 'django__django'
+            continue
+        res.append(file)
+    return res
+
+
+def parse_python_file(file_full_path: str) -> tuple[list, dict, list] | None:
+    """
+    Main method to parse AST and build search index.
+    Handles complication where python ast module cannot parse a file.
+    """
+    try:
+        file_content = pathlib.Path(file_full_path).read_text()
+        tree = ast.parse(file_content)
+    except Exception:
+        # failed to read/parse one file, we should ignore it
+        return None
+
+    # (1) get all classes defined in the file
+    classes = []
+    # (2) for each class in the file, get all functions defined in the class.
+    class_to_funcs = {}
+    # (3) get top-level functions in the file (exclues functions defined in classes)
+    top_level_funcs = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            ## class part (1): collect class info
+            class_name = node.name
+            start_lineno = node.lineno
+            end_lineno = node.end_lineno
+            # line numbers are 1-based
+            classes.append((class_name, start_lineno, end_lineno))
+
+            ## class part (2): collect function info inside this class
+            class_funcs = [
+                (n.name, n.lineno, n.end_lineno)
+                for n in ast.walk(node)
+                if isinstance(n, ast.FunctionDef)
+            ]
+            class_to_funcs[class_name] = class_funcs
+
+        elif isinstance(node, ast.FunctionDef):
+            function_name = node.name
+            start_lineno = node.lineno
+            end_lineno = node.end_lineno
+            # line numbers are 1-based
+            top_level_funcs.append((function_name, start_lineno, end_lineno))
+
+    return classes, class_to_funcs, top_level_funcs
+
+
+def get_func_snippet_in_class(
+    file_full_path: str, class_name: str, func_name: str, include_lineno=False
+) -> str | None:
+    """Get actual function source code in class.
+
+    All source code of the function is returned.
+    Assumption: the class and function exist.
+    """
+    with open(file_full_path) as f:
+        file_content = f.read()
+
+    tree = ast.parse(file_content)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for n in ast.walk(node):
+                if isinstance(n, ast.FunctionDef) and n.name == func_name:
+                    start_lineno = n.lineno
+                    end_lineno = n.end_lineno
+                    assert end_lineno is not None, "end_lineno is None"
+                    if include_lineno:
+                        return get_code_snippets_with_lineno(
+                            file_full_path, start_lineno, end_lineno
+                        )
+                    else:
+                        return get_code_snippets(
+                            file_full_path, start_lineno, end_lineno
+                        )
+    # In this file, cannot find either the class, or a function within the class
+    return None
+
+
+def get_code_region_containing_code(
+    file_full_path: str, code_str: str
+) -> list[tuple[int, str]]:
+    """In a file, get the region of code that contains a specific string.
+
+    Args:
+        - file_full_path: Path to the file. (absolute path)
+        - code_str: The string that the function should contain.
+    Returns:
+        - A list of tuple, each of them is a pair of (line_no, code_snippet).
+        line_no is the starting line of the matched code; code snippet is the
+        source code of the searched region.
+    """
+    with open(file_full_path) as f:
+        file_content = f.read()
+
+    context_size = 3
+    # since the code_str may contain multiple lines, let's not split the source file.
+
+    # we want a few lines before and after the matched string. Since the matched string
+    # can also contain new lines, this is a bit trickier.
+    pattern = re.compile(re.escape(code_str))
+    # each occurrence is a tuple of (line_no, code_snippet) (1-based line number)
+    occurrences: list[tuple[int, str]] = []
+    for match in pattern.finditer(file_content):
+        matched_start_pos = match.start()
+        # first, find the line number of the matched start position (1-based)
+        matched_line_no = file_content.count("\n", 0, matched_start_pos) + 1
+        # next, get a few surrounding lines as context
+        search_start = match.start() - 1
+        search_end = match.end() + 1
+        # from the matched position, go left to find 5 new lines.
+        for _ in range(context_size):
+            # find the \n to the left
+            left_newline = file_content.rfind("\n", 0, search_start)
+            if left_newline == -1:
+                # no more new line to the left
+                search_start = 0
+                break
+            else:
+                search_start = left_newline
+        # go right to fine 5 new lines
+        for _ in range(context_size):
+            right_newline = file_content.find("\n", search_end + 1)
+            if right_newline == -1:
+                # no more new line to the right
+                search_end = len(file_content)
+                break
+            else:
+                search_end = right_newline
+
+        start = max(0, search_start)
+        end = min(len(file_content), search_end)
+        context = file_content[start:end]
+        occurrences.append((matched_line_no, context))
+
+    return occurrences
+
+
+def get_func_snippet_with_code_in_file(file_full_path: str, code_str: str) -> list[str]:
+    """In a file, get the function code, for which the function contains a specific string.
+
+    Args:
+        file_full_path (str): Path to the file. (absolute path)
+        code_str (str): The string that the function should contain.
+
+    Returns:
+        A list of code snippets, each of them is the source code of the searched function.
+    """
+    with open(file_full_path) as f:
+        file_content = f.read()
+
+    tree = ast.parse(file_content)
+    all_snippets = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        func_start_lineno = node.lineno
+        func_end_lineno = node.end_lineno
+        assert func_end_lineno is not None
+        func_code = get_code_snippets(
+            file_full_path, func_start_lineno, func_end_lineno
+        )
+        # This func code is a raw concatenation of source lines which contains new lines and tabs.
+        # For the purpose of searching, we remove all spaces and new lines in the code and the
+        # search string, to avoid non-match due to difference in formatting.
+        stripped_func = " ".join(func_code.split())
+        stripped_code_str = " ".join(code_str.split())
+        if stripped_code_str in stripped_func:
+            all_snippets.append(func_code)
+
+    return all_snippets
+
+
+def get_code_snippets_with_lineno(file_full_path: str, start: int, end: int) -> str:
+    """Get the code snippet in the range in the file.
+
+    The code snippet should come with line number at the beginning for each line.
+
+    TODO: When there are too many lines, return only parts of the output.
+          For class, this should only involve the signatures.
+          For functions, maybe do slicing with dependency analysis?
+
+    Args:
+        file_path (str): Path to the file.
+        start (int): Start line number. (1-based)
+        end (int): End line number. (1-based)
+    """
+    with open(file_full_path) as f:
+        file_content = f.readlines()
+
+    snippet = ""
+    for i in range(start - 1, end):
+        snippet += f"{i+1} {file_content[i]}"
+    return snippet
+
+
+def get_code_snippets(file_full_path: str, start: int, end: int) -> str:
+    """Get the code snippet in the range in the file, without line numbers.
+
+    Args:
+        file_path (str): Full path to the file.
+        start (int): Start line number. (1-based)
+        end (int): End line number. (1-based)
+    """
+    with open(file_full_path) as f:
+        file_content = f.readlines()
+    snippet = ""
+    for i in range(start - 1, end):
+        snippet += file_content[i]
+    return snippet
+
+
+def extract_func_sig_from_ast(func_ast: ast.FunctionDef) -> list[int]:
+    """Extract the function signature from the AST node.
+
+    Includes the decorators, method name, and parameters.
+
+    Args:
+        func_ast (ast.FunctionDef): AST of the function.
+
+    Returns:
+        The source line numbers that contains the function signature.
+    """
+    func_start_line = func_ast.lineno
+    if func_ast.decorator_list:
+        # has decorators
+        decorator_start_lines = [d.lineno for d in func_ast.decorator_list]
+        decorator_first_line = min(decorator_start_lines)
+        func_start_line = min(decorator_first_line, func_start_line)
+    # decide end line from body
+    if func_ast.body:
+        # has body
+        body_start_line = func_ast.body[0].lineno
+        end_line = body_start_line - 1
+    else:
+        # no body
+        end_line = func_ast.end_lineno
+    assert end_line is not None
+    return list(range(func_start_line, end_line + 1))
+
+
+def extract_class_sig_from_ast(class_ast: ast.ClassDef) -> list[int]:
+    """Extract the class signature from the AST.
+
+    Args:
+        class_ast (ast.ClassDef): AST of the class.
+
+    Returns:
+        The source line numbers that contains the class signature.
+    """
+    # STEP (1): extract the class signature
+    sig_start_line = class_ast.lineno
+    if class_ast.body:
+        # has body
+        body_start_line = class_ast.body[0].lineno
+        sig_end_line = body_start_line - 1
+    else:
+        # no body
+        sig_end_line = class_ast.end_lineno
+    assert sig_end_line is not None
+    sig_lines = list(range(sig_start_line, sig_end_line + 1))
+
+    # STEP (2): extract the function signatures and assign signatures
+    for stmt in class_ast.body:
+        if isinstance(stmt, ast.FunctionDef):
+            sig_lines.extend(extract_func_sig_from_ast(stmt))
+        elif isinstance(stmt, ast.Assign):
+            # for Assign, skip some useless cases where the assignment is to create docs
+            stmt_str_format = ast.dump(stmt)
+            if "__doc__" in stmt_str_format:
+                continue
+            # otherwise, Assign is easy to handle
+            assert stmt.end_lineno is not None
+            assign_range = list(range(stmt.lineno, stmt.end_lineno + 1))
+            sig_lines.extend(assign_range)
+
+    return sig_lines
+
+
+def get_class_signature(file_full_path: str, class_name: str) -> str:
+    """Get the class signature.
+
+    Args:
+        file_path (str): Path to the file.
+        class_name (str): Name of the class.
+    """
+    with open(file_full_path) as f:
+        file_content = f.read()
+
+    tree = ast.parse(file_content)
+    relevant_lines = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            # we reached the target class
+            relevant_lines = extract_class_sig_from_ast(node)
+            break
+    if not relevant_lines:
+        return ""
+    else:
+        with open(file_full_path) as f:
+            file_content = f.readlines()
+        result = ""
+        for line in relevant_lines:
+            line_content: str = file_content[line - 1]
+            if line_content.strip().startswith("#"):
+                # this kind of comment could be left until this stage.
+                # reason: # comments are not part of func body if they appear at beginning of func
+                continue
+            result += line_content
+        return result
+
+def to_relative_path(file_path: str, project_root: str) -> str:
+    """Convert an absolute path to a path relative to the project root.
+
+    Args:
+        - file_path (str): The absolute path.
+        - project_root (str): Absolute path of the project root dir.
+
+    Returns:
+        The relative path.
+    """
+    if Path(file_path).is_absolute():
+        return str(Path(file_path).relative_to(project_root))
+    else:
+        return file_path

--- a/tests/unit/test_agent_skill.py
+++ b/tests/unit/test_agent_skill.py
@@ -1139,6 +1139,19 @@ def test_search_dir_cwd(tmp_path, monkeypatch):
     )
     assert result.split('\n') == expected.split('\n')
 
+def test_search_class(tmp_path, monkeypatch):
+    temp_file_path = tmp_path / 'foo.py'
+    temp_file_path.write_text('class Hello:\n   pass')
+
+    monkeypatch.chdir(tmp_path)
+    with io.StringIO() as buf:
+        with contextlib.redirect_stdout(buf):
+            search_class('Hello')
+        result = buf.getvalue()
+    assert result is not None
+    expected = 'Found 1 classes with name Hello in the codebase:\n\n- Search result 1:\n```\n<file>./foo.py</file>\n<class>Hello</class>\n<code>\nclass Hello:\n\n</code>\n```\n\n'
+    assert result.split('\n') == expected.split('\n')
+
 
 def test_search_file(tmp_path):
     temp_file_path = tmp_path / 'a.txt'


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

WIP for issue [2798](https://github.com/OpenDevin/OpenDevin/issues/2798).
---

Adds the autorover `search_manage` and `search_utils` modules, and adds initial `search_class` functionality along with working test.  Will need to incorporate additional functions, and remove unnecessary code from autorover.

Currently returning Autorover's output. But can update to align with OpenDevin's `search_dir` output if preferable.

'Found 1 classes with name Hello in the codebase:\n\n- Search result 1:\n```\n<file>./foo.py</file>\n<class>Hello</class>\n<code>\nclass Hello:\n\n</code>\n```\n\n' 

