### PR TITLE
Split Frontend and Python Unit tests

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # * Always run on "main"
-# * Run on PRs that target the "main" branch
+# * Run on PRs that target the "main" branch and have changed anything in the "docs" folder
 on:
   push:
     branches:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# * Always run on "main"
+# * Run on PRs that target the "main" branch
 on:
   push:
     branches:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # * Always run on "main"
-# * Run on PRs that target the "main" branch and have changed anything in the "docs" folder
+# * Run on PRs that target the "main" branch and have changes in the "docs" folder
 on:
   push:
     branches:

--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -2,7 +2,7 @@
 name: Run Frontend Unit Tests
 
 # * Always run on "main"
-# * Run on PRs that have changes in the "frontend" folder
+# * Run on PRs that have changes in the "frontend" folder or this workflow
 on:
   push:
     branches:
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths:
       - 'frontend/**'
+      -  '.github/workflows/fe-unit-tests.yml'
 
 jobs:
   # Run frontend unit tests

--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -1,0 +1,36 @@
+# Workflow that runs frontend unit tests
+name: Run Frontend Unit Tests
+
+# * Always run on "main"
+# * Always run on PRs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  # Run frontend unit tests
+  fe-test:
+    name: FE Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: npm ci
+      - name: Run tests and collect coverage
+        working-directory: ./frontend
+        run: npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/fe-unit-tests.yml
+++ b/.github/workflows/fe-unit-tests.yml
@@ -2,12 +2,14 @@
 name: Run Frontend Unit Tests
 
 # * Always run on "main"
-# * Always run on PRs
+# * Run on PRs that have changes in the "frontend" folder
 on:
   push:
     branches:
       - main
   pull_request:
+    paths:
+      - 'frontend/**'
 
 jobs:
   # Run frontend unit tests

--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'frontend/**'
+      - 'docs/**'
+      - 'evaluation/**'
 
 jobs:
   # Run python unit tests on macOS

--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -2,7 +2,7 @@
 name: Run Python Unit Tests
 
 # * Always run on "main"
-# * Always run on PRs
+# * Run on PRs unless the only changed files are in the "paths-ignore"
 on:
   push:
     branches:

--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -1,18 +1,14 @@
 # Workflow that runs python unit tests
 name: Run Python Unit Tests
 
+# The jobs in this workflow are required, so they must run at all times
 # * Always run on "main"
-# * Run on PRs unless the only changed files are in the "paths-ignore"
+# * Always run on PRs
 on:
   push:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'frontend/**'
-      - 'docs/**'
-      - 'evaluation/**'
 
 jobs:
   # Run python unit tests on macOS

--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -1,52 +1,18 @@
-# Workflow that runs frontend and python unit tests
-name: Run Unit Tests
+# Workflow that runs python unit tests
+name: Run Python Unit Tests
 
-# Only run one workflow of the same group at a time.
-# There can be at most one running and one pending job in a concurrency group at any time.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
+# * Always run on "main"
+# * Always run on PRs
 on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - 'frontend/**'
-      - 'docs/**'
-      - 'evaluation/**'
   pull_request:
 
-
 jobs:
-  # Run frontend unit tests
-  fe-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
-        working-directory: ./frontend
-        run: npm ci
-      - name: Run tests and collect coverage
-        working-directory: ./frontend
-        run: npm run test:coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
   # Run python unit tests on macOS
   test-on-macos:
-    name: Test on macOS
+    name: Python Unit Tests on macOS
     runs-on: macos-12
     env:
       INSTALL_DOCKER: '1' # Set to '0' to skip Docker installation
@@ -123,7 +89,7 @@ jobs:
 
   # Run python unit tests on Linux
   test-on-linux:
-    name: Test on Linux
+    name: Python Unit Tests on Linux
     runs-on: ubuntu-latest
     env:
       INSTALL_DOCKER: '0' # Set to '0' to skip Docker installation


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

The split isn't quite necessary but it's a quality of life improvement. Just makes following the different workflows easier.

The real change is: Always run all unit tests. This is a minimum test that should always be run, especially on main (This was being skipped on main pushes that only had the paths-ignore changes.)


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**



---
**Other references**
