### PR TITLE
CVE: Patch `tempfile` module

### DIFF
--- a/tests/unit/tempfile.py
+++ b/tests/unit/tempfile.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import tempfile
+from types import MethodType
+
+
+def _rmtree(cls, name, ignore_errors=False):
+    def onerror(func, path, exc_info):
+        if issubclass(exc_info[0], PermissionError):
+
+            def resetperms(path):
+                try:
+                    if os.chflags in os.supports_follow_symlinks:  # This is the patch
+                        os.chflags(path, 0, follow_symlinks=False)  # This is the patch
+                    elif not os.path.islink(path):  # This is the patch
+                        os.chflags(path, 0)
+                except AttributeError:
+                    pass
+                if os.chmod in os.supports_follow_symlinks:  # This is the patch
+                    os.chmod(path, 0o700, follow_symlinks=False)  # This is the patch
+                elif not os.path.islink(path):  # This is the patch
+                    os.chmod(path, 0o700)
+
+            try:
+                if path != name:
+                    resetperms(os.path.dirname(path))
+                resetperms(path)
+
+                try:
+                    os.unlink(path)
+                # PermissionError is raised on FreeBSD for directories
+                except (IsADirectoryError, PermissionError):
+                    cls._rmtree(path, ignore_errors=ignore_errors)
+            except FileNotFoundError:
+                pass
+        elif issubclass(exc_info[0], FileNotFoundError):
+            pass
+        else:
+            if not ignore_errors:
+                raise
+
+    shutil.rmtree(name, onerror=onerror)
+
+
+# Monkey patch the class method tempfile.TemporaryDirectory._rmtree
+tempfile.TemporaryDirectory._rmtree = MethodType(_rmtree, tempfile.TemporaryDirectory)


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

[ERROR tests/unit/test_runtime.py::test_multiline_command_loop[EventStreamRuntime] - PermissionError: [Errno 1] Operation not permitted: '/tmp/tmpr4ejc4xo/_modules'](https://github.com/OpenDevin/OpenDevin/actions/runs/10125954519/job/28002242178?pr=3128#step:8:2003)


---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Applied the patch from https://github.com/python/cpython/issues/91133#issuecomment-1093946353

---
**Other references**

[CVE-2023-6597 Detail](https://nvd.nist.gov/vuln/detail/CVE-2023-6597)
