### PR TITLE
Clear last_error when restoring a session

### DIFF
--- a/opendevin/controller/state/state.py
+++ b/opendevin/controller/state/state.py
@@ -126,10 +126,17 @@ class State:
         except Exception as e:
             logger.error(f'Failed to restore state from session: {e}')
             raise e
+
+        # update state
         if state.agent_state in RESUMABLE_STATES:
             state.resume_state = state.agent_state
         else:
             state.resume_state = None
+
+        # don't carry last_error anymore after restore
+        state.last_error = None
+
+        # first state after restore
         state.agent_state = AgentState.LOADING
         return state
 


### PR DESCRIPTION
This PR proposes a quick fix for the behavior of `last_error` which is set on a number of errors, but never cleared: clear it at least when loading a session, because after reload we should have the history, including some error at the end if that happened, but behave normally again and eventually succeed new tasks etc (so this flag shouldn't be set).