### PR TITLE
Rework --llm-config CLI arg

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -656,7 +656,7 @@ def get_parser() -> argparse.ArgumentParser:
         '--llm-config',
         default=None,
         type=str,
-        help='The group of llm settings, e.g. "llama3" for [llm.llama3] section in the toml file. Overrides model if both are provided.',
+        help='Replace default LLM ([llm] section in config.toml) config with the specified LLM config, e.g. "llama3" for [llm.llama3] section in config.toml',
     )
     return parser
 

--- a/opendevin/core/main.py
+++ b/opendevin/core/main.py
@@ -157,14 +157,13 @@ if __name__ == '__main__':
     else:
         raise ValueError('No task provided. Please specify a task through -t, -f.')
 
-    # Figure out the LLM config
+    # Override default LLM configs ([llm] section in config.toml)
     if args.llm_config:
         llm_config = get_llm_config_arg(args.llm_config)
         if llm_config is None:
             raise ValueError(f'Invalid toml file, cannot read {args.llm_config}')
-        llm = LLM(llm_config=llm_config)
-    else:
-        llm = LLM(llm_config=config.get_llm_config_from_agent(args.agent_cls))
+        config.set_llm_config(llm_config)
+    llm = LLM(llm_config=config.get_llm_config_from_agent(args.agent_cls))
 
     # Create the agent
     AgentCls: Type[Agent] = Agent.get_cls(args.agent_cls)

--- a/tests/unit/test_arg_parser.py
+++ b/tests/unit/test_arg_parser.py
@@ -41,9 +41,9 @@ options:
   --eval-note EVAL_NOTE
                         The note to add to the evaluation directory
   -l LLM_CONFIG, --llm-config LLM_CONFIG
-                        The group of llm settings, e.g. "llama3" for
-                        [llm.llama3] section in the toml file. Overrides model
-                        if both are provided.
+                        Replace default LLM ([llm] section in config.toml)
+                        config with the specified LLM config, e.g. "llama3"
+                        for [llm.llama3] section in config.toml
 """
 
     actual_lines = captured.out.strip().split('\n')


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

After #2756, the semantics of `--llm-config` CLI arg becomes ambiguous: what exactly does it mean to provide a LLM config group via CLI, especially when agent delegation is involved?

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR makes it clear that `--llm-config` allows one to override default LLM config (`[llm]` section in `config.toml`) with a given config group. For example, say you have

```config.toml
[llm.eval_gpt4_1106_preview_llm]
model = "gpt-4-1106-preview"
api_key = "XXX"
temperature = 0.0

[llm.eval_some_openai_compatible_model_llm]
model = "openai/MODEL_NAME"
base_url = "https://OPENAI_COMPATIBLE_URL/v1"
api_key = "XXX"
temperature = 0.0
```

Then you can use `--llm-config eval_gpt4_1106_preview_llm` or `--llm-config eval_some_openai_compatible_model_llm` to control the default LLM config used in the entire lifecycle of `main.py`.

What if I also have the following in my `config.yaml`?

```config.yaml
[agent.BrowsingAgent]
llm_config="gpt-4o"
```

Then `BrowsingAgent` would use `llm.gpt-4o` while other agents would use `--llm-config`.