### PR TITLE
Fix: Parse exit code correctly for background commands

### DIFF
--- a/opendevin/runtime/client/client.py
+++ b/opendevin/runtime/client/client.py
@@ -128,7 +128,7 @@ class RuntimeClient:
         self.shell.expect(self.__bash_expect_regex)
         _exit_code_output = self.shell.before
         logger.debug(f'Exit code Output: {_exit_code_output}')
-        exit_code = int(_exit_code_output.strip())
+        exit_code = int(_exit_code_output.strip().split()[0])
         return output, exit_code
 
     async def run_action(self, action) -> Observation:

--- a/opendevin/runtime/docker/ssh_box.py
+++ b/opendevin/runtime/docker/ssh_box.py
@@ -444,7 +444,7 @@ class DockerSSHBox(Sandbox):
                 return self._send_interrupt(
                     cmd, command_output, ignore_last_output=True
                 )
-        cleaned_exit_code_str = exit_code_str.replace('echo $?', '').strip()
+        cleaned_exit_code_str = exit_code_str.replace('echo $?', '').strip().split()[0]
 
         try:
             exit_code = int(cleaned_exit_code_str)


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

[Action link](https://github.com/OpenDevin/OpenDevin/actions/runs/10140735788/job/28037474949?pr=3156#step:8:1907) from #3156

![image](https://github.com/user-attachments/assets/e903b764-d144-4b4c-93f6-3f8bda015d08)


---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Parsed the first line

---
**Other references**
