### PR TITLE
Fix typing for fake user response function

### DIFF
--- a/opendevin/core/main.py
+++ b/opendevin/core/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 import uuid
-from typing import Callable, Type
+from typing import Callable, Protocol, Type
 
 import agenthub  # noqa F401 (we import this to get the agents registered)
 from opendevin.controller import AgentController
@@ -17,12 +17,22 @@ from opendevin.core.logger import opendevin_logger as logger
 from opendevin.core.schema import AgentState
 from opendevin.events import EventSource, EventStream, EventStreamSubscriber
 from opendevin.events.action import MessageAction
+from opendevin.events.action.action import Action
 from opendevin.events.event import Event
 from opendevin.events.observation import AgentStateChangedObservation
 from opendevin.llm.llm import LLM
 from opendevin.runtime import get_runtime_cls
 from opendevin.runtime.runtime import Runtime
 from opendevin.storage import get_file_store
+
+
+class FakeUserResponseFunc(Protocol):
+    def __call__(
+        self,
+        state: State,
+        encapsulate_solution: bool = ...,
+        try_parse: Callable[[Action], str] = ...,
+    ) -> str: ...
 
 
 def read_task_from_file(file_path: str) -> str:
@@ -75,7 +85,7 @@ async def run_controller(
     runtime: Runtime | None = None,
     agent: Agent | None = None,
     exit_on_message: bool = False,
-    fake_user_response_fn: Callable[[State | None], str] | None = None,
+    fake_user_response_fn: FakeUserResponseFunc | None = None,
     headless_mode: bool = True,
 ) -> State | None:
     """Main coroutine to run the agent controller with task input flexibility.
@@ -87,7 +97,8 @@ async def run_controller(
         runtime: (optional) A runtime for the agent to run on.
         agent: (optional) A agent to run.
         exit_on_message: quit if agent asks for a message from user (optional)
-        fake_user_response_fn: An optional function that receives the current state (could be None) and returns a fake user response.
+        fake_user_response_fn: An optional function that receives the current state
+            (could be None) and returns a fake user response.
         headless_mode: Whether the agent is run in headless mode.
     """
     # Create the agent
@@ -126,7 +137,8 @@ async def run_controller(
     assert isinstance(task_str, str), f'task_str must be a string, got {type(task_str)}'
     # Logging
     logger.info(
-        f'Agent Controller Initialized: Running agent {agent.name}, model {agent.llm.config.model}, with task: "{task_str}"'
+        f'Agent Controller Initialized: Running agent {agent.name}, model '
+        f'{agent.llm.config.model}, with task: "{task_str}"'
     )
 
     # start event is a MessageAction with the task, either resumed or new
@@ -134,7 +146,10 @@ async def run_controller(
         # we're resuming the previous session
         event_stream.add_event(
             MessageAction(
-                content="Let's get back on track. If you experienced errors before, do NOT resume your task. Ask me about it."
+                content=(
+                    "Let's get back on track. If you experienced errors before, do "
+                    'NOT resume your task. Ask me about it.'
+                ),
             ),
             EventSource.USER,
         )


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Previously, the [typing](https://github.com/OpenDevin/OpenDevin/blob/b2221f135f36d8a94585c7cf87c451272ac91fe9/opendevin/core/main.py#L78) on `fake_user_response_func` did not match the [actual type](https://github.com/OpenDevin/OpenDevin/blob/b2221f135f36d8a94585c7cf87c451272ac91fe9/evaluation/utils/shared.py#L69) of `codeact_user_response`.

This didn't cause errors in CI because our typing checks in CI are rather lenient, but it's incorrect and was throwing errors in my IDE, so it'd probably be nicer to fix it.

**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR creates a [typing protocol](https://typing.readthedocs.io/en/latest/spec/protocol.html) that matches the actual type, fixing the typing issue.

(I also shortened a few long lines, since they were also caught by my IDE.)