### PR TITLE
Fix max budget per task error in headless mode

### DIFF
--- a/opendevin/controller/agent_controller.py
+++ b/opendevin/controller/agent_controller.py
@@ -380,10 +380,18 @@ class AgentController:
                     self.state.traffic_control_state = TrafficControlState.NORMAL
                 else:
                     self.state.traffic_control_state = TrafficControlState.THROTTLING
-                    await self.report_error(
-                        f'Task budget exceeded. Current cost: {current_cost:.2f}, Max budget: {self.max_budget_per_task:.2f}, task paused. {TRAFFIC_CONTROL_REMINDER}'
-                    )
-                    await self.set_agent_state_to(AgentState.PAUSED)
+                    if self.headless_mode:
+                        # set to ERROR state if running in headless mode
+                        # there is no way to resume
+                        await self.report_error(
+                            f'Task budget exceeded. Current cost: {current_cost:.2f}, max budget: {self.max_budget_per_task:.2f}, task stopped.'
+                        )
+                        await self.set_agent_state_to(AgentState.ERROR)
+                    else:
+                        await self.report_error(
+                            f'Task budget exceeded. Current cost: {current_cost:.2f}, Max budget: {self.max_budget_per_task:.2f}, task paused. {TRAFFIC_CONTROL_REMINDER}'
+                        )
+                        await self.set_agent_state_to(AgentState.PAUSED)
                     return
 
         self.update_state_before_step()

--- a/opendevin/core/main.py
+++ b/opendevin/core/main.py
@@ -177,6 +177,13 @@ if __name__ == '__main__':
     AgentCls: Type[Agent] = Agent.get_cls(args.agent_cls)
     agent = AgentCls(llm=llm)
 
+    # if max budget per task is not sent on the command line, use the config value
+    max_budget_per_task = (
+        args.max_budget_per_task
+        if args.max_budget_per_task
+        else config.max_budget_per_task
+    )
+
     asyncio.run(
         run_agent_controller(
             agent=agent,


### PR DESCRIPTION
This PR proposes a fix for the `max_budget_per_task` attribute when running from CLI: set agent in ERROR state since we cannot use PAUSED (we cannot resume) and use value from config when no user value overrides it from the command line parameters.