### PR TITLE
fix: copy over pyproject and poetry lock for App docker

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -72,6 +72,7 @@ COPY --chown=opendevin:app --chmod=777 ./opendevin/runtime/plugins ./opendevin/r
 COPY --chown=opendevin:app --chmod=770 ./agenthub ./agenthub
 COPY --chown=opendevin:app --chmod=770 ./pyproject.toml ./pyproject.toml
 COPY --chown=opendevin:app --chmod=770 ./poetry.lock ./poetry.lock
+COPY --chown=opendevin:app --chmod=770 ./README.md ./README.md
 
 RUN python opendevin/core/download.py # No-op to download assets
 RUN chown -R opendevin:app /app/logs && chmod -R 770 /app/logs # This gets created by the download.py script

--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -46,8 +46,10 @@ RUN mkdir -p $WORKSPACE_BASE
 RUN apt-get update -y \
     && apt-get install -y curl ssh sudo
 
-RUN sed -i 's/^UID_MIN.*/UID_MIN 499/' /etc/login.defs # Default is 1000, but OSX is often 501
-RUN sed -i 's/^UID_MAX.*/UID_MAX 1000000/' /etc/login.defs # Default is 60000, but we've seen up to 200000
+# Default is 1000, but OSX is often 501
+RUN sed -i 's/^UID_MIN.*/UID_MIN 499/' /etc/login.defs
+# Default is 60000, but we've seen up to 200000
+RUN sed -i 's/^UID_MAX.*/UID_MAX 1000000/' /etc/login.defs
 
 RUN groupadd app
 RUN useradd -l -m -u $OPENDEVIN_USER_ID -s /bin/bash opendevin && \
@@ -68,6 +70,8 @@ RUN playwright install --with-deps chromium
 COPY --chown=opendevin:app --chmod=770 ./opendevin ./opendevin
 COPY --chown=opendevin:app --chmod=777 ./opendevin/runtime/plugins ./opendevin/runtime/plugins
 COPY --chown=opendevin:app --chmod=770 ./agenthub ./agenthub
+COPY --chown=opendevin:app --chmod=770 ./pyproject.toml ./pyproject.toml
+COPY --chown=opendevin:app --chmod=770 ./poetry.lock ./poetry.lock
 
 RUN python opendevin/core/download.py # No-op to download assets
 RUN chown -R opendevin:app /app/logs && chmod -R 770 /app/logs # This gets created by the download.py script


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fix https://github.com/OpenDevin/OpenDevin/issues/3283.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- Include `pyproject.toml` and `poetry.lock` inside `app` container, since it is required for `EventStreamRuntime` builder to create source code distribution

---
**Other references**
