### PR TITLE
(fix) fix error in ghcr_push_runtime (tags processing)

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -305,7 +305,7 @@ jobs:
     needs: [ghcr_build_runtime, test_runtime, runtime_integration_tests_on_linux]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     env:
-      tags: ${{ needs.ghcr_build_runtime.outputs.tags }}
+      RUNTIME_TAGS: ${{ needs.ghcr_build_runtime.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -349,16 +349,15 @@ jobs:
             exit 1
           fi
           echo "loaded image = $loaded_image"
-          tags=$(echo ${tags} | tr ' ' '\n')
           image_name=$(echo "ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}" | tr '[:upper:]' '[:lower:]')
           echo "image name = $image_name"
-          for tag in $tags; do
+          echo "$RUNTIME_TAGS" | tr ' ' '\n' | while read -r tag; do
             echo "tag = $tag"
-            if [ -n "$image_name" ]; then
+            if [ -n "$image_name" ] && [ -n "$tag" ]; then
               docker tag $loaded_image $image_name:${tag}_${{ matrix.platform }}
               docker push $image_name:${tag}_${{ matrix.platform }}
             else
-              echo "Skipping tag and push due to empty image_name"
+              echo "Skipping tag and push due to empty image_name or tag"
             fi
           done
 


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Try to fix this error in workflow:
`Error parsing reference: "ghcr.io/opendevin/od_runtime:$DOCKER_IMAGE_TAG_arm64" is not a valid repository/tag: invalid reference format`

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Processing of tags within the matrix seemed to be the issue. Need to see test runs if this approach by Sonnet works.

---

**Other references**

Example action where this last was observed:
https://github.com/OpenDevin/OpenDevin/actions/runs/10316652985/job/28561146144#step:7:27