### PR TITLE
(Eval) Apply config arguments for miniwob ssh box if None is passed

### DIFF
--- a/evaluation/miniwob/run_infer.py
+++ b/evaluation/miniwob/run_infer.py
@@ -33,7 +33,14 @@ docker_ssh_box: DockerSSHBox | None = None
 def get_sandbox():
     global docker_ssh_box
     if docker_ssh_box is None:
-        docker_ssh_box = DockerSSHBox()
+        docker_ssh_box = DockerSSHBox(
+            config=config.sandbox,
+            persist_sandbox=False,
+            workspace_mount_path=config.workspace_mount_path,
+            sandbox_workspace_dir=config.workspace_mount_path_in_sandbox,
+            cache_dir=config.cache_dir,
+            run_as_devin=config.run_as_devin,
+        )
     return docker_ssh_box
 
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

The miniwob evaluation doesn't apply the config's values in its DockerSSHBox initialization, if None is passed in.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Added parameters to `get_sandbox` to initialize the docker_ssh_box if None.

---
**Other references**

Follows #3075 