### PR TITLE
(fix) fixed ghcr_push use of image name

### DIFF
--- a/.github/workflows/ghcr-runtime.yml
+++ b/.github/workflows/ghcr-runtime.yml
@@ -175,6 +175,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check disk space before freeing
+        run: df -h /
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:
@@ -190,16 +204,23 @@ jobs:
 
       - name: Load images and push to registry
         run: |
-          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}_image_${{ matrix.platform }}.tar .
-          loaded_image=$(docker load -i ${{ matrix.image }}_image_${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}')
+          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}-docker-image-${{ matrix.platform }}.tar .
+          if ! loaded_image=$(docker load -i ${{ matrix.image }}-docker-image-${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}'); then
+            echo "Failed to load Docker image"
+            exit 1
+          fi
           echo "loaded image = $loaded_image"
           tags=$(echo ${tags} | tr ' ' '\n')
           image_name=$(echo "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}" | tr '[:upper:]' '[:lower:]')
           echo "image name = $image_name"
           for tag in $tags; do
             echo "tag = $tag"
-            docker tag $loaded_image $image_name:${tag}_${{ matrix.platform }}
-            docker push $image_name:${tag}_${{ matrix.platform }}
+            if [ -n "$image_name" ]; then
+              docker tag $loaded_image $image_name:${tag}_${{ matrix.platform }}
+              docker push $image_name:${tag}_${{ matrix.platform }}
+            else
+              echo "Skipping tag and push due to empty image_name"
+            fi
           done
 
   create_manifest:


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fix error in GitHub action `ghcr_push (od_runtime, amd64)` due to wrongly used image name.

@xingyaoww please let me know, if these changes look alright to you. 😃 

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Added steps for a) display of disk space and b) a `Free Disk Space` action.
- Tweaked `Load images and push to registry` to have `docker load` return an error if it fails.
- In the `tags` loop also checked for empty `image_name`

---

Initial successful run shows: "Final size is 7453141642 bytes"