### PR TITLE
(fix) exclude Python cache files/folders from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+# Exclude all Python bytecode files
+global-exclude *.pyc
+
+# Exclude Python cache directories
+global-exclude __pycache__


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fixes #3169 to avoid permission errors upon call of `build` (sdist)

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Added special manifest file to exclude Python cache files and folders from sdist.
These cache files are not needed, but can cause errors at runtime due to different file permissions.

---
**Other references**
