### PR TITLE
(fix) fix wrong quotes around env vars in ghcr.yml

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -125,7 +125,7 @@ jobs:
           else
             echo 'No Dockerfile detected which means an exact image is already built. Pulling the image and saving it to a tar file...'
             source containers/runtime/config.sh
-            echo '$DOCKER_IMAGE_TAG $DOCKER_IMAGE_HASH_TAG' >> tags.txt
+            echo "$DOCKER_IMAGE_TAG $DOCKER_IMAGE_HASH_TAG" >> tags.txt
             echo "Pulling image $DOCKER_IMAGE/$DOCKER_IMAGE_HASH_TAG to /tmp/${{ matrix.image }}_image_${{ matrix.platform }}.tar"
             docker pull $DOCKER_IMAGE:$DOCKER_IMAGE_HASH_TAG
             docker save $DOCKER_IMAGE:$DOCKER_IMAGE_HASH_TAG -o /tmp/${{ matrix.image }}_image_${{ matrix.platform }}.tar


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This should finally fix this error in workflows on merges:
```Error parsing reference: "ghcr.io/opendevin/od_runtime:$DOCKER_IMAGE_TAG_amd64" is not a valid repository/tag: invalid reference format```

Follow-up to #3311 

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This line had single-quotes and thus the env vars were not expanded, i.e. they were written "as is" into the tags.txt file:
```echo "$DOCKER_IMAGE_TAG $DOCKER_IMAGE_HASH_TAG" >> tags.txt```

---

**Other references**

https://github.com/OpenDevin/OpenDevin/actions/runs/10318854385/job/28567802141#step:7:26