### PR TITLE
(fix) Dockerfile for app: re-declare ARG OPEN_DEVIN_BUILD_VERSION

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -32,6 +32,8 @@ FROM python:3.12.3-slim AS runtime
 
 WORKDIR /app
 
+ARG OPEN_DEVIN_BUILD_VERSION #re-declare for this section
+
 ENV RUN_AS_DEVIN=true
 # A random number--we need this to be different from the user's UID on the host machine
 ENV OPENDEVIN_USER_ID=42420


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

As per Sonnet, the first line `ARG` command only applies to the first `FROM` Docker section.

Thus added a line to redeclare it, as occasionally runs reported a warning like this:
`UndefinedVar: Usage of undefined variable '$OPEN_DEVIN_BUILD_VERSION' (line 41)`

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Added `ARG` line for final `FROM` section.