### PR TITLE
(fix) correct dependabot.yml groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,23 +5,28 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 20
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/frontend" # Location of package manifests
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 20
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/docs" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
 
-groups:
-  docusaurus:
-    patterns:
-    - "*docusaurus*"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20
+    groups:
+      docusaurus:
+        patterns:
+          - "*docusaurus*"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 20
+    groups:
+      docusaurus:
+        patterns:
+          - "*docusaurus*"


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Followup to #3359 to move the newly added `groups` to proper sections.

---

**Give a summary of what the PR does, explaining any non-trivial design decisions**

Previous implementation put the `groups` as sortof "independent" entry, which causes errors.
