### PR TITLE
(backend) Added workflow clean-up.yml to remove old workflows and artifacts

### DIFF
--- a/.github/workflows/clean-up.yml
+++ b/.github/workflows/clean-up.yml
@@ -1,7 +1,5 @@
 name: Delete old workflow runs
 on:
-  schedule:
-    - cron: '0 0 1 * *' # Run monthly, at 00:00 on the 1st day of month.
   workflow_dispatch:
     inputs:
       days:

--- a/.github/workflows/clean-up.yml
+++ b/.github/workflows/clean-up.yml
@@ -1,0 +1,68 @@
+name: Delete old workflow runs
+on:
+  schedule:
+    - cron: '0 0 1 * *' # Run monthly, at 00:00 on the 1st day of month.
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Days-worth of runs to keep for each workflow'
+        required: true
+        default: '30'
+      minimum_runs:
+        description: 'Minimum runs to keep for each workflow'
+        required: true
+        default: '10'
+      delete_workflow_pattern:
+        description: 'Name or filename of the workflow (if not set, all workflows are targeted)'
+        required: false
+      delete_workflow_by_state_pattern:
+        description: 'Filter workflows by state: active, deleted, disabled_fork, disabled_inactivity, disabled_manually'
+        required: true
+        default: "ALL"
+        type: choice
+        options:
+          - "ALL"
+          - active
+          - deleted
+          - disabled_inactivity
+          - disabled_manually
+      delete_run_by_conclusion_pattern:
+        description: 'Remove runs based on conclusion: action_required, cancelled, failure, skipped, success'
+        required: true
+        default: "ALL"
+        type: choice
+        options:
+          - "ALL"
+          - "Unsuccessful: action_required,cancelled,failure,skipped"
+          - action_required
+          - cancelled
+          - failure
+          - skipped
+          - success
+      dry_run:
+        description: 'Logs simulated changes, no deletions are performed'
+        required: false
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.days }}
+          keep_minimum_runs: ${{ github.event.inputs.minimum_runs }}
+          delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern }}
+          delete_workflow_by_state_pattern: ${{ github.event.inputs.delete_workflow_by_state_pattern }}
+          delete_run_by_conclusion_pattern: >-
+            ${{
+              startsWith(github.event.inputs.delete_run_by_conclusion_pattern, 'Unsuccessful:')
+              && 'action_required,cancelled,failure,skipped'
+              || github.event.inputs.delete_run_by_conclusion_pattern
+            }}
+          dry_run: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           name: ${{ matrix.image }}-docker-image-${{ matrix.platform }}
           path: /tmp/${{ matrix.image }}_image_${{ matrix.platform }}.tar
+          retention-days: 14
 
   ghcr_build_runtime:
     runs-on: ubuntu-latest
@@ -155,6 +156,7 @@ jobs:
         with:
           name: ${{ matrix.image }}-docker-image-${{ matrix.platform }}
           path: /tmp/${{ matrix.image }}_image_${{ matrix.platform }}.tar
+          retention-days: 14
 
   test_runtime:
     name: Test Runtime


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

To prevent further out of disk space issues, we have to have some workflow to remove outdated workflow runs and their artifacts. This PR introduces `clean-up.yml` to offer this feature.

- In this first iteration this workflow needs to be dispatched manually as it offers manual filtering. If we want to go full automatic with a cron job, we need to specify the desired values, either in this or a follow-up PR.
- Added `retention-days: 14` flag to the 2 `upload-artifact` occurences in `ghcr.yml`

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

- The new script is closely based on the action's example (see reference below) with removing entries older than 30 days.
- Manual dispatch with inputs for filtering is the first iteration.

---

**Other references**

Repository of the used action:
https://github.com/Mattraks/delete-workflow-runs/tree/v2/