### PR TITLE
(fix) EventStreamRuntime: fix config passing on init (fixes test_runtime.py errors)

### DIFF
--- a/opendevin/runtime/client/runtime.py
+++ b/opendevin/runtime/client/runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import os
 import tempfile
 import uuid
@@ -49,6 +50,7 @@ class EventStreamRuntime(Runtime):
         plugins: list[PluginRequirement] | None = None,
         container_image: str | None = None,
     ):
+        self.config = copy.deepcopy(config)
         super().__init__(
             config, event_stream, sid, plugins
         )  # will initialize the event stream
@@ -136,11 +138,14 @@ class EventStreamRuntime(Runtime):
 
             if mount_dir is not None:
                 volumes = {mount_dir: {'bind': sandbox_workspace_dir, 'mode': 'rw'}}
+                logger.info(f'Mount dir: {sandbox_workspace_dir}')
             else:
                 logger.warn(
                     'Mount dir is not set, will not mount the workspace directory to the container.'
                 )
                 volumes = None
+
+            logger.info(f'run_as_devin: `{self.config.run_as_devin}`')
 
             container = self.docker_client.containers.run(
                 self.container_image,
@@ -170,26 +175,25 @@ class EventStreamRuntime(Runtime):
             raise e
 
     async def _ensure_session(self):
+        await asyncio.sleep(1)
         if self.session is None or self.session.closed:
             self.session = aiohttp.ClientSession()
         return self.session
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(10),
-        wait=tenacity.wait_exponential(multiplier=2, min=4, max=600),
+        wait=tenacity.wait_exponential(multiplier=2, min=4, max=60),
     )
     async def _wait_until_alive(self):
+        logger.info('Reconnecting session')
         async with aiohttp.ClientSession() as session:
             async with session.get(f'{self.api_url}/alive') as response:
                 if response.status == 200:
                     return
                 else:
-                    logger.error(
-                        f'Action execution API is not alive. Response: {response}'
-                    )
-                    raise RuntimeError(
-                        f'Action execution API is not alive. Response: {response}'
-                    )
+                    msg = f'Action execution API is not alive. Response: {response}'
+                    logger.error(msg)
+                    raise RuntimeError(msg)
 
     @property
     def sandbox_workspace_dir(self):
@@ -278,12 +282,14 @@ class EventStreamRuntime(Runtime):
                     f'Action {action_type} is not supported in the current runtime.'
                 )
 
+            logger.info('Awaiting session')
             session = await self._ensure_session()
             await self._wait_until_alive()
 
             assert action.timeout is not None
 
             try:
+                logger.info('Executing command')
                 async with session.post(
                     f'{self.api_url}/execute_action',
                     json={'action': event_to_dict(action)},


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

- `EventStreamRuntime` in its initialization did not copy over the passed `config` values to its own `self.config`, thus the base runtime did not get e.g. a changed value like `run_as_devin` as it happens in `test_runtime.py` (see: `test_ipython_multi_user`).
- Added more logging to runtime
- Changed max retry wait from 600 to 60 seconds as it otherwise would wait a painfully long time

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In `test_runtime.py` several tests will be called twice for `run_as_devin` of True and False (root).
Even though the` _load_runtime` fixture instantiates a new `EventStreamRuntime` each time, the underlying base `Runtime` is only instantiated once and thus kept the same config values after the first instantiation.

Example: if test `test_ipython_multi_user` was first called with `run_as_devin` being True, the second run with fixture value of False would still cause the command in the container to be run with `opendevin` instead of `root`.

