### PR TITLE
Remove global config from session

### DIFF
--- a/opendevin/server/listen.py
+++ b/opendevin/server/listen.py
@@ -40,7 +40,9 @@ from opendevin.events.observation import (
 from opendevin.events.serialization import event_to_dict
 from opendevin.llm import bedrock
 from opendevin.server.auth import get_sid_from_token, sign_token
-from opendevin.server.session import session_manager
+from opendevin.server.session import SessionManager
+
+session_manager = SessionManager(config)
 
 app = FastAPI()
 app.add_middleware(

--- a/opendevin/server/session/__init__.py
+++ b/opendevin/server/session/__init__.py
@@ -1,6 +1,4 @@
 from .manager import SessionManager
 from .session import Session
 
-session_manager = SessionManager()
-
-__all__ = ['Session', 'SessionManager', 'session_manager']
+__all__ = ['Session', 'SessionManager']

--- a/opendevin/server/session/manager.py
+++ b/opendevin/server/session/manager.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from fastapi import WebSocket
 
+from opendevin.core.config import AppConfig
 from opendevin.core.logger import opendevin_logger as logger
 
 from .session import Session
@@ -14,13 +15,14 @@ class SessionManager:
     cleanup_interval: int = 300
     session_timeout: int = 600
 
-    def __init__(self):
+    def __init__(self, config: AppConfig):
         asyncio.create_task(self._cleanup_sessions())
+        self.config = config
 
     def add_or_restart_session(self, sid: str, ws_conn: WebSocket) -> Session:
         if sid in self._sessions:
             asyncio.create_task(self._sessions[sid].close())
-        self._sessions[sid] = Session(sid=sid, ws=ws_conn)
+        self._sessions[sid] = Session(sid=sid, ws=ws_conn, config=self.config)
         return self._sessions[sid]
 
     def get_session(self, sid: str) -> Session | None:

--- a/opendevin/server/session/session.py
+++ b/opendevin/server/session/session.py
@@ -93,7 +93,7 @@ class Session:
         # TODO: override other LLM config & agent config groups (#2075)
 
         llm = LLM(config=self.config.get_llm_config_from_agent(agent_cls))
-        agent = agent = Agent.get_cls(agent_cls)(llm)
+        agent = Agent.get_cls(agent_cls)(llm)
 
         # Create the agent session
         try:


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This PR removes global config from the session manager.

**Give a summary of what the PR does, explaining any non-trivial design decisions**

1. Removes global config from the session management code, and instead passes in variables
2. Converts some of the lower-level functions to take normal arguments instead of dictionaries
3. Initializes the session manager within the server listener

(I have run this and confirmed that it runs)

**Other references**
Part of #2758 