### PR TITLE
fix: app docker permission issue

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -56,7 +56,7 @@ RUN useradd -l -m -u $OPENDEVIN_USER_ID -s /bin/bash opendevin && \
     usermod -aG app opendevin && \
     usermod -aG sudo opendevin && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN chown -R opendevin:app /app && chmod -R 2770 /app
+RUN chown -R opendevin:app /app && chmod -R 770 /app
 RUN sudo chown -R opendevin:app $WORKSPACE_BASE && sudo chmod -R 770 $WORKSPACE_BASE
 USER opendevin
 
@@ -75,7 +75,12 @@ COPY --chown=opendevin:app --chmod=770 ./poetry.lock ./poetry.lock
 COPY --chown=opendevin:app --chmod=770 ./README.md ./README.md
 COPY --chown=opendevin:app --chmod=770 ./MANIFEST.in ./MANIFEST.in
 
+# This is run as "opendevin" user, and will create __pycache__ with opendevin:opendevin ownership
 RUN python opendevin/core/download.py # No-op to download assets
+# Add this line to set group ownership of all files/directories not already in "app" group
+# opendevin:opendevin -> opendevin:app
+RUN find /app \! -group app -exec chgrp app {} +
+
 RUN chown -R opendevin:app /app/logs && chmod -R 770 /app/logs # This gets created by the download.py script
 
 COPY --chown=opendevin:app --chmod=770 --from=frontend-builder /app/dist ./frontend/dist

--- a/containers/app/entrypoint.sh
+++ b/containers/app/entrypoint.sh
@@ -59,7 +59,6 @@ else
   fi
 
   usermod -aG $DOCKER_SOCKET_GID enduser
-  usermod -aG opendevin enduser
   echo "Running as enduser"
   su enduser /bin/bash -c "$*"
 fi


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Fix https://github.com/OpenDevin/OpenDevin/issues/3169#issuecomment-2294178270 (again!!!)

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

In `containers/app/Dockerfile`, the `__pycache__` directories will be created when Python code is executed or imported -> `RUN python opendevin/core/download.py # No-op to download assets`

- This PR chgrp of every file not owned by `app` to `app` group after `python download.py`.
- This PR also revert some of the ineffective changes introduced in #3246.


Correct pycache permission after build from this PR:
![image](https://github.com/user-attachments/assets/b0a4d118-b9b0-44f6-8ee1-e9214435f1e4)


---
**Other references**
