### PR TITLE
Fix: handle the case where env var is empty

### DIFF
--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -115,9 +115,9 @@ class Runtime:
 
     # ====================================================================
 
-    async def add_env_var(self, vars):
+    async def add_env_var(self, env_vars: dict[str, str]) -> None:
         cmd = ''
-        for key, value in vars.items():
+        for key, value in env_vars.items():
             # Note: json.dumps gives us nice escaping for free
             cmd += f'export {key}={json.dumps(value)}; '
         if not cmd:
@@ -126,7 +126,9 @@ class Runtime:
         logger.debug(f'Adding env var: {cmd}')
         obs: Observation = await self.run(CmdRunAction(cmd))
         if not isinstance(obs, CmdOutputObservation) or obs.exit_code != 0:
-            raise RuntimeError(f'Failed to add env vars [{vars}] to environment.')
+            raise RuntimeError(
+                f'Failed to add env vars [{env_vars}] to environment: {obs.content}'
+            )
 
     async def on_event(self, event: Event) -> None:
         if isinstance(event, Action):

--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -120,6 +120,8 @@ class Runtime:
         for key, value in vars.items():
             # Note: json.dumps gives us nice escaping for free
             cmd += f'export {key}={json.dumps(value)}; '
+        if not cmd:
+            return
         cmd = cmd.strip()
         logger.debug(f'Adding env var: {cmd}')
         obs: Observation = await self.run(CmdRunAction(cmd))

--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -126,7 +126,7 @@ class Runtime:
         logger.debug(f'Adding env var: {cmd}')
         obs: Observation = await self.run(CmdRunAction(cmd))
         if not isinstance(obs, CmdOutputObservation) or obs.exit_code != 0:
-            raise RuntimeError(f'Failed to add {key} to environment: {obs}')
+            raise RuntimeError(f'Failed to add env vars [{vars}] to environment.')
 
     async def on_event(self, event: Event) -> None:
         if isinstance(event, Action):

--- a/opendevin/runtime/runtime.py
+++ b/opendevin/runtime/runtime.py
@@ -75,10 +75,10 @@ class Runtime:
         This method should be called after the runtime's constructor.
         """
         logger.debug(f'Adding default env vars: {self.DEFAULT_ENV_VARS}')
-        await self.add_env_var(self.DEFAULT_ENV_VARS)
+        await self.add_env_vars(self.DEFAULT_ENV_VARS)
         if env_vars is not None:
             logger.debug(f'Adding provided env vars: {env_vars}')
-            await self.add_env_var(env_vars)
+            await self.add_env_vars(env_vars)
 
     async def close(self) -> None:
         pass
@@ -115,7 +115,7 @@ class Runtime:
 
     # ====================================================================
 
-    async def add_env_var(self, env_vars: dict[str, str]) -> None:
+    async def add_env_vars(self, env_vars: dict[str, str]) -> None:
         cmd = ''
         for key, value in env_vars.items():
             # Note: json.dumps gives us nice escaping for free

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -113,6 +113,32 @@ async def test_env_vars_runtime_add_env_var():
 
 
 @pytest.mark.asyncio
+async def test_env_vars_runtime_add_empty_dict():
+    plugins = [JupyterRequirement(), AgentSkillsRequirement()]
+    sid = 'test'
+    cli_session = 'main_test'
+
+    for box_class in RUNTIME_TO_TEST:
+        event_stream = EventStream(cli_session)
+        runtime = await _load_runtime(box_class, event_stream, plugins, sid)
+
+        prev_obs = await runtime.run_action(CmdRunAction(command='env'))
+        assert prev_obs.exit_code == 0, 'The exit code should be 0.'
+        print(prev_obs)
+
+        await runtime.add_env_var({})
+
+        obs = await runtime.run_action(CmdRunAction(command='env'))
+        assert obs.exit_code == 0, 'The exit code should be 0.'
+        print(obs)
+        assert (
+            obs.content == prev_obs.content
+        ), 'The env var content should be the same after adding an empty dict.'
+
+        await runtime.close()
+
+
+@pytest.mark.asyncio
 async def test_env_vars_runtime_add_multiple_env_vars():
     plugins = [JupyterRequirement(), AgentSkillsRequirement()]
     sid = 'test'

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -91,7 +91,7 @@ async def test_env_vars_os_environ():
 
 
 @pytest.mark.asyncio
-async def test_env_vars_runtime_add_env_var():
+async def test_env_vars_runtime_add_env_vars():
     plugins = [JupyterRequirement(), AgentSkillsRequirement()]
     sid = 'test'
     cli_session = 'main_test'
@@ -99,7 +99,7 @@ async def test_env_vars_runtime_add_env_var():
     for box_class in RUNTIME_TO_TEST:
         event_stream = EventStream(cli_session)
         runtime = await _load_runtime(box_class, event_stream, plugins, sid)
-        await runtime.add_env_var({'QUUX': 'abc"def'})
+        await runtime.add_env_vars({'QUUX': 'abc"def'})
 
         obs: CmdOutputObservation = await runtime.run_action(
             CmdRunAction(command='echo $QUUX')
@@ -126,7 +126,7 @@ async def test_env_vars_runtime_add_empty_dict():
         assert prev_obs.exit_code == 0, 'The exit code should be 0.'
         print(prev_obs)
 
-        await runtime.add_env_var({})
+        await runtime.add_env_vars({})
 
         obs = await runtime.run_action(CmdRunAction(command='env'))
         assert obs.exit_code == 0, 'The exit code should be 0.'
@@ -147,7 +147,7 @@ async def test_env_vars_runtime_add_multiple_env_vars():
     for box_class in RUNTIME_TO_TEST:
         event_stream = EventStream(cli_session)
         runtime = await _load_runtime(box_class, event_stream, plugins, sid)
-        await runtime.add_env_var({'QUUX': 'abc"def', 'FOOBAR': 'xyz'})
+        await runtime.add_env_vars({'QUUX': 'abc"def', 'FOOBAR': 'xyz'})
 
         obs: CmdOutputObservation = await runtime.run_action(
             CmdRunAction(command='echo $QUUX $FOOBAR')
@@ -161,7 +161,7 @@ async def test_env_vars_runtime_add_multiple_env_vars():
 
 
 @pytest.mark.asyncio
-async def test_env_vars_runtime_add_env_var_overwrite():
+async def test_env_vars_runtime_add_env_vars_overwrite():
     plugins = [JupyterRequirement(), AgentSkillsRequirement()]
     sid = 'test'
     cli_session = 'main_test'
@@ -170,7 +170,7 @@ async def test_env_vars_runtime_add_env_var_overwrite():
         with patch.dict(os.environ, {'SANDBOX_ENV_FOOBAR': 'BAZ'}):
             event_stream = EventStream(cli_session)
             runtime = await _load_runtime(box_class, event_stream, plugins, sid)
-            await runtime.add_env_var({'FOOBAR': 'xyz'})
+            await runtime.add_env_vars({'FOOBAR': 'xyz'})
 
             obs: CmdOutputObservation = await runtime.run_action(
                 CmdRunAction(command='echo $FOOBAR')


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fix the issue @mamoodi reported in slack: https://opendevin.slack.com/archives/C06TZ1VCCAD/p1721328419082809?thread_ts=1721247898.211409&cid=C06TZ1VCCAD

```
14:46:37 - opendevin:ERROR: session.py:113 - Error creating controller: cannot access local variable 'key' where it is not associated with a value
Traceback (most recent call last):
  File "/Users/mahmoudwork/Desktop/OpenDevin_Forks/tobifork/OpenDevin/opendevin/server/session/session.py", line 105, in _initialize_agent
    await self.agent_session.start(
  File "/Users/mahmoudwork/Desktop/OpenDevin_Forks/tobifork/OpenDevin/opendevin/server/session/agent.py", line 56, in start
    await self._create_runtime(runtime_name, sandbox_config)
  File "/Users/mahmoudwork/Desktop/OpenDevin_Forks/tobifork/OpenDevin/opendevin/server/session/agent.py", line 83, in _create_runtime
    await self.runtime.ainit()
  File "/Users/mahmoudwork/Desktop/OpenDevin_Forks/tobifork/OpenDevin/opendevin/runtime/server/runtime.py", line 84, in ainit
    await super().ainit()
  File "/Users/mahmoudwork/Desktop/OpenDevin_Forks/tobifork/OpenDevin/opendevin/runtime/runtime.py", line 90, in ainit
    await self.add_env_var(self.DEFAULT_ENV_VARS)
  File "/Users/mahmoudwork/Desktop/OpenDevin_Forks/tobifork/OpenDevin/opendevin/runtime/runtime.py", line 140, in add_env_var
    raise RuntimeError(f'Failed to add {key} to environment: {obs}')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'key' where it is not associated with a value
```
---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Fix the potential issue and add a test case to test setting empty env var.

---
**Other references**
