### PR TITLE
(workflow) ghcr.yml with paths/paths-ignore conditions for pull_request

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'docs/**'
     branches:
       - main
 

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -11,21 +11,10 @@ on:
     tags:
       - '*'
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - 'agenthub/**'
-      - 'containers/**'
-      - 'dev_config/**'
-      - 'evaluation/**'
-      - 'opendevin/**'
-      - 'tests/**'
-      - 'Makefile'
-      - 'poetry.lock'
-      - 'pyproject.toml'
-      - 'pytest.ini'
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - 'frontend/**'
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -11,6 +11,20 @@ on:
     tags:
       - '*'
   pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'agenthub/**'
+      - 'containers/**'
+      - 'dev_config/**'
+      - 'opendevin/**'
+      - 'tests/**'
+      - 'Makefile'
+      - 'poetry.lock'
+      - 'pyproject.toml'
+      - 'pytest.ini'
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -15,6 +15,7 @@ on:
       - '**.md'
       - 'docs/**'
       - 'frontend/**'
+      - 'evaluation/**'
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -16,6 +16,7 @@ on:
       - 'agenthub/**'
       - 'containers/**'
       - 'dev_config/**'
+      - 'evaluation/**'
       - 'opendevin/**'
       - 'tests/**'
       - 'Makefile'


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Attempt to reduce CI workflow execution time, for PR's only, dependent on affected paths.
E.g. we don't need to build images if changes were only in `docs` folder or to `.md` files.

@xingyaoww I have left out the `frontend` folder as that is covered by other tests, and this PR is not touching `push`, so this should be no problem?

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Applied to the `pull_request` section `paths` and `paths-ignore` criteria.
