### PR TITLE
Add init_runtime_tools for event stream runtime

### DIFF
--- a/opendevin/runtime/client/runtime.py
+++ b/opendevin/runtime/client/runtime.py
@@ -30,6 +30,7 @@ from opendevin.events.serialization import event_to_dict, observation_from_dict
 from opendevin.events.serialization.action import ACTION_TYPE_TO_CLASS
 from opendevin.runtime.plugins import PluginRequirement
 from opendevin.runtime.runtime import Runtime
+from opendevin.runtime.tools import RuntimeTool
 from opendevin.runtime.utils import find_available_tcp_port
 from opendevin.runtime.utils.runtime_build import build_runtime_image
 
@@ -350,3 +351,11 @@ class EventStreamRuntime(Runtime):
         raise NotImplementedError(
             'This method is not implemented in the runtime client.'
         )
+
+    def init_runtime_tools(
+        self,
+        runtime_tools: list[RuntimeTool],
+        runtime_tools_config: Optional[dict[RuntimeTool, Any]] = None,
+    ) -> None:
+        # TODO: deprecate this method when we move to the new EventStreamRuntime
+        logger.warning('init_runtime_tools is not implemented in the runtime client.')


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Currently if `init_runtime_tools` is called when using the event stream runtime OpenDevin dies. This changes it to a warning (this should be removed when server runtime is deprecated).