### PR TITLE
Fix bug with model list

### DIFF
--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -301,6 +301,7 @@ async def get_litellm_models() -> list[str]:
     )
     # TODO: for bedrock, this is using the default config
     llm_config: LLMConfig = config.get_llm_config()
+    bedrock_model_list = []
     if (
         llm_config.aws_region_name
         and llm_config.aws_access_key_id
@@ -311,7 +312,7 @@ async def get_litellm_models() -> list[str]:
             llm_config.aws_access_key_id,
             llm_config.aws_secret_access_key,
         )
-        model_list = litellm_model_list_without_bedrock + bedrock_model_list
+    model_list = litellm_model_list_without_bedrock + bedrock_model_list
     for llm_config in config.llms.values():
         ollama_base_url = llm_config.ollama_base_url
         if llm_config.model.startswith('ollama'):


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

There was a bug with the model list that wasn't caught by my previous testing when incorporating #2954 as pointed out by @mamoodi 

```
mahmoudwork@Mahmouds-Mini OpenDevin % make run
Running the app...
Starting backend server...
Waiting for the backend to start...
10:18:41 - opendevin:INFO: config.py:450 - Attempt to load default LLM config from config toml
ERROR:root:  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/bin/uvicorn", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/lib/python3.11/site-packages/uvicorn/main.py", line 410, in main
    run(
  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/lib/python3.11/site-packages/uvicorn/main.py", line 577, in run
    server.run()
  File "/Users/mahmoudwork/Library/Caches/pypoetry/virtualenvs/opendevin-0q8VcB7c-py3.11/lib/python3.11/site-packages/uvicorn/server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
```

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR fixes the bug.
