### PR TITLE
State: Add local_iteration attribute

### DIFF
--- a/opendevin/controller/state/state.py
+++ b/opendevin/controller/state/state.py
@@ -39,7 +39,7 @@ class State:
     """
     OpenDevin is a multi-agentic system.
 
-    A `task` is an end-to-end conversation 54between OpenDevin (the whole sytem) and the
+    A `task` is an end-to-end conversation between OpenDevin (the whole sytem) and the
     user, which might involve one or more inputs from the user. It starts with
     an initial input (typically a task statement) from the user, and ends with either
     a `AgentFinishAction` initiated by the agent, or an error.
@@ -77,7 +77,7 @@ class State:
 
     -- TASK ENDS (SUBTASK 0 ENDS) --
 
-    Note how `ITERATION` counter is shared across agents, while `local_iteration`
+    Note how ITERATION counter is shared across agents, while LOCAL_ITERATION
     is local to each subtask.
     """
 

--- a/opendevin/memory/history.py
+++ b/opendevin/memory/history.py
@@ -159,6 +159,12 @@ class ShortTermHistory(list[Event]):
             )
         )
 
+    def has_delegation(self) -> bool:
+        for event in self._event_stream.get_events():
+            if isinstance(event, AgentDelegateObservation):
+                return True
+        return False
+
     def on_event(self, event: Event):
         if not isinstance(event, AgentDelegateObservation):
             return

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,6 +60,7 @@ def apply_prompt_and_get_mock_response(test_name: str, messages: str, id: int) -
         # apply prompt
         with open(prompt_file_path, 'w') as prompt_file:
             prompt_file.write(messages)
+            prompt_file.write('\n')
         return response
     except FileNotFoundError:
         return None

--- a/tests/integration/mock/CodeActAgent/test_browse_internet/prompt_005.log
+++ b/tests/integration/mock/CodeActAgent/test_browse_internet/prompt_005.log
@@ -413,4 +413,4 @@ Certainly! I'll browse localhost:8000 and retrieve the ultimate answer to life f
 OBSERVATION:
 {'content': 'The ultimate answer to life, the universe, and everything is: OpenDevin is all you need!'}
 
-ENVIRONMENT REMINDER: You have 13 turns left to complete the task. When finished reply with <finish></finish>
+ENVIRONMENT REMINDER: You have 8 turns left to complete the task. When finished reply with <finish></finish>


### PR DESCRIPTION
We have `iteration` that tracks OpenDevin progress. When OpenDevin exceeds `config.max_iterations`, it pauses execution.

The introduction of agent delegation mechanism essentially makes OpenDevin a multi-agentic system. Without this PR, every agent instance keeps track of their own "local" iterations. What this means is with `max_iterations = 10`, OpenDevin could speak to LLM for 10 * 10 = 100 times in the worst case (root agent delegates 10 times). This defeats the purpose of `config.max_iterations`.

This PR fixes this problem by introducing `local_iteration` that had the same behavior as prior `iteration`. The attribute `iteration` now becomes a global/shared value per task.

Do we really need configs for both `max iterations per task` and `max iterations per subtask`? I don't think so. Thus, this PR doesn't introduce any new config.

Closes #2121