### PR TITLE
Finish action is missing from the prompt

### DIFF
--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -121,6 +121,8 @@ class CodeActAgent(Agent):
             return f'{action.thought}\n<execute_browse>\n{action.inputs["task"]}\n</execute_browse>'
         elif isinstance(action, MessageAction):
             return action.content
+        elif isinstance(action, AgentFinishAction) and action.source == 'agent':
+            return action.thought
         return ''
 
     def get_action_message(self, action: Action) -> dict[str, str] | None:
@@ -129,6 +131,8 @@ class CodeActAgent(Agent):
             or isinstance(action, CmdRunAction)
             or isinstance(action, IPythonRunCellAction)
             or isinstance(action, MessageAction)
+            or isinstance(action, AgentFinishAction)
+            and action.source == 'agent'
         ):
             return {
                 'role': 'user' if action.source == 'user' else 'assistant',

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -131,8 +131,7 @@ class CodeActAgent(Agent):
             or isinstance(action, CmdRunAction)
             or isinstance(action, IPythonRunCellAction)
             or isinstance(action, MessageAction)
-            or isinstance(action, AgentFinishAction)
-            and action.source == 'agent'
+            or (isinstance(action, AgentFinishAction) and action.source == 'agent')
         ):
             return {
                 'role': 'user' if action.source == 'user' else 'assistant',


### PR DESCRIPTION
Since we have an AgentFinishAction sent by the agent in CodeAct, the agent is able to send a lot of messages in the `thoughts` attribute, even a full solution of the task at hand. This needs inserted in the prompt, otherwise the agent is re-doing the task it had done already.

This PR proposes a fix.

Example (session done, ended, followed by session restore)
Before this PR: 
```
write concisely about the moon. very short

----------

Let's get back on track. If you experienced errors before, do NOT resume your task. Ask me about it.

----------

The Moon is Earth's only natural satellite. It orbits Earth and is about 384,400 km away. The Moon's surface is covered with craters, mountains, and plains called maria. It has a significant impact on Earth's tides due to its gravitational pull. The Moon has phases, including new moon, first quarter, full moon, and last quarter, which result from its position relative to Earth and the Sun.

How can I assist you further?
```

After this PR:
```
write concisely about the moon. very short

----------

The Moon is Earth's only natural satellite, orbiting at an average distance of about 384,400 km. It influences tides, stabilizes Earth's rotation, and has a surface marked by craters and maria. The Moon has no atmosphere and experiences extreme temperature variations. It was first visited by humans during NASA's Apollo missions.

----------

Let's get back on track. If you experienced errors before, do NOT resume your task. Ask me about it.

----------

Sure! How can I assist you further?
```

In the 'before' prompt, the response to the Moon question (sent in a Finish action) is not present in the prompt. So after session restore, the agent went ahead and made a new LLM call to get a new answer and added it in the prompt. (the first message after restore is "Let's get back on track...").
In the 'after' prompt, the response to the Moon question is present when first received, as a Finish action at the end of the previous session. (so it's before "Let's get back on track...", and then the agent doesn't send another call to the LLM to figure it out again).