### PR TITLE
refactor: rename 'changeAgentState' Issue#2977

### DIFF
--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -1,4 +1,4 @@
-import { changeAgentState } from "#/state/agentSlice";
+import { setCurrentAgentState } from "#/state/agentSlice";
 import { setUrl, setScreenshotSrc } from "#/state/browserSlice";
 import store from "#/store";
 import { ObservationMessage } from "#/types/Message";
@@ -25,7 +25,7 @@ export function handleObservationMessage(message: ObservationMessage) {
       }
       break;
     case ObservationType.AGENT_STATE_CHANGED:
-      store.dispatch(changeAgentState(message.extras.agent_state));
+      store.dispatch(setCurrentAgentState(message.extras.agent_state));
       break;
     case ObservationType.DELEGATE:
       // TODO: better UI for delegation result (#2309)

--- a/frontend/src/state/agentSlice.tsx
+++ b/frontend/src/state/agentSlice.tsx
@@ -7,12 +7,12 @@ export const agentSlice = createSlice({
     curAgentState: AgentState.LOADING,
   },
   reducers: {
-    changeAgentState: (state, action) => {
+    setCurrentAgentState: (state, action) => {
       state.curAgentState = action.payload;
     },
   },
 });
 
-export const { changeAgentState } = agentSlice.actions;
+export const { setCurrentAgentState } = agentSlice.actions;
 
 export default agentSlice.reducer;


### PR DESCRIPTION


**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
Fix to issue#2977
- keeping agentStateService unchanged.
- Renamed 'changeAgentState' inside 'agentSlice' to 'setCurrentAgentState'
---

**Give a summary of what the PR does, explaining any non-trivial design decisions**
- keeping agentStateService unchanged. As the function performs to change agent state.
- Renamed 'changeAgentState' inside 'agentSlice' to 'setCurrentAgentState'. As the function performs to update the current action payload and maintain the current agent state.
---
**Other references**
