### PR TITLE
(fix) revert #3240 - remove paths_ignore in ghcr.yml again

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -12,11 +12,6 @@ on:
     tags:
       - '*'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'frontend/**'
-      - 'evaluation/**'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Revert #3240 to remove `paths_ignore` option again as this blocked some required workflows.
