### PR TITLE
(fix) Remove unneeded message about config file not found

### DIFF
--- a/opendevin/core/config.py
+++ b/opendevin/core/config.py
@@ -433,8 +433,7 @@ def load_from_toml(cfg: AppConfig, toml_file: str = 'config.toml'):
     try:
         with open(toml_file, 'r', encoding='utf-8') as toml_contents:
             toml_config = toml.load(toml_contents)
-    except FileNotFoundError as e:
-        logger.opendevin_logger.info(f'Config file not found: {e}')
+    except FileNotFoundError:
         return
     except toml.TomlDecodeError as e:
         logger.opendevin_logger.warning(


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Removes an unneeded message that is confusing users:
`config.py:437 - Config file not found: [Errno 2] No such file or directory: 'config.toml'`
This lead to confusion whether some other error had anything to do with this.

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

That message was only intended for debugging purposes after arch refactor and can now be removed as it is not an actual error if no config file is present.