### PR TITLE
(fix) test_runtime.py parametrization; prevent duplicate test runs

### DIFF
--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -48,30 +48,47 @@ TEST_RUNTIME = os.getenv('TEST_RUNTIME', 'both')
 PY3_FOR_TESTING = '/opendevin/miniforge3/bin/mamba run -n base python3'
 
 
-# This assures that all tests run together for each runtime, not alternating between them,
-# which caused them to fail previously.
-@pytest.fixture(scope='module')
-def box_class(request):
-    time.sleep(1)
+# Depending on TEST_RUNTIME, feed the appropriate box class(es) to the test.
+def get_box_classes():
     runtime = TEST_RUNTIME
     if runtime.lower() == 'eventstream':
-        return EventStreamRuntime
+        return [EventStreamRuntime]
     elif runtime.lower() == 'server':
-        return ServerRuntime
+        return [ServerRuntime]
     else:
-        return pytest.param([EventStreamRuntime, ServerRuntime])
+        return [EventStreamRuntime, ServerRuntime]
+
+
+# This assures that all tests run together per runtime, not alternating between them,
+# which cause errors (especially outside GitHub actions).
+@pytest.fixture(scope='module', params=get_box_classes())
+def box_class(request):
+    time.sleep(2)
+    return request.param
 
 
 # TODO: We will change this to `run_as_user` when `ServerRuntime` is deprecated.
 # since `EventStreamRuntime` supports running as an arbitrary user.
+# Prevent duplicate executions of tests that don't require run_as_devin.
+@pytest.fixture(scope='module')
+def run_as_devin():
+    return False  # default value for tests that don't care
+
+
 @pytest.fixture(scope='module', params=[True, False])
-def run_as_devin(request):
+def parameterized_run_as_devin(request):
     time.sleep(1)
     return request.param
 
 
+# Prevent duplicate executions of tests that don't require enable_auto_lint.
+@pytest.fixture(scope='module')
+def enable_auto_lint():
+    return False  # default value for tests that don't care
+
+
 @pytest.fixture(scope='module', params=[True, False])
-def enable_auto_lint(request):
+def parameterized_enable_auto_lint(request):
     time.sleep(1)
     return request.param
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

#3157 introduced changes to the test_runtime.py fixture parametrization.
- This broke the processing if no `TEST_RUNTIME` parameter was specified as it caused runtime errors:
```py
>           raise ValueError(f'Invalid box class: {box_class}')
E           ValueError: Invalid box class: ParameterSet(values=([<class 'opendevin.runtime.client.runtime.EventStreamRuntime'>, <class 'opendevin.runtime.server.runtime.ServerRuntime'>],), marks=(), id=None)
```
- Fixtures for `run_as_devin` and `enable_auto_lint` cause tests, that don't use these, to run twice

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- `box_class` fixture now takes `get_box_classes` as actual params
- defined "default" fixtures for above params, that shall apply to tests, that don't use them

---
**Other references**
