### PR TITLE
fix: app docker permission issue

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -56,7 +56,7 @@ RUN useradd -l -m -u $OPENDEVIN_USER_ID -s /bin/bash opendevin && \
     usermod -aG app opendevin && \
     usermod -aG sudo opendevin && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN chown -R opendevin:app /app && chmod -R 770 /app
+RUN chown -R opendevin:app /app && chmod -R 2770 /app
 RUN sudo chown -R opendevin:app $WORKSPACE_BASE && sudo chmod -R 770 $WORKSPACE_BASE
 USER opendevin
 

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -59,6 +59,7 @@ else
   fi
 
   usermod -aG $DOCKER_SOCKET_GID enduser
+  usermod -aG opendevin enduser
   echo "Running as enduser"
   su enduser /bin/bash -c "$*"
 fi


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fix https://github.com/OpenDevin/OpenDevin/issues/3169.

The permission issue is likely caused by weird `.pyc` file that's owned by `opendevin:opendevin`

<img width="923" alt="image" src="https://github.com/user-attachments/assets/9ae980b8-f7f2-413e-a992-75116a868f4a">


---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

- The `setgid` bit (represented by `2`) ensures that new files and directories created within `/app` will inherit the group ownership (`app`) from the parent directory.
- Add `opendevin` to the group of `enduser` to hopefully address the 

---
**Other references**
