### PR TITLE
[evaluation] remove `task` entry in ml-bench evaluation

### DIFF
--- a/evaluation/ml_bench/run_infer.py
+++ b/evaluation/ml_bench/run_infer.py
@@ -138,7 +138,6 @@ def process_instance(instance: Any, metadata: EvalMetadata, reset_logger: bool =
         # Prepare the task instruction
         instruction = (
             f'Please complete the Machine Learning task in the following repository: {repo_name}\n\n'
-            f'The task is: {instance["task"]}\n\n'
             f'{instance["instruction"]}\n\n'
             'You should create a script named `run.sh` under the specified path in the repo to run the task.\n\n'
             f'You can find the task repo at: {task_path}\n\n'


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**
The `task` entry was missing in the latest ml-bench dataset. 

![image](https://github.com/user-attachments/assets/392bfb51-ad5d-475e-8991-38a23898a3e7)
![image](https://github.com/user-attachments/assets/c236b937-0a88-47a8-b734-4c37067916a2)


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**
None


---
**Other references**
None