### PR TITLE
chore: remove deprecated RuntimeTool

### DIFF
--- a/agenthub/browsing_agent/browsing_agent.py
+++ b/agenthub/browsing_agent/browsing_agent.py
@@ -22,7 +22,6 @@ from opendevin.llm.llm import LLM
 from opendevin.runtime.plugins import (
     PluginRequirement,
 )
-from opendevin.runtime.tools import RuntimeTool
 
 USE_NAV = (
     os.environ.get('USE_NAV', 'true') == 'true'
@@ -94,7 +93,6 @@ class BrowsingAgent(Agent):
     """
 
     sandbox_plugins: list[PluginRequirement] = []
-    runtime_tools: list[RuntimeTool] = [RuntimeTool.BROWSER]
     response_parser = BrowsingResponseParser()
 
     def __init__(

--- a/agenthub/codeact_agent/codeact_agent.py
+++ b/agenthub/codeact_agent/codeact_agent.py
@@ -32,7 +32,6 @@ from opendevin.runtime.plugins import (
     JupyterRequirement,
     PluginRequirement,
 )
-from opendevin.runtime.tools import RuntimeTool
 
 ENABLE_GITHUB = True
 
@@ -94,7 +93,6 @@ class CodeActAgent(Agent):
         AgentSkillsRequirement(),
         JupyterRequirement(),
     ]
-    runtime_tools: list[RuntimeTool] = [RuntimeTool.BROWSER]
 
     system_message: str = get_system_message()
     in_context_example: str = f"Here is an example of how you can interact with the environment for task solving:\n{get_in_context_example()}\n\nNOW, LET'S START!"

--- a/agenthub/codeact_swe_agent/codeact_swe_agent.py
+++ b/agenthub/codeact_swe_agent/codeact_swe_agent.py
@@ -29,7 +29,6 @@ from opendevin.runtime.plugins import (
     JupyterRequirement,
     PluginRequirement,
 )
-from opendevin.runtime.tools import RuntimeTool
 
 
 def get_system_message() -> str:
@@ -57,7 +56,6 @@ class CodeActSWEAgent(Agent):
         AgentSkillsRequirement(),
         JupyterRequirement(),
     ]
-    runtime_tools: list[RuntimeTool] = []
 
     system_message: str = get_system_message()
     in_context_example: str = f"Here is an example of how you can interact with the environment for task solving:\n{get_in_context_example()}\n\nNOW, LET'S START!"

--- a/agenthub/planner_agent/agent.py
+++ b/agenthub/planner_agent/agent.py
@@ -5,7 +5,6 @@ from opendevin.core.config import AgentConfig
 from opendevin.core.message import ImageContent, Message, TextContent
 from opendevin.events.action import Action, AgentFinishAction
 from opendevin.llm.llm import LLM
-from opendevin.runtime.tools import RuntimeTool
 
 from .prompt import get_prompt_and_images
 
@@ -16,7 +15,6 @@ class PlannerAgent(Agent):
     The planner agent utilizes a special prompting strategy to create long term plans for solving problems.
     The agent is given its previous action-observation pairs, current task, and hint based on last action taken at every step.
     """
-    runtime_tools: list[RuntimeTool] = [RuntimeTool.BROWSER]
     response_parser = PlannerResponseParser()
 
     def __init__(self, llm: LLM, config: AgentConfig):

--- a/opendevin/controller/agent.py
+++ b/opendevin/controller/agent.py
@@ -11,7 +11,6 @@ from opendevin.core.exceptions import (
 )
 from opendevin.llm.llm import LLM
 from opendevin.runtime.plugins import PluginRequirement
-from opendevin.runtime.tools import RuntimeTool
 
 
 class Agent(ABC):
@@ -25,7 +24,6 @@ class Agent(ABC):
 
     _registry: dict[str, Type['Agent']] = {}
     sandbox_plugins: list[PluginRequirement] = []
-    runtime_tools: list[RuntimeTool] = []
 
     def __init__(
         self,

--- a/opendevin/runtime/tools.py
+++ b/opendevin/runtime/tools.py
@@ -1,5 +1,0 @@
-from enum import Enum
-
-
-class RuntimeTool(Enum):
-    BROWSER = 'browser'


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

We deprecate `RuntimeTool` since the completion of runtime refactor.

---
**Give a summary of what the PR does, explaining any non-trivial design decisions**

This PR removes the remaining occurrence of `RuntimeTool` to clean up the codebase.

---
**Other references**
