### PR TITLE
Always log user messages

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -161,6 +161,10 @@ class AgentController:
             await self.set_agent_state_to(event.agent_state)  # type: ignore
         elif isinstance(event, MessageAction):
             if event.source == EventSource.USER:
+                logger.info(
+                    event,
+                    extra={'msg_type': 'ACTION', 'event_source': EventSource.USER},
+                )
                 if self.get_agent_state() != AgentState.RUNNING:
                     await self.set_agent_state_to(AgentState.RUNNING)
             elif event.source == EventSource.AGENT and event.wait_for_response:

--- a/opendevin/server/session/session.py
+++ b/opendevin/server/session/session.py
@@ -10,7 +10,7 @@ from opendevin.core.logger import opendevin_logger as logger
 from opendevin.core.schema import AgentState
 from opendevin.core.schema.action import ActionType
 from opendevin.core.schema.config import ConfigType
-from opendevin.events.action import Action, ChangeAgentStateAction, NullAction
+from opendevin.events.action import ChangeAgentStateAction, NullAction
 from opendevin.events.event import Event, EventSource
 from opendevin.events.observation import (
     AgentStateChangedObservation,
@@ -146,10 +146,6 @@ class Session:
             return
         event = event_from_dict(data.copy())
         self.agent_session.event_stream.add_event(event, EventSource.USER)
-        if isinstance(event, Action):
-            logger.info(
-                event, extra={'msg_type': 'ACTION', 'event_source': EventSource.USER}
-            )
 
     async def send(self, data: dict[str, object]) -> bool:
         try:


### PR DESCRIPTION
Restore logging of user messages when using cli.

If logging happens only for the server session, it won't be logged when using cli, so this PR moves it a bit so that it happens for all cases.