### PR TITLE
(fix) colima: use a docker context specific to runner; prevent duplicate start

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -89,7 +89,12 @@ jobs:
           docker context create $DOCKER_CONTEXT --docker host=unix:///var/run/docker.sock
 
           start_colima() {
-            colima start --network-address --arch x86_64 --cpu=1 --memory=1 --ssh
+            # Find a free port
+            RANDOM_PORT=$((RANDOM % 16384 + 49152))
+
+            echo "Using random port: $RANDOM_PORT for SSH"
+
+            colima start --network-address --arch x86_64 --cpu=1 --memory=1 --ssh-port $RANDOM_PORT
             docker context use $DOCKER_CONTEXT
           }
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -89,7 +89,7 @@ jobs:
           docker context create $DOCKER_CONTEXT --docker host=unix:///var/run/docker.sock
 
           start_colima() {
-            colima start --network-address --arch x86_64 --cpu=1 --memory=1
+            colima start --network-address --arch x86_64 --cpu=1 --memory=1 --ssh
             docker context use $DOCKER_CONTEXT
           }
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -83,16 +83,15 @@ jobs:
           fi
           rm -rf ~/.colima ~/.lima
           brew install --HEAD colima
-          brew services start colima
           brew install docker
-          colima delete
-          # Attempt to start Colima
-          ATTEMPT_LIMIT=3
 
+          export DOCKER_CONTEXT="colima-$GITHUB_RUN_ID"
           start_colima() {
-            colima start --network-address --arch x86_64 --cpu=1 --memory=1
+            colima start --network-address --arch x86_64 --cpu=1 --memory=1 --context $DOCKER_CONTEXT
           }
 
+          # Attempt to start Colima
+          ATTEMPT_LIMIT=3
           for ((i=1; i<=ATTEMPT_LIMIT; i++)); do
             if start_colima; then
               echo "Colima started successfully."

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -86,8 +86,11 @@ jobs:
           brew install docker
 
           export DOCKER_CONTEXT="colima-$GITHUB_RUN_ID"
+          docker context create $DOCKER_CONTEXT --docker host=unix:///var/run/docker.sock
+
           start_colima() {
-            colima start --network-address --arch x86_64 --cpu=1 --memory=1 --context $DOCKER_CONTEXT
+            colima start --network-address --arch x86_64 --cpu=1 --memory=1
+            docker context use $DOCKER_CONTEXT
           }
 
           # Attempt to start Colima


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This PR attempts to fix colima startup by 
- preventing to start colima 2 times in a row (first with brew, then in `for` loop)
- use a docker context to separate docker resources for the runner instance
- use a random port number

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

- removed the initial mangling of colima start and delete, which shouldn't be necessary
- added env variable DOCKER_CONTEXT to be used by colima
