### PR TITLE
Change doc title of agent hub

### DIFF
--- a/agenthub/README.md
+++ b/agenthub/README.md
@@ -1,4 +1,4 @@
-# Agent Framework Research
+# Agent Hub
 
 In this folder, there may exist multiple implementations of `Agent` that will be used by the framework.
 


### PR DESCRIPTION
This PR changes the title of the `agenthub` doc from "Agent Framework Research" to "Agent Hub".