### PR TITLE
UI: Enable right click to paste in terminal

### DIFF
--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -73,7 +73,14 @@ export const useTerminal = (commands: Command[] = []) => {
         }
         return true;
       });
-
+      // right click to paste
+      terminal.current.element?.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+        navigator.clipboard.readText().then((text) => {
+          terminal.current?.write(text);
+          commandBuffer += text;
+        });
+      });
       /* Listen for resize events */
       resizeObserver = new ResizeObserver(() => {
         fitAddon.current?.fit();

--- a/frontend/src/services/terminalService.ts
+++ b/frontend/src/services/terminalService.ts
@@ -2,9 +2,10 @@ import ActionType from "#/types/ActionType";
 import Session from "./session";
 
 export function sendTerminalCommand(command: string): void {
-  // replace END OF TEXT character
-  command = command.replace(/\u0003+/, '');
-  const event = { action: ActionType.RUN, args: { command } };
+  // replace END OF TEXT character copied from terminal
+  // eslint-disable-next-line no-control-regex
+  const cleanedCommand = command.replace(/\u0003+/, "");
+  const event = { action: ActionType.RUN, args: { command: cleanedCommand } };
   const eventString = JSON.stringify(event);
   Session.send(eventString);
 }

--- a/frontend/src/services/terminalService.ts
+++ b/frontend/src/services/terminalService.ts
@@ -2,6 +2,8 @@ import ActionType from "#/types/ActionType";
 import Session from "./session";
 
 export function sendTerminalCommand(command: string): void {
+  // replace END OF TEXT character
+  command = command.replace(/\u0003+/, '');
   const event = { action: ActionType.RUN, args: { command } };
   const eventString = JSON.stringify(event);
   Session.send(eventString);

--- a/frontend/src/services/terminalService.ts
+++ b/frontend/src/services/terminalService.ts
@@ -5,6 +5,7 @@ export function sendTerminalCommand(command: string): void {
   // replace END OF TEXT character copied from terminal
   // eslint-disable-next-line no-control-regex
   const cleanedCommand = command.replace(/\u0003+/, "");
+  if (!cleanedCommand) return;
   const event = { action: ActionType.RUN, args: { command: cleanedCommand } };
   const eventString = JSON.stringify(event);
   Session.send(eventString);


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This pull request enables the functionality to paste text in the terminal using the right-click context menu. Previously, right-clicking in the terminal would not allow users to paste text directly, which could hinder usability and efficiency.

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR adds an event listener to the terminal's current element for the `contextmenu` event. When the event is triggered, the default context menu is prevented, and the text from the clipboard is read and written to the terminal. The `commandBuffer` is also updated with the pasted text. The use of the optional chaining operator (`?.`) ensures that the code does not throw errors if `terminal.current` or `terminal.current.element` is null or undefined.

```javascript
terminal.current.element?.addEventListener("contextmenu", (e) => {
    e.preventDefault();
    navigator.clipboard.readText().then((text) => {
      terminal.current?.write(text);
      commandBuffer += text;
    });
});
