### PR TITLE
(fix) Runtime yml missing zip handling (fixes #3101)

### DIFF
--- a/.github/workflows/ghcr-runtime.yml
+++ b/.github/workflows/ghcr-runtime.yml
@@ -175,6 +175,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check disk space before freeing
+        run: df -h /
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:
@@ -190,16 +204,23 @@ jobs:
 
       - name: Load images and push to registry
         run: |
-          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}_image_${{ matrix.platform }}.tar .
-          loaded_image=$(docker load -i ${{ matrix.image }}_image_${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}')
+          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}-docker-image-${{ matrix.platform }}.tar .
+          if ! loaded_image=$(docker load -i ${{ matrix.image }}-docker-image-${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}'); then
+            echo "Failed to load Docker image"
+            exit 1
+          fi
           echo "loaded image = $loaded_image"
           tags=$(echo ${tags} | tr ' ' '\n')
           image_name=$(echo "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}" | tr '[:upper:]' '[:lower:]')
           echo "image name = $image_name"
           for tag in $tags; do
             echo "tag = $tag"
-            docker tag $loaded_image $image_name:${tag}_${{ matrix.platform }}
-            docker push $image_name:${tag}_${{ matrix.platform }}
+            if [ -n "$image_name" ]; then
+              docker tag $loaded_image $image_name:${tag}_${{ matrix.platform }}
+              docker push $image_name:${tag}_${{ matrix.platform }}
+            else
+              echo "Skipping tag and push due to empty image_name"
+            fi
           done
 
   create_manifest:

--- a/.github/workflows/ghcr-runtime.yml
+++ b/.github/workflows/ghcr-runtime.yml
@@ -175,9 +175,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check disk space before freeing
-        run: df -h /
-
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
@@ -202,10 +199,13 @@ jobs:
           name: ${{ matrix.image }}-docker-image-${{ matrix.platform }}
           path: /tmp/${{ matrix.platform }}
 
+      - name: Unzip Docker image artifact
+        run: unzip /tmp/${{ matrix.platform }}/${{ matrix.image }}-docker-image-${{ matrix.platform }}.zip -d /tmp/${{ matrix.platform }}
+
       - name: Load images and push to registry
         run: |
-          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}-docker-image-${{ matrix.platform }}.tar .
-          if ! loaded_image=$(docker load -i ${{ matrix.image }}-docker-image-${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}'); then
+          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}_image_${{ matrix.platform }}.tar .
+          if ! loaded_image=$(docker load -i ${{ matrix.image }}_image_${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}'); then
             echo "Failed to load Docker image"
             exit 1
           fi


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fixes #3101  
The `ghcr_push` action did not take into account, that the created artifact was being downloaded as `zip` file and needed to be extracted first.

Action error on `mv` statement example:
https://github.com/OpenDevin/OpenDevin/actions/runs/10087360603/job/27893720863#step:7:1

This is not easy to test as that workflow is only triggered on `push` (which makes sense).

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Added step to unzip the downloaded artifact before trying to move its content,
which should be a .tar file.

---
**Other references**

#3055 