### PR TITLE
(fix) jobs need if condition modified to enable run on PR push

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -263,7 +263,7 @@ jobs:
   ghcr_push:
     runs-on: ubuntu-latest
     needs: [ghcr_build]
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
     env:
       tags: ${{ needs.ghcr_build.outputs.tags }}
     permissions:

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -305,7 +305,7 @@ jobs:
   ghcr_push_runtime:
     runs-on: ubuntu-latest
     needs: [ghcr_build_runtime, test_runtime, runtime_integration_tests_on_linux]
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
     env:
       RUNTIME_TAGS: ${{ needs.ghcr_build_runtime.outputs.tags }}
     permissions:
@@ -367,7 +367,7 @@ jobs:
   create_manifest:
     runs-on: ubuntu-latest
     needs: [ghcr_build, ghcr_push]
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
     env:
       tags: ${{ needs.ghcr_build.outputs.tags }}
     strategy:
@@ -401,7 +401,7 @@ jobs:
   create_manifest_runtime:
     runs-on: ubuntu-latest
     needs: [ghcr_build_runtime, ghcr_push_runtime]
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
     env:
       tags: ${{ needs.ghcr_build_runtime.outputs.tags }}
     strategy:


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

`if` condition for `ghcr_push` and other jobs needed extra checks to not be skipped on PR merge.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The `if` condition for this job states that it should only run when:
- The GitHub reference is refs/heads/main (i.e., pushes to the main branch)
- OR when the reference starts with refs/tags/ (i.e., when a new tag is created)

When a **_pull request_** is merged to the main branch, the workflow runs in the context of the pull request, not the main branch itself.

In a pull request context, the github.ref would typically be something like refs/pull/123/merge, not refs/heads/main. 

This means the condition github.ref == 'refs/heads/main' evaluates to false.

To fix this and ensure the ghcr_push job runs when a PR is merged to main, the condition should be modified to include pull request merges.

(Fix provided by Sonnet)

---
**Other references**
