### PR TITLE
Improve listen.py test coverage

### DIFF
--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 from opendevin.core.config import AppConfig
 
 
@@ -18,7 +19,7 @@ class MockStaticFiles:
 with patch('opendevin.server.session.SessionManager', MockSessionManager), patch(
     'fastapi.staticfiles.StaticFiles', MockStaticFiles
 ):
-    from opendevin.server.listen import load_file_upload_config
+    from opendevin.server.listen import is_extension_allowed, load_file_upload_config
 
 
 def test_load_file_upload_config():
@@ -42,32 +43,36 @@ def test_load_file_upload_config_invalid_max_size():
         file_uploads_allowed_extensions=[],
     )
     with patch('opendevin.server.listen.config', config):
-
         max_size, restrict_types, allowed_extensions = load_file_upload_config()
 
         assert max_size == 0  # Should default to 0 when invalid
         assert restrict_types is False
         assert allowed_extensions == ['.*']  # Should default to '.*' when empty
 
-from opendevin.server.listen import is_extension_allowed
 
 def test_is_extension_allowed():
-    with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', True),          patch('opendevin.server.listen.ALLOWED_EXTENSIONS', ['.txt', '.pdf']):
-        assert is_extension_allowed('file.txt') == True
-        assert is_extension_allowed('file.pdf') == True
-        assert is_extension_allowed('file.doc') == False
-        assert is_extension_allowed('file') == False
+    with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', True), patch(
+        'opendevin.server.listen.ALLOWED_EXTENSIONS', ['.txt', '.pdf']
+    ):
+        assert is_extension_allowed('file.txt')
+        assert is_extension_allowed('file.pdf')
+        assert not is_extension_allowed('file.doc')
+        assert not is_extension_allowed('file')
+
 
 def test_is_extension_allowed_no_restrictions():
     with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', False):
-        assert is_extension_allowed('file.txt') == True
-        assert is_extension_allowed('file.pdf') == True
-        assert is_extension_allowed('file.doc') == True
-        assert is_extension_allowed('file') == True
+        assert is_extension_allowed('file.txt')
+        assert is_extension_allowed('file.pdf')
+        assert is_extension_allowed('file.doc')
+        assert is_extension_allowed('file')
+
 
 def test_is_extension_allowed_wildcard():
-    with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', True),          patch('opendevin.server.listen.ALLOWED_EXTENSIONS', ['.*']):
-        assert is_extension_allowed('file.txt') == True
-        assert is_extension_allowed('file.pdf') == True
-        assert is_extension_allowed('file.doc') == True
-        assert is_extension_allowed('file') == True
+    with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', True), patch(
+        'opendevin.server.listen.ALLOWED_EXTENSIONS', ['.*']
+    ):
+        assert is_extension_allowed('file.txt')
+        assert is_extension_allowed('file.pdf')
+        assert is_extension_allowed('file.doc')
+        assert is_extension_allowed('file')

--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -1,0 +1,38 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from opendevin.server.listen import load_file_upload_config, session_manager
+from opendevin.server.session import SessionManager
+from opendevin.core.config import AppConfig
+
+@pytest.fixture
+def mock_config():
+    return MagicMock(spec=AppConfig)
+
+def test_load_file_upload_config(mock_config):
+    with patch('opendevin.server.listen.config', mock_config):
+        mock_config.file_uploads_max_file_size_mb = 10
+        mock_config.file_uploads_restrict_file_types = True
+        mock_config.file_uploads_allowed_extensions = ['.txt', '.pdf']
+
+        max_size, restrict_types, allowed_extensions = load_file_upload_config()
+
+        assert max_size == 10
+        assert restrict_types is True
+        assert set(allowed_extensions) == {'.txt', '.pdf'}
+
+def test_load_file_upload_config_invalid_max_size(mock_config):
+    with patch('opendevin.server.listen.config', mock_config):
+        mock_config.file_uploads_max_file_size_mb = -5
+        mock_config.file_uploads_restrict_file_types = False
+        mock_config.file_uploads_allowed_extensions = []
+
+        max_size, restrict_types, allowed_extensions = load_file_upload_config()
+
+        assert max_size == 0  # Should default to 0 when invalid
+        assert restrict_types is False
+        assert allowed_extensions == []
+
+def test_session_manager_initialization():
+    assert isinstance(session_manager, SessionManager)
+
+# Add more tests here as needed

--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -48,3 +48,26 @@ def test_load_file_upload_config_invalid_max_size():
         assert max_size == 0  # Should default to 0 when invalid
         assert restrict_types is False
         assert allowed_extensions == ['.*']  # Should default to '.*' when empty
+
+from opendevin.server.listen import is_extension_allowed
+
+def test_is_extension_allowed():
+    with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', True),          patch('opendevin.server.listen.ALLOWED_EXTENSIONS', ['.txt', '.pdf']):
+        assert is_extension_allowed('file.txt') == True
+        assert is_extension_allowed('file.pdf') == True
+        assert is_extension_allowed('file.doc') == False
+        assert is_extension_allowed('file') == False
+
+def test_is_extension_allowed_no_restrictions():
+    with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', False):
+        assert is_extension_allowed('file.txt') == True
+        assert is_extension_allowed('file.pdf') == True
+        assert is_extension_allowed('file.doc') == True
+        assert is_extension_allowed('file') == True
+
+def test_is_extension_allowed_wildcard():
+    with patch('opendevin.server.listen.RESTRICT_FILE_TYPES', True),          patch('opendevin.server.listen.ALLOWED_EXTENSIONS', ['.*']):
+        assert is_extension_allowed('file.txt') == True
+        assert is_extension_allowed('file.pdf') == True
+        assert is_extension_allowed('file.doc') == True
+        assert is_extension_allowed('file') == True

--- a/tests/unit/test_listen.py
+++ b/tests/unit/test_listen.py
@@ -1,38 +1,50 @@
-import pytest
-from unittest.mock import patch, MagicMock
-from opendevin.server.listen import load_file_upload_config, session_manager
-from opendevin.server.session import SessionManager
+from unittest.mock import patch
 from opendevin.core.config import AppConfig
 
-@pytest.fixture
-def mock_config():
-    return MagicMock(spec=AppConfig)
 
-def test_load_file_upload_config(mock_config):
-    with patch('opendevin.server.listen.config', mock_config):
-        mock_config.file_uploads_max_file_size_mb = 10
-        mock_config.file_uploads_restrict_file_types = True
-        mock_config.file_uploads_allowed_extensions = ['.txt', '.pdf']
+# Mock the SessionManager to avoid asyncio issues
+class MockSessionManager:
+    def __init__(self, *args, **kwargs):
+        pass
 
+
+# Mock StaticFiles
+class MockStaticFiles:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+# Patch necessary components before importing from listen
+with patch('opendevin.server.session.SessionManager', MockSessionManager), patch(
+    'fastapi.staticfiles.StaticFiles', MockStaticFiles
+):
+    from opendevin.server.listen import load_file_upload_config
+
+
+def test_load_file_upload_config():
+    config = AppConfig(
+        file_uploads_max_file_size_mb=10,
+        file_uploads_restrict_file_types=True,
+        file_uploads_allowed_extensions=['.txt', '.pdf'],
+    )
+    with patch('opendevin.server.listen.config', config):
         max_size, restrict_types, allowed_extensions = load_file_upload_config()
 
         assert max_size == 10
         assert restrict_types is True
         assert set(allowed_extensions) == {'.txt', '.pdf'}
 
-def test_load_file_upload_config_invalid_max_size(mock_config):
-    with patch('opendevin.server.listen.config', mock_config):
-        mock_config.file_uploads_max_file_size_mb = -5
-        mock_config.file_uploads_restrict_file_types = False
-        mock_config.file_uploads_allowed_extensions = []
+
+def test_load_file_upload_config_invalid_max_size():
+    config = AppConfig(
+        file_uploads_max_file_size_mb=-5,
+        file_uploads_restrict_file_types=False,
+        file_uploads_allowed_extensions=[],
+    )
+    with patch('opendevin.server.listen.config', config):
 
         max_size, restrict_types, allowed_extensions = load_file_upload_config()
 
         assert max_size == 0  # Should default to 0 when invalid
         assert restrict_types is False
-        assert allowed_extensions == []
-
-def test_session_manager_initialization():
-    assert isinstance(session_manager, SessionManager)
-
-# Add more tests here as needed
+        assert allowed_extensions == ['.*']  # Should default to '.*' when empty


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

`opendevin/server/listen.py` had no unit tests, so in testing OpenDevin I asked it to write some.

**Other references**

Prompt:
```
The repo https://github.com/OpenDevin/OpenDevin/
Please clone it locally and cd into the OpenDevin directory.
Then you can run `poetry install` to install all the dependencies.

Within this larger OpenDevin directory, there is a file opendevin/server/listen.py that has no tests.
Please create a file called tests/unit/test_listen.py and write tests that test the functionality in this directory.
If you need to use a `Runtime` object, try to use `EventStreamRuntime`, which is implemented in opendevin/runtime/client/runtime.py.
You can mock its various functions as necessary.

Please run the tests using
$ poetry run pytest ./tests/unit/test_listen.py
to make sure that they work.

When you are done writing these tests, please create a new git branch, and push to github so I can review the code for a code review.
When you push, you can use the token GITHUB_TOKEN, which I have provided as an environment variable.
```