### PR TITLE
Add dependabot group for eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       docusaurus:
         patterns:
           - "*docusaurus*"
+      eslint:
+        patterns:
+          - "*eslint*"
 
   - package-ecosystem: "npm"
     directory: "/docs"
@@ -30,3 +33,6 @@ updates:
       docusaurus:
         patterns:
           - "*docusaurus*"
+      eslint:
+        patterns:
+          - "*eslint*"


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

This PR adds a depandabot group for eslint, which should help fix errors in the version upgrade here: https://github.com/OpenDevin/OpenDevin/pull/3368
