### PR TITLE
fix(frontend): Remove unused react router package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,6 @@
         "react-icons": "^5.2.1",
         "react-markdown": "^9.0.1",
         "react-redux": "^9.1.2",
-        "react-router-dom": "^6.24.1",
         "react-syntax-highlighter": "^15.5.0",
         "tailwind-merge": "^2.4.0",
         "vite": "^5.3.3",
@@ -4496,14 +4495,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.1.tgz",
-      "integrity": "sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -13207,36 +13198,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.1.tgz",
-      "integrity": "sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==",
-      "dependencies": {
-        "@remix-run/router": "1.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.1.tgz",
-      "integrity": "sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==",
-      "dependencies": {
-        "@remix-run/router": "1.17.1",
-        "react-router": "6.24.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-style-singleton": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,6 @@
     "react-icons": "^5.2.1",
     "react-markdown": "^9.0.1",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^6.24.1",
     "react-syntax-highlighter": "^15.5.0",
     "tailwind-merge": "^2.4.0",
     "vite": "^5.3.3",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,18 +4,10 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import { Provider } from "react-redux";
 import { NextUIProvider } from "@nextui-org/react";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import store from "#/store";
 import "#/i18n";
-
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <App />,
-  },
-]);
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement,
@@ -24,7 +16,7 @@ root.render(
   <React.StrictMode>
     <Provider store={store}>
       <NextUIProvider>
-        <RouterProvider router={router} />
+        <App />
       </NextUIProvider>
     </Provider>
   </React.StrictMode>,


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
The React Router package was added in the past and was never utilized beyond initialization. There also does not seem to be any issue or near-term requirement for it.

To avoid including it as a dependency and unnecessarily update it via dependabot, I propose to remove it until required. When required, we will install the latest version anyways.

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

---
**Other references**
