### PR TITLE
(fix) revert a 1s sleep from _ensure_session (runtime)

### DIFF
--- a/opendevin/runtime/client/runtime.py
+++ b/opendevin/runtime/client/runtime.py
@@ -183,7 +183,6 @@ class EventStreamRuntime(Runtime):
             raise e
 
     async def _ensure_session(self):
-        await asyncio.sleep(1)
         if self.session is None or self.session.closed:
             self.session = aiohttp.ClientSession()
         return self.session


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Revert an extra 1 second delay from a frequently called method in client `runtime`, which added a noticable delay compared to previous versions.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This reverts a line added by me in PR #3233 
