### PR TITLE
(fix) RuntimeClient: make _init_user more robust

### DIFF
--- a/opendevin/runtime/client/client.py
+++ b/opendevin/runtime/client/client.py
@@ -121,6 +121,16 @@ class RuntimeClient:
         if username == 'root':
             return
 
+        # Check if the username already exists
+        try:
+            subprocess.run(
+                f'id -u {username}', shell=True, check=True, capture_output=True
+            )
+            logger.debug(f'User {username} already exists. Skipping creation.')
+            return
+        except subprocess.CalledProcessError:
+            pass  # User does not exist, continue with creation
+
         # Add sudoer
         sudoer_line = r"echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers"
         output = subprocess.run(sudoer_line, shell=True, capture_output=True)
@@ -128,30 +138,33 @@ class RuntimeClient:
             raise RuntimeError(f'Failed to add sudoer: {output.stderr.decode()}')
         logger.debug(f'Added sudoer successfully. Output: [{output.stdout.decode()}]')
 
-        # Add user and change ownership of the initial working directory if it doesn't exist
-        command = (
-            f'useradd -rm -d /home/{username} -s /bin/bash '
-            f'-g root -G sudo -u {user_id} {username}'
-        )
-
-        if not os.path.exists(self.initial_pwd):
-            command += f' && mkdir -p {self.initial_pwd}'
-            command += f' && chown -R {username}:root {self.initial_pwd}'
-            command += f' && chmod g+s {self.initial_pwd}'
-
-        output = subprocess.run(
-            command,
-            shell=True,
-            capture_output=True,
-        )
-        if output.returncode != 0:
-            raise RuntimeError(
-                f'Failed to create user {username}: {output.stderr.decode()}'
+        # Attempt to add the user, retrying with incremented user_id if necessary
+        while True:
+            command = (
+                f'useradd -rm -d /home/{username} -s /bin/bash '
+                f'-g root -G sudo -u {user_id} {username}'
             )
 
-        logger.debug(
-            f'Added user {username} successfully. Output: [{output.stdout.decode()}]'
-        )
+            if not os.path.exists(self.initial_pwd):
+                command += f' && mkdir -p {self.initial_pwd}'
+                command += f' && chown -R {username}:root {self.initial_pwd}'
+                command += f' && chmod g+s {self.initial_pwd}'
+
+            output = subprocess.run(command, shell=True, capture_output=True)
+            if output.returncode == 0:
+                logger.debug(
+                    f'Added user {username} successfully with UID {user_id}. Output: [{output.stdout.decode()}]'
+                )
+                break
+            elif f'UID {user_id} is not unique' in output.stderr.decode():
+                logger.warning(
+                    f'UID {user_id} is not unique. Incrementing UID and retrying...'
+                )
+                user_id += 1
+            else:
+                raise RuntimeError(
+                    f'Failed to create user {username}: {output.stderr.decode()}'
+                )
 
     def _init_bash_shell(self, work_dir: str, username: str) -> None:
         self.shell = pexpect.spawn(


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Prevent below error during sandbox startup:
```RuntimeError: Failed to create user opendevin: useradd: UID 1000 is not unique```

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The `_init_user` method now first checks, if the given username (e.g. `opendevin`) already exists.
If yes, it can return early.

Otherwise it'll try to add the user with the given user id (usually 1000) and **IF** that fails with a `not unique` error, it will increase the user id and retry, e.g.
```py
04:57:04 - opendevin:WARNING: client.py:158 - UID 1000 is not unique. Incrementing UID and retrying...
04:57:04 - opendevin:DEBUG: client.py:153 - Added user opendevin successfully with UID 1001. Output: []
```

Only under rare circumstances this should cause issues, but happy to refine it further in followup PR.