### PR TITLE
(fix) ghcr-runtime: no unzip, artifact downloads as-is (followup to #3104)

### DIFF
--- a/.github/workflows/ghcr-runtime.yml
+++ b/.github/workflows/ghcr-runtime.yml
@@ -199,12 +199,14 @@ jobs:
           name: ${{ matrix.image }}-docker-image-${{ matrix.platform }}
           path: /tmp/${{ matrix.platform }}
 
-      - name: Unzip Docker image artifact
-        run: unzip /tmp/${{ matrix.platform }}/${{ matrix.image }}-docker-image-${{ matrix.platform }}.zip -d /tmp/${{ matrix.platform }}
+      - name: List downloaded files
+        run: |
+          ls -la /tmp/${{ matrix.platform }}
+          file /tmp/${{ matrix.platform }}/*
 
       - name: Load images and push to registry
         run: |
-          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}_image_${{ matrix.platform }}.tar .
+          mv /tmp/${{ matrix.platform }}/${{ matrix.image }}-docker-image-${{ matrix.platform }} ./${{ matrix.image }}_image_${{ matrix.platform }}.tar
           if ! loaded_image=$(docker load -i ${{ matrix.image }}_image_${{ matrix.platform }}.tar | grep "Loaded image:" | head -n 1 | awk '{print $3}'); then
             echo "Failed to load Docker image"
             exit 1


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fixes #3101  #3104 
From an error log where a download link mentioned ".zip" as extention, I mistakenly thought that the download would also have that, but the download-artifact action just downloads the file with the name it was given.
Here: it was uploaded without a file extention.

Thus removed the previously added unzip step again. Instead changed the `mv` command to copy the downloaded file to the expected filename with extension, so that the docker command can pick up that file.

This is cumbesome to test as that workflow is only triggered on `push` (which makes sense).

---
**Other references**

#3101 
#3055 