### PR TITLE
[LLM] Increase the default retries for LLM

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -33,6 +33,7 @@ class LLMConfig:
         aws_secret_access_key: The AWS secret access key.
         aws_region_name: The AWS region name.
         num_retries: The number of retries to attempt.
+        retry_multiplier: The multiplier for the exponential backoff.
         retry_min_wait: The minimum time to wait between retries, in seconds. This is exponential backoff minimum. For models with very low limits, this can be set to 15-20.
         retry_max_wait: The maximum time to wait between retries, in seconds. This is exponential backoff maximum.
         timeout: The timeout for the API.
@@ -57,9 +58,10 @@ class LLMConfig:
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
     aws_region_name: str | None = None
-    num_retries: int = 5
+    num_retries: int = 10
+    retry_multiplier: float = 2
     retry_min_wait: int = 3
-    retry_max_wait: int = 60
+    retry_max_wait: int = 300
     timeout: int | None = None
     max_message_chars: int = 10_000  # maximum number of characters in an observation's content when sent to the llm
     temperature: float = 0

--- a/opendevin/llm/llm.py
+++ b/opendevin/llm/llm.py
@@ -117,7 +117,9 @@ class LLM:
             reraise=True,
             stop=stop_after_attempt(config.num_retries),
             wait=wait_random_exponential(
-                min=config.retry_min_wait, max=config.retry_max_wait
+                multiplier=config.retry_multiplier,
+                min=config.retry_min_wait,
+                max=config.retry_max_wait,
             ),
             retry=retry_if_exception_type(
                 (


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

I was happily using OpenDevin to build a website for me until it hit Anthropic API's rate limit.

For some reason, the exponential back-off does not work - See log: it retries every 2 seconds, which quickly runs out of retries and breaks the application for me.

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/c21730c3-c38c-4a0d-a3a6-e15c7b6c8efc">

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/4b6617e4-200b-43f9-9004-d73937572ce2">

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR tries to increase the default backoff strategy to be more aggressive rather than erroring out for user.

---
**Other references**
