### PR TITLE
copy manifest file into container

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -73,10 +73,10 @@ COPY --chown=opendevin:app --chmod=770 ./agenthub ./agenthub
 COPY --chown=opendevin:app --chmod=770 ./pyproject.toml ./pyproject.toml
 COPY --chown=opendevin:app --chmod=770 ./poetry.lock ./poetry.lock
 COPY --chown=opendevin:app --chmod=770 ./README.md ./README.md
+COPY --chown=opendevin:app --chmod=770 ./MANIFEST.in ./MANIFEST.in
 
 RUN python opendevin/core/download.py # No-op to download assets
 RUN chown -R opendevin:app /app/logs && chmod -R 770 /app/logs # This gets created by the download.py script
-
 
 COPY --chown=opendevin:app --chmod=770 --from=frontend-builder /app/dist ./frontend/dist
 COPY --chown=opendevin:app --chmod=770 ./containers/app/entrypoint.sh /app/entrypoint.sh


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Previously added `MANIFEST.in` file needs to be copied into the app container at least.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Just added a COPY command.

---
**Other references**

Follow up to #3381 