### PR TITLE
Remove the use of realpath when the file doesn't exist

### DIFF
--- a/tests/integration/regenerate.sh
+++ b/tests/integration/regenerate.sh
@@ -34,8 +34,8 @@ fi
 export SCRIPT_DIR=$(get_script_dir)
 export PROJECT_ROOT=$(realpath "$SCRIPT_DIR/../..")
 
-WORKSPACE_MOUNT_PATH=$(realpath "${WORKSPACE_MOUNT_PATH}/_test_workspace")
-WORKSPACE_BASE=$(realpath "${WORKSPACE_BASE}/_test_workspace")
+WORKSPACE_MOUNT_PATH=$(realpath "${WORKSPACE_MOUNT_PATH}")/_test_workspace
+WORKSPACE_BASE=$(realpath "${WORKSPACE_BASE}")/_test_workspace
 WORKSPACE_MOUNT_PATH_IN_SANDBOX="/workspace"
 
 echo "Current working directory: $(pwd)"


### PR DESCRIPTION
The latest version of regenerate.sh fails on my machine (Mac), because realpath requires existing files. This looks like a regression from [PR 2935](https://github.com/OpenDevin/OpenDevin/pull/2935).

This PR proposes to simply restore the lines with non-existent files/directories, as it worked before PR 2935. The rest appears to work fine.

```
> tests/integration/regenerate.sh
realpath: /Users/enyst/repos/devin/_test_workspace: No such file or directory
```

```
man 3 realpath
...
All components of
     file_name must exist when realpath() is called.
```