### PR TITLE
Fix playwright cache error during container restart

### DIFF
--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -22,7 +22,9 @@ if [[ "$SANDBOX_USER_ID" -eq 0 ]]; then
   echo "Running OpenDevin as root"
   export RUN_AS_DEVIN=false
   mkdir -p /root/.cache/ms-playwright/
-  mv /home/opendevin/.cache/ms-playwright/ /root/.cache/
+  if [ -d "/home/opendevin/.cache/ms-playwright/" ]; then
+    mv /home/opendevin/.cache/ms-playwright/ /root/.cache/
+  fi
   "$@"
 else
   echo "Setting up enduser with id $SANDBOX_USER_ID"
@@ -52,7 +54,9 @@ else
 
   mkdir -p /home/enduser/.cache/huggingface/hub/
   mkdir -p /home/enduser/.cache/ms-playwright/
-  mv /home/opendevin/.cache/ms-playwright/ /home/enduser/.cache/
+  if [ -d "/home/opendevin/.cache/ms-playwright/" ]; then
+    mv /home/opendevin/.cache/ms-playwright/ /home/enduser/.cache/
+  fi
 
   usermod -aG $DOCKER_SOCKET_GID enduser
   echo "Running as enduser"


### PR DESCRIPTION
Fixes #3007

Fix the issue where the container cannot restart due to a missing directory error.

* Check if the directory `/home/opendevin/.cache/ms-playwright/` exists before attempting to move it.
* If the directory does not exist, skip the move operation to prevent the error.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OpenDevin/OpenDevin/issues/3007?shareId=ec3b6bb3-7a2c-4395-8ce0-fb8013e60bd5).