### PR TITLE
_create_project_source_dist: run subprocess as shell

### DIFF
--- a/opendevin/runtime/client/runtime.py
+++ b/opendevin/runtime/client/runtime.py
@@ -188,12 +188,12 @@ class EventStreamRuntime(Runtime):
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(10),
-        wait=tenacity.wait_exponential(multiplier=2, min=4, max=60),
+        wait=tenacity.wait_exponential(multiplier=2, min=10, max=60),
     )
     async def _wait_until_alive(self):
         logger.info('Reconnecting session')
         container = self.docker_client.containers.get(self.container_name)
-        # print logs
+        # get logs
         _logs = container.logs(tail=10).decode('utf-8').split('\n')
         # add indent
         _logs = '\n'.join([f'    |{log}' for log in _logs])

--- a/opendevin/runtime/utils/runtime_build.py
+++ b/opendevin/runtime/utils/runtime_build.py
@@ -40,7 +40,7 @@ def _create_project_source_dist():
     logger.info(f'Using project root: {project_root}')
 
     # run "python -m build -s" on project_root to create project tarball
-    result = subprocess.run(['python', '-m', 'build', '-s', project_root])
+    result = subprocess.run(f'python -m build -s {project_root}', shell=True)
     if result.returncode != 0:
         logger.error(f'Build failed: {result}')
         raise Exception(f'Build failed: {result}')


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Attempt to fix #3169 : run the subprocess for build as shell command so that it should inherit permissions.

Also increased minimum wait time in `_ensure_session` to 10 seconds.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Same as above.