### PR TITLE
[config] Get rid the use of global config in runtime

### DIFF
--- a/opendevin/core/main.py
+++ b/opendevin/core/main.py
@@ -84,7 +84,9 @@ async def run_agent_controller(
     # runtime and tools
     runtime_cls = get_runtime_cls(config.runtime)
     runtime = runtime_cls(
-        sandbox_config=config.sandbox, event_stream=event_stream, sandbox=sandbox
+        config=config,
+        event_stream=event_stream,
+        sandbox=sandbox,
     )
     await runtime.ainit()
     runtime.init_sandbox_plugins(controller.agent.sandbox_plugins)

--- a/opendevin/runtime/e2b/runtime.py
+++ b/opendevin/runtime/e2b/runtime.py
@@ -1,4 +1,4 @@
-from opendevin.core.config import SandboxConfig
+from opendevin.core.config import AppConfig
 from opendevin.events.action import (
     FileReadAction,
     FileWriteAction,
@@ -21,12 +21,12 @@ from .sandbox import E2BSandbox
 class E2BRuntime(ServerRuntime):
     def __init__(
         self,
-        sandbox_config: SandboxConfig,
+        config: AppConfig,
         event_stream: EventStream,
         sid: str = 'default',
         sandbox: Sandbox | None = None,
     ):
-        super().__init__(sandbox_config, event_stream, sid, sandbox)
+        super().__init__(config, event_stream, sid, sandbox)
         if not isinstance(self.sandbox, E2BSandbox):
             raise ValueError('E2BRuntime requires an E2BSandbox')
         self.file_store = E2BFileStore(self.sandbox.filesystem)

--- a/opendevin/server/session/agent.py
+++ b/opendevin/server/session/agent.py
@@ -4,7 +4,7 @@ from agenthub.codeact_agent.codeact_agent import CodeActAgent
 from opendevin.controller import AgentController
 from opendevin.controller.agent import Agent
 from opendevin.controller.state.state import State
-from opendevin.core.config import LLMConfig, SandboxConfig
+from opendevin.core.config import AppConfig, LLMConfig
 from opendevin.core.logger import opendevin_logger as logger
 from opendevin.events.stream import EventStream
 from opendevin.runtime import DockerSSHBox, get_runtime_cls
@@ -33,7 +33,7 @@ class AgentSession:
     async def start(
         self,
         runtime_name: str,
-        sandbox_config: SandboxConfig,
+        config: AppConfig,
         agent: Agent,
         confirmation_mode: bool,
         max_iterations: int,
@@ -49,7 +49,7 @@ class AgentSession:
             raise Exception(
                 'Session already started. You need to close this session and start a new one.'
             )
-        await self._create_runtime(runtime_name, sandbox_config)
+        await self._create_runtime(runtime_name, config)
         await self._create_controller(
             agent,
             confirmation_mode,
@@ -69,7 +69,7 @@ class AgentSession:
             await self.runtime.close()
         self._closed = True
 
-    async def _create_runtime(self, runtime_name: str, sandbox_config: SandboxConfig):
+    async def _create_runtime(self, runtime_name: str, config: AppConfig):
         """Creates a runtime instance."""
         if self.runtime is not None:
             raise Exception('Runtime already created')
@@ -77,7 +77,7 @@ class AgentSession:
         logger.info(f'Using runtime: {runtime_name}')
         runtime_cls = get_runtime_cls(runtime_name)
         self.runtime = runtime_cls(
-            sandbox_config=sandbox_config, event_stream=self.event_stream, sid=self.sid
+            config=config, event_stream=self.event_stream, sid=self.sid
         )
         await self.runtime.ainit()
 

--- a/opendevin/server/session/session.py
+++ b/opendevin/server/session/session.py
@@ -102,7 +102,7 @@ class Session:
         try:
             await self.agent_session.start(
                 runtime_name=self.config.runtime,
-                sandbox_config=self.config.sandbox,
+                config=self.config,
                 agent=agent,
                 confirmation_mode=confirmation_mode,
                 max_iterations=max_iterations,


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

- pass `AppConfig` instead of `SandboxConfig` to runtime. We can't use `SandboxConfig` alone because workspace mount dir is specified in `AppConfig`
- handle the case for `EventStreamRuntime` to not mount directory when `sandbox_workspace_dir` is None.


---
**Other references**
