### PR TITLE
fix: Remove extra arg from swebench ssh box

### DIFF
--- a/evaluation/swe_bench/swe_env_box.py
+++ b/evaluation/swe_bench/swe_env_box.py
@@ -56,7 +56,6 @@ class SWEBenchSSHBox(DockerSSHBox):
             workspace_mount_path=config.workspace_mount_path,
             sandbox_workspace_dir=config.workspace_mount_path_in_sandbox,
             cache_dir=config.cache_dir,
-            use_host_network=config.use_host_network,
             run_as_devin=config.run_as_devin,
             ssh_hostname=config.ssh_hostname,
             ssh_password=config.ssh_password,


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

`use_host_network` is already removed from the init argument of `SSHBox` yet still in the swe env box, which causes the evaluation to fail to run.

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Remove `use_host_network` from `swe_env_box.py`

---
**Other references**
