### PR TITLE
Group docusaurus dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
+
+groups:
+  docusaurus:
+    patterns:
+    - "*docusaurus*"


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Docusaurus requires multiple packages be upgraded at the same time, causing dependabot updates to fail:
- https://github.com/OpenDevin/OpenDevin/pull/3347
- https://github.com/OpenDevin/OpenDevin/pull/3345
- https://github.com/OpenDevin/OpenDevin/pull/3343

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR uses [dependabot groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) to group these into a single PR, which should hopefully solve the problem.
