### PR TITLE
(workflow) ghcr.yml: bump docker/login-action@v2 to v3

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -329,7 +329,7 @@ jobs:
           docker-images: false
           swap-storage: true
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -380,7 +380,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -414,7 +414,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
**What is the problem that this fixes or functionality that this introduces? Does it fix any open issues?**

Bump outdated `docker/login-action@v2` to v3 to resolve warnings about Node versions.