### PR TITLE
Bug fix drag resize

### DIFF
--- a/frontend/src/components/Resizable.tsx
+++ b/frontend/src/components/Resizable.tsx
@@ -35,14 +35,14 @@ export function Container({
     if (mouseDownPosition == null || !firstRef.current) {
       return undefined;
     }
-    const getCurrentSize = (e: MouseEvent) => {
+    const getCurrentSizeFromEvent = (e: MouseEvent) => {
       const position =
         orientation === Orientation.HORIZONTAL ? e.clientX : e.clientY;
       return currentSize + position - mouseDownPosition;
     };
     const onMouseMove = (e: MouseEvent) => {
       e.preventDefault();
-      const firstSize = getCurrentSize(e);
+      const firstSize = getCurrentSizeFromEvent(e);
       const { current } = firstRef;
       if (current) {
         if (orientation === Orientation.HORIZONTAL) {
@@ -54,7 +54,7 @@ export function Container({
     };
     const onMouseUp = (e: MouseEvent) => {
       e.preventDefault();
-      setCurrentSize(getCurrentSize(e));
+      setCurrentSize(getCurrentSizeFromEvent(e));
       setMouseDownPosition(null);
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
@@ -74,6 +74,13 @@ export function Container({
     setMouseDownPosition(position);
   };
 
+  const getStyleForFirst = () => {
+    if (orientation === Orientation.HORIZONTAL) {
+      return { width: `${currentSize}px` };
+    }
+    return { height: `${currentSize}px` };
+  };
+
   return (
     <div
       className={twMerge(
@@ -81,7 +88,7 @@ export function Container({
         className,
       )}
     >
-      <div ref={firstRef} className={firstClassName}>
+      <div ref={firstRef} className={firstClassName} style={getStyleForFirst()}>
         {firstChild}
       </div>
       <div

--- a/frontend/src/components/Resizable.tsx
+++ b/frontend/src/components/Resizable.tsx
@@ -25,37 +25,35 @@ export function Container({
   orientation,
   initialSize,
 }: ContainerProps): JSX.Element {
-  const [currentSize, setCurrentSize] = useState<number>(initialSize);
-  const [mouseDownPosition, setMouseDownPosition] = useState<number | null>(
-    null,
-  );
+  const [firstSize, setFirstSize] = useState<number>(initialSize);
+  const [dividerPosition, setDividerPosition] = useState<number | null>(null);
   const firstRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (mouseDownPosition == null || !firstRef.current) {
+    if (dividerPosition == null || !firstRef.current) {
       return undefined;
     }
-    const getCurrentSizeFromEvent = (e: MouseEvent) => {
+    const getFirstSizeFromEvent = (e: MouseEvent) => {
       const position =
         orientation === Orientation.HORIZONTAL ? e.clientX : e.clientY;
-      return currentSize + position - mouseDownPosition;
+      return firstSize + position - dividerPosition;
     };
     const onMouseMove = (e: MouseEvent) => {
       e.preventDefault();
-      const firstSize = getCurrentSizeFromEvent(e);
+      const newFirstSize = getFirstSizeFromEvent(e);
       const { current } = firstRef;
       if (current) {
         if (orientation === Orientation.HORIZONTAL) {
-          current.style.width = `${firstSize}px`;
+          current.style.width = `${newFirstSize}px`;
         } else {
-          current.style.height = `${firstSize}px`;
+          current.style.height = `${newFirstSize}px`;
         }
       }
     };
     const onMouseUp = (e: MouseEvent) => {
       e.preventDefault();
-      setCurrentSize(getCurrentSizeFromEvent(e));
-      setMouseDownPosition(null);
+      setFirstSize(getFirstSizeFromEvent(e));
+      setDividerPosition(null);
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
     };
@@ -65,20 +63,20 @@ export function Container({
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
     };
-  }, [mouseDownPosition, currentSize, orientation]);
+  }, [dividerPosition, firstSize, orientation]);
 
   const onMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     const position =
       orientation === Orientation.HORIZONTAL ? e.clientX : e.clientY;
-    setMouseDownPosition(position);
+    setDividerPosition(position);
   };
 
   const getStyleForFirst = () => {
     if (orientation === Orientation.HORIZONTAL) {
-      return { width: `${currentSize}px` };
+      return { width: `${firstSize}px` };
     }
-    return { height: `${currentSize}px` };
+    return { height: `${firstSize}px` };
   };
 
   return (


### PR DESCRIPTION
The first time you mouse down to drag resize a panel it does not work. It only works on subsequent mouse down events.

The reason is that the current implementation has a flaw (It is not surprising as this is something difficult to get right)
`onMouseDown` calls `setDividerPosition` which triggers a re-render, making the code inside useEffect obsolete - it is applied to a context which no longer exists.

The update moves the onMouseMove and onMouseUp inside the useEffect and adds a destructor, meaning that:

* `onMouseMove` and `onMouseUp` are not applied and do not exist unless a mouse down has occurred, setting the `dividerPosition`
* `onMouseMove` resizes the ref but does not trigger a re-render.
* `onMouseUp` removes the event listeners and triggers a re-render
* The destructor (Called in the event of a re-render) removes the event listeners  anyway.