### PR TITLE
Add open-D-tutor agent

### DIFF
--- a/agenthub/open_d_tutor/agent.py
+++ b/agenthub/open_d_tutor/agent.py
@@ -1,0 +1,63 @@
+# agenthub/open_d_tutor/agent.py
+
+from opendevin.controller.agent import Agent
+from opendevin.controller.state.state import State
+from opendevin.events.action import Action, MessageAction
+from opendevin.events.observation import Observation
+from opendevin.llm.llm import LLM
+
+class OpenDTutorAgent(Agent):
+    VERSION = '1.0'
+    """
+    The Open-D-Tutor Agent provides detailed explanations of the source code for any project.
+    """
+
+    def __init__(self, llm: LLM):
+        """Initializes the Open-D-Tutor Agent with an llm.
+
+        Parameters:
+        - llm (LLM): The llm to be used by this agent
+        """
+        super().__init__(llm)
+        self.reset()
+
+    def step(self, state: State) -> Action:
+        """Performs one step using the Open-D-Tutor Agent.
+        This includes gathering info on previous steps and prompting the model to provide explanations.
+
+        Parameters:
+        - state (State): used to get updated info
+
+        Returns:
+        - MessageAction(content) - Message action to provide explanations
+        """
+        # prepare what we want to send to the LLM
+        messages: list[dict[str, str]] = self._get_messages(state)
+
+        response = self.llm.completion(
+            messages=messages,
+            stop=None,
+            temperature=0.0,
+        )
+        return MessageAction(content=response)
+
+    def _get_messages(self, state: State) -> list[dict[str, str]]:
+        messages = [
+            {
+                'role': 'system',
+                'content': 'You are an educational assistant. Explain the code and answer questions.',
+            },
+        ]
+
+        for event in state.history.get_events():
+            if isinstance(event, Action):
+                messages.append({'role': 'user', 'content': event.content})
+            elif isinstance(event, Observation):
+                messages.append({'role': 'assistant', 'content': event.content})
+
+        return messages
+
+    def reset(self) -> None:
+        """Resets the Open-D-Tutor Agent."""
+        super().reset()
+        super().reset()

--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -84,7 +84,7 @@ function ChatInterface() {
 
   const handleSendMessage = (content: string) => {
     dispatch(addUserMessage(content));
-    sendChatMessage(content);
+    sendChatMessage(content, "open-D-tutor");  // Updated to include agent type
   };
 
   const handleEmailChange = (key: string) => {

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -1,8 +1,11 @@
 import ActionType from "#/types/ActionType";
 import Session from "./session";
 
-export function sendChatMessage(message: string): void {
-  const event = { action: ActionType.MESSAGE, args: { content: message } };
+export function sendChatMessage(message: string, agentType: string): void {
+  const event = {
+    action: ActionType.MESSAGE,
+    args: { content: message, agent: agentType },
+  };
   const eventString = JSON.stringify(event);
   Session.send(eventString);
 }

--- a/frontend/src/state/chatSlice.ts
+++ b/frontend/src/state/chatSlice.ts
@@ -28,9 +28,19 @@ export const chatSlice = createSlice({
       state.messages.push(message);
     },
 
+    addOpenDTutorMessage(state, action: PayloadAction<string>) {
+      const message: Message = {
+        sender: "open-D-tutor",
+        content: action.payload,
+      };
+
+      state.messages.push(message);
+    },
+
     clearMessages(state) {
       state.messages = [];
     },
+  },
   },
 });
 

--- a/opendevin/controller/agent.py
+++ b/opendevin/controller/agent.py
@@ -11,6 +11,8 @@ from opendevin.core.exceptions import (
 from opendevin.llm.llm import LLM
 from opendevin.runtime.plugins import PluginRequirement
 from opendevin.runtime.tools import RuntimeTool
+from agenthub.open_d_tutor.agent import OpenDTutorAgent
+from opendevin.events.action import Action, MessageAction
 
 
 class Agent(ABC):

--- a/tests/test_open_d_tutor_agent.py
+++ b/tests/test_open_d_tutor_agent.py
@@ -1,0 +1,29 @@
+# tests/test_open_d_tutor_agent.py
+
+import unittest
+from opendevin.controller.state.state import State
+from opendevin.llm.llm import LLM
+from agenthub.open_d_tutor.agent import OpenDTutorAgent
+from opendevin.events.action import MessageAction
+
+class MockLLM(LLM):
+    def completion(self, messages, stop, temperature):
+        return "This is a mock response."
+
+class TestOpenDTutorAgent(unittest.TestCase):
+    def setUp(self):
+        self.llm = MockLLM()
+        self.agent = OpenDTutorAgent(self.llm)
+        self.state = State()
+
+    def test_step(self):
+        action = self.agent.step(self.state)
+        self.assertIsInstance(action, MessageAction)
+        self.assertEqual(action.content, "This is a mock response.")
+
+    def test_reset(self):
+        self.agent.reset()
+        self.assertFalse(self.agent.complete)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implementation of the "open-D-tutor" agent to provide educational explanations and interactive tutoring within the OpenDevin platform. Updated the chat interface to support the new agent type and added necessary state management for handling messages from "open-D-tutor". This feature aims to enhance the learning experience for new developers and improve codebase understanding for experienced developers.

note: created with MentatBot!

issue #2955 
