### PR TITLE
(fix) Session: set base_url in default_llm_config

### DIFF
--- a/opendevin/server/session/session.py
+++ b/opendevin/server/session/session.py
@@ -89,6 +89,9 @@ class Session:
         default_llm_config.api_key = args.get(
             ConfigType.LLM_API_KEY, default_llm_config.api_key
         )
+        default_llm_config.base_url = args.get(
+            ConfigType.LLM_BASE_URL, default_llm_config.base_url
+        )
 
         # TODO: override other LLM config & agent config groups (#2075)
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

The Session instance sets the `api_key` and `model` of the `default_llm_config`, but not the `base_url`.

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Like the 2 already existing assignments, the base_url should also be set.

---
**Other references**
