### PR TITLE
fix bug in config.py file, update reference to variable

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -470,7 +470,7 @@ def load_from_toml(cfg: AppConfig, toml_file: str = 'config.toml'):
 
     try:
         # set sandbox config from the toml file
-        sandbox_config = config.sandbox
+        sandbox_config = cfg.sandbox
 
         # migrate old sandbox configs from [core] section to sandbox config
         keys_to_migrate = [key for key in core_config if key.startswith('sandbox_')]


### PR DESCRIPTION
Resolves the `NameError: name 'config' is not defined` bug in

```
opendevin/core/config.py:473: in load_from_toml
sandbox_config = config.sandbox
```