### PR TITLE
Test: Remove redundant lines

### DIFF
--- a/tests/unit/test_event_stream.py
+++ b/tests/unit/test_event_stream.py
@@ -1,5 +1,4 @@
 import json
-import pathlib
 import tempfile
 
 import pytest
@@ -16,7 +15,6 @@ from opendevin.storage import get_file_store
 def temp_dir(monkeypatch):
     # get a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
-        pathlib.Path(temp_dir).mkdir(parents=True, exist_ok=True)
         yield temp_dir
 
 

--- a/tests/unit/test_ipython.py
+++ b/tests/unit/test_ipython.py
@@ -1,4 +1,3 @@
-import pathlib
 import tempfile
 from unittest.mock import MagicMock, call, patch
 
@@ -14,7 +13,6 @@ from opendevin.runtime.server.runtime import ServerRuntime
 def temp_dir(monkeypatch):
     # get a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
-        pathlib.Path(temp_dir).mkdir(parents=True, exist_ok=True)
         yield temp_dir
 
 

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import os
-import pathlib
 import tempfile
 import time
 from unittest.mock import patch
@@ -44,7 +43,6 @@ def print_method_name(request):
 def temp_dir(monkeypatch):
     # get a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
-        pathlib.Path(temp_dir).mkdir(parents=True, exist_ok=True)
         yield temp_dir
 
 

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import tempfile
 
 import pytest
@@ -43,7 +42,6 @@ def print_method_name(request):
 def temp_dir(monkeypatch):
     # get a temporary directory
     with tempfile.TemporaryDirectory() as temp_dir:
-        pathlib.Path(temp_dir).mkdir(parents=True, exist_ok=True)
         yield temp_dir
 
 


### PR DESCRIPTION

**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This PR removes unnecessary calls to `pathlib.Path(temp_dir).mkdir(parents=True, exist_ok=True)` from various test files. The `tempfile.TemporaryDirectory` already creates a temporary directory, so these calls are redundant. This PR improves test efficiency and cleanliness.



---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR refactors the test setup code by removing redundant directory creation logic. Specifically, it eliminates the `pathlib.Path(temp_dir).mkdir(parents=True, exist_ok=True)` line from the following test files:

* `tests/unit/test_event_stream.py`
* `tests/unit/test_ipython.py`
* `tests/unit/test_runtime.py`
* `tests/unit/test_sandbox.py`

The use of `tempfile.TemporaryDirectory()` provides a temporary directory context, making additional manual directory creation unnecessary.



---

**Other references**

No related issues or references.



---